### PR TITLE
Fix npm test on Node 20+ by replacing esm with @babel/register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 # Claude
 .claude/settings.local.json
 .claude/tmp/
+thoughts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `npm test` now works on Node 20+ by replacing the unmaintained `esm` loader with `@babel/register`, aligning the test and coverage execution paths.
+
 ## [1.24.6] - 2026-05-14
 
 ### Changed
@@ -19,13 +25,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `serialize-javascript` ≤7.0.4 remains in `mocha` and `rollup-plugin-terser`. The `mocha` fix requires a major upgrade (tracked in #99); the `rollup-plugin-terser` fix is a downgrade and tracked under #107.
 - `vue-template-compiler` ≥2.0.0 remains in `documentation`. The fix would downgrade to `documentation@6.2.0`; issue #116 will replace this tool.
 
-## [Unreleased]
-
-### Added
-
-- Exponentiated Weibull distribution.
-- Minor style change in docs.
-- Changelog added.
-- Tests are simplified and improved by removing numerically not feasible cases.
-- Test are more thorough and accurate.
-- Generalized harmonic number is more accurate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "documentation": "^14.0.0",
         "eslint": "^7.32.0",
         "eslint-config-standard": "^16.0.3",
-        "esm": "^3.2.25",
         "highlight.js": "^11.7.0",
         "istanbul": "^0.4.5",
         "lodash.flattendeep": "^4.4.0",
@@ -5008,16 +5007,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/espree": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/standard src/**/*.js test/*.js",
     "standard": "./node_modules/.bin/standard --fix src/**/*.js test/*.js",
-    "test": "./node_modules/.bin/_mocha -r esm",
+    "test": "./node_modules/.bin/_mocha --require @babel/register",
     "docs": "node ./docs/index.js",
     "build": "./node_modules/.bin/rollup -c",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=html _mocha --require @babel/register"
@@ -43,7 +43,6 @@
     "documentation": "^14.0.0",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",
-    "esm": "^3.2.25",
     "highlight.js": "^11.7.0",
     "istanbul": "^0.4.5",
     "lodash.flattendeep": "^4.4.0",

--- a/solutions/tooling/2026-05-14-1400-esm-shim-node20-breakage.md
+++ b/solutions/tooling/2026-05-14-1400-esm-shim-node20-breakage.md
@@ -1,0 +1,41 @@
+---
+date: 2026-05-14T14:00:00Z
+category: "tooling"
+problem: "npm test crashed on Node 20+ with ERR_MODULE_NOT_FOUND due to unmaintained esm shim"
+status: complete
+related_issue: "#99"
+related_plan: "thoughts/plans/2026-05-14-1230-ci-test-workflow-fix.md"
+tags: [ci, mocha, esm, babel, node20, devDependencies, module-loader]
+---
+
+# Solution: esm shim replaced with @babel/register for Node 20+ compatibility
+
+**Date**: 2026-05-14
+**Category**: tooling
+**Related Issue**: #99
+
+## Problem
+
+`npm test` failed on Node 20+ with `ERR_MODULE_NOT_FOUND` on extensionless relative imports (e.g. `import { repeat } from './test-utils'`). CI was completely broken — not because of flaky statistical tests, but because the ES module loader shim used by the `test` script had become incompatible with the Node 20 runtime. The `coverage` script ran without issue, creating a confusing split where coverage passed but plain testing did not.
+
+## Root Cause
+
+The `test` script used the `esm` npm package (v3.2.25, last published in 2019) as a CommonJS-to-ESM shim via `-r esm`. On Node 20+, Node's built-in ESM loader activates and intercepts module resolution before the `esm` shim can handle it. The shim's extensionless import resolution — which was always a non-standard workaround — no longer ran, causing `ERR_MODULE_NOT_FOUND` for every `import` statement that omitted the `.js` extension.
+
+The `coverage` script was immune because it already used `@babel/register`, which transpiles `import`/`export` to CommonJS `require()` calls before execution; CJS `require()` resolves extensionless paths natively.
+
+## Fix
+
+Replaced `-r esm` with `--require @babel/register` in the `test` script (`package.json:29`), then removed the `esm` devDependency entirely. The Babel stack (`@babel/core`, `@babel/preset-env`, `@babel/register`) was already present and fully configured. This unified the test and coverage execution paths.
+
+## Prevention Strategy
+
+When two npm scripts (e.g. `test` and `coverage`) invoke the same test suite, they must use the same module loader/transpiler. Divergent loader choices are a latent fragility: if one path relies on an unmaintained shim, it will break silently as the Node runtime evolves while the other path masks the failure. Codify the canonical loader in one place so both scripts inherit it rather than duplicating it as separate flags. Flag any devDependency whose last publish date is more than 2 years old during dependency audits.
+
+## Related Solutions
+
+No prior solutions found in this repo.
+
+## Key Insight
+
+The `esm` shim (last published 2019) silently broke on Node 20+ because native ESM supersedes it — if a project's `test` and `coverage` scripts use different module loaders, the working one masks the broken one until CI is run without coverage.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,11 +2676,6 @@ eslint-visitor-keys@^2.0.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.25:
-  version "3.2.25"
-  resolved "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
-
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz"


### PR DESCRIPTION
Closes #99

## Summary

- `npm test` was completely broken on Node 20+ because the `esm` npm package (v3.2.25, last published 2019) conflicts with Node's native ESM loader, causing `ERR_MODULE_NOT_FOUND` on every extensionless relative import
- Replaced `-r esm` with `--require @babel/register` in the `test` script — the Babel stack was already present and proven via the `coverage` script
- Removed `esm` from `devDependencies`; both `test` and `coverage` now use identical module loading

## Design decisions

No ADR — this is a test toolchain fix with no impact on the library API or base class conventions.

## Non-trivial changes

- **`package.json:29`**: `test` script changed from `_mocha -r esm` to `_mocha --require @babel/register`. This unifies the module loader used by both `test` and `coverage`, eliminating the divergence where `coverage` passed CI but `test` crashed before running a single assertion.
- **`package.json` devDependencies**: `esm@^3.2.25` removed. The package is unmaintained (no releases since 2019) and no longer needed.

## Comprehension checklist

- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`.gitignore`**: Added `thoughts/` — Claude Code working directory, not tracked source
- **`CHANGELOG.md`**: Added `[Unreleased]` entry; removed orphaned stale `[Unreleased]` block from before versioning was adopted
- **`package-lock.json` / `yarn.lock`**: Lockfile updates from `esm` removal
- **`solutions/tooling/...`**: Solution document for future reference

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_015PHBmiBRoAN5Vw9L7MALRP)_