### PR TITLE
Fix Kolmogorov boundary: correct open support and guard _cdf at x ≤ 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `npm test` now works on Node 20+ by replacing the unmaintained `esm` loader with `@babel/register`, aligning the test and coverage execution paths.
+- `Kolmogorov.pdf(0)` and `Kolmogorov.cdf(0)` now correctly return 0. Previously the lower support bound was declared `closed: true` (contradicting the documented support x > 0), causing `cdf(0)` to evaluate a non-convergent Grandi's series and return −1.
 
 ## [1.24.6] - 2026-05-14
 

--- a/src/dist/kolmogorov.js
+++ b/src/dist/kolmogorov.js
@@ -19,7 +19,7 @@ export default class Davis extends Distribution {
     // Set support.
     this.s = [{
       value: 0,
-      closed: true
+      closed: false
     }, {
       value: Infinity,
       closed: false
@@ -43,6 +43,7 @@ export default class Davis extends Distribution {
   }
 
   _cdf (x) {
+    if (x <= 0) return 0
     let y = 0
     for (let k = 1; k < MAX_ITER; k++) {
       const dy = (k % 2 === 0 ? 1 : -1) * Math.exp(-2 * (k * x) ** 2)

--- a/test/dist.js
+++ b/test/dist.js
@@ -345,6 +345,29 @@ describe('dist', () => {
       })
     })
 
+  // Kolmogorov: open lower boundary — x=0 is outside the support (x>0) and must return 0.
+  describe('Kolmogorov', () => {
+    const k = new dist.Kolmogorov()
+
+    describe('.pdf()', () => {
+      it('should return 0 at the open lower boundary x = 0', () => {
+        assert.equal(k.pdf(0), 0)
+      })
+    })
+
+    describe('.cdf()', () => {
+      it('should return 0 at the open lower boundary x = 0', () => {
+        assert.equal(k.cdf(0), 0)
+      })
+    })
+
+    describe('.survival()', () => {
+      it('should return 1 at the open lower boundary x = 0', () => {
+        assert.equal(k.survival(0), 1)
+      })
+    })
+  })
+
   // Degenerate distribution.
   describe('Degenerate', () => {
     describe('.sample()', () => {


### PR DESCRIPTION
Closes #51

## Summary
- The Kolmogorov distribution's lower support was declared `closed: true` despite the documented support being x > 0 (open). This caused the base class to pass `x = 0` through to `_cdf`, which evaluated a non-convergent Grandi's series and returned −1.
- Fixed by changing the support to `closed: false`, so the base class correctly returns `pdf(0) = 0` and `cdf(0) = 0` without entering the series loop.
- Added a guard `if (x <= 0) return 0` in `_cdf` so that `survival(0)`, `hazard(0)`, and `cHazard(0)` — which call `_cdf` directly, bypassing the base class bounds check — also return correct values.

## Non-trivial changes
- **`src/dist/kolmogorov.js`**: `closed: true` → `closed: false` on the lower support bound. This is the root fix: with an open boundary the base class handles `pdf(0)` and `cdf(0)` automatically. The original issue suggested a guard in `_pdf`; code review revealed the deeper problem was in the support declaration, which also caused `cdf(0) = −1`.
- **`src/dist/kolmogorov.js`**: Guard `if (x <= 0) return 0` added to `_cdf`. Necessary because `survival`, `hazard`, and `cHazard` in the base class call `_cdf` directly, not through the public `cdf()` method, so they bypass the open-boundary intercept.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Three targeted assertions added for `pdf(0)`, `cdf(0)`, and `survival(0)` — placed in a dedicated Kolmogorov block alongside the existing Degenerate block, since the generic `runX` harness never lands exactly at the support boundary.
- **`CHANGELOG.md`**: Entry added under `[Unreleased] → Fixed`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtH4ku5KQAefUE71NyCdce)_