### PR TITLE
Switch master to main and add session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+git fetch origin main
+git checkout main
+git pull origin main
+
+npm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CircleCI](https://img.shields.io/circleci/build/github/synesenom/ran)](https://app.circleci.com/pipelines/github/synesenom/ran)
+[![Coverage Status](https://coveralls.io/repos/github/synesenom/ran/badge.svg?branch=main)](https://coveralls.io/github/synesenom/ran?branch=main)
 [![npm](https://img.shields.io/npm/v/ranjs.svg)](https://www.npmjs.com/package/ranjs)
-[![Inline docs](http://inch-ci.org/github/synesenom/ran.svg?branch=master)](http://inch-ci.org/github/synesenom/ran)
+[![Inline docs](http://inch-ci.org/github/synesenom/ran.svg?branch=main)](http://inch-ci.org/github/synesenom/ran)
 [![License](https://img.shields.io/npm/l/ranjs.svg)](https://www.npmjs.com/package/ranjs)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![CodeScene Code Health](https://codescene.io/projects/28921/status-badges/code-health)](https://codescene.io/projects/28921)


### PR DESCRIPTION
## Summary

- Update README.md badge URLs from `branch=master` to `branch=main` (Coveralls and Inch CI badges)
- Add `.claude/hooks/session-start.sh` to checkout and pull `main` on every remote session start, then run `npm install`
- Register hook in `.claude/settings.json`

## Test plan

- [ ] Merge PR
- [ ] Start a new remote Claude Code session and verify the SessionStart hook runs: checks out `main`, pulls latest, installs deps

https://claude.ai/code/session_01GJjuW6Vtm1WcKiueictvLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJjuW6Vtm1WcKiueictvLH)_