### PR TITLE
fix(session-start): force-create local main from origin/main

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,7 +6,6 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 git fetch origin main
-git checkout main
-git pull origin main
+git checkout -B main origin/main
 
 npm install


### PR DESCRIPTION
## Summary

Make the SessionStart hook robust to fresh clones that have no local `main` branch yet.

## The problem

Today's hook runs:

```bash
git fetch origin main
git checkout main
git pull origin main
```

On a fresh clone that only has `refs/remotes/origin/main` (no local `main`), `git checkout main` succeeds only when git's auto-DWIM picks the remote ref — which doesn't happen if the clone has stale local refs (e.g. a cached pre-rename `master`). The hook fails under `set -e`, and because the hook *is* what's supposed to bring the working tree onto `main`, the session is left wedged on whatever commit it booted from.

In practice we've seen sessions boot on the pre-switch master HEAD (`22a111d`), where `.claude/` doesn't exist at all — so skills like `/next`, `/build`, `/fix`, etc. silently aren't there.

## The fix

```bash
git fetch origin main
git checkout -B main origin/main
```

`-B` (re)creates the local branch from the remote tip in one step, whether or not it already exists. Hard-resetting to `origin/main` also subsumes the previous `git pull`.

## Test plan

- [ ] Start a new remote session — verify the hook lands the working tree at `origin/main` HEAD.
- [ ] Repeat on a session whose cached clone has no local `main` ref — verify the hook still succeeds and `.claude/skills/next/SKILL.md` is on disk.
- [ ] Confirm `/next` is invokable in a fresh session.

https://claude.ai/code/session_01WuGQEB2YaUfc3mv7oRVfqo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuGQEB2YaUfc3mv7oRVfqo)_