### PR TITLE
test(dist-cases): replace random params() with fixed mid-range values (#103)

### DIFF
--- a/test/dist-cases.js
+++ b/test/dist-cases.js
@@ -1638,6 +1638,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
+    // mu must lie within [a, b] so the truncated PDF isn't near-flat
     params: () => [2.5, 2, 0, 5]
   }]
 }, {

--- a/test/dist-cases.js
+++ b/test/dist-cases.js
@@ -1,47 +1,3 @@
-import { float, int } from '../src/core'
-
-const Param = {
-  rangeMin () {
-    return float(1, 10)
-  },
-
-  rangeIn () {
-    return float(10, 20)
-  },
-
-  rangeMax () {
-    return float(20, 30)
-  },
-
-  shape () {
-    return float(0.1, 5)
-  },
-
-  location () {
-    return float(-5, 5)
-  },
-
-  scale () {
-    return float(0.1, 5)
-  },
-
-  prob () {
-    return float(0.01, 0.99)
-  },
-
-  count () {
-    return int(2, 20)
-  },
-
-  degree () {
-    return int(1, 10)
-  },
-
-  rate () {
-    return float(0.1, 10)
-  }
-}
-
 export default [{
   name: 'Alpha',
   invalidParams: [
@@ -50,10 +6,10 @@ export default [{
   ],
   foreign: {
     generator: 'Pareto',
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   },
   cases: [{
-    params: () => [Param.shape(), Param.scale()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'Anglit',
@@ -65,7 +21,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'Arcsine',
@@ -77,7 +33,7 @@ export default [{
     params: s => [3, Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rangeMin(), Param.rangeMax()]
+    params: () => [5, 25]
   }]
 }, {
   name: 'BaldingNichols',
@@ -90,7 +46,7 @@ export default [{
     params: () => [3, 0, 1]
   },
   cases: [{
-    params: () => [Param.prob(), Param.prob()]
+    params: () => [0.5, 0.5]
   }]
 }, {
   name: 'Bates',
@@ -103,7 +59,7 @@ export default [{
     params: () => [2]
   },
   cases: [{
-    params: () => [Param.count(), Param.rangeMin(), Param.rangeMax()]
+    params: () => [10, 5, 25]
   }]
 }, {
   name: 'Benini',
@@ -117,7 +73,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape(), Param.scale()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'BenktanderII',
@@ -131,13 +87,13 @@ export default [{
   },
   cases: [{
     name: 'high shape parameter',
-    params: () => [Param.scale(), 1 - Param.prob() / 1000]
+    params: () => [2, 0.9995]
   }, {
     name: 'unit shape parameter',
-    params: () => [Param.scale(), 1]
+    params: () => [2, 1]
   }, {
     name: 'normal shape parameter',
-    params: () => [Param.scale(), Math.min(0.9, Param.prob())]
+    params: () => [2, 0.5]
   }]
 }, {
   name: 'Bernoulli',
@@ -149,7 +105,7 @@ export default [{
     params: () => [0, 5]
   },
   cases: [{
-    params: () => [Param.prob()]
+    params: () => [0.5]
   }]
 }, {
   name: 'Beta',
@@ -162,7 +118,7 @@ export default [{
     params: () => [3]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'BetaBinomial',
@@ -176,7 +132,7 @@ export default [{
     params: s => [3, Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree() * 5, Param.shape(), Param.shape()]
+    params: () => [25, 2, 2]
   }]
 }, /*, {
   name: 'BetaGeometric',
@@ -189,7 +145,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape()]
+    params: () => [2, 2]
   }]
 } */ {
   name: 'BetaPrime',
@@ -202,7 +158,7 @@ export default [{
     params: s => [3, 0, Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'BetaRectangular',
@@ -215,7 +171,7 @@ export default [{
     params: () => [3, 0, 1]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape(), Param.prob(), Param.rangeMin(), Param.rangeMax()]
+    params: () => [2, 2, 0.5, 5, 25]
   }]
 }, {
   name: 'Binomial',
@@ -228,7 +184,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rangeMax(), Param.prob()]
+    params: () => [25, 0.5]
   }]
 }, {
   name: 'BirnbaumSaunders',
@@ -241,7 +197,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale(), Param.shape()]
+    params: () => [0, 2, 2]
   }]
 }, {
   name: 'Borel',
@@ -257,7 +213,7 @@ export default [{
     params: () => [0]
   }, {
     name: 'positive parameter',
-    params: () => [Param.prob()]
+    params: () => [0.5]
   }]
 }, {
   name: 'BorelTanner',
@@ -271,10 +227,10 @@ export default [{
   },
   cases: [{
     name: 'zero parameter',
-    params: () => [0, Param.degree()]
+    params: () => [0, 5]
   }, {
     name: 'positive parameter',
-    params: () => [Param.prob(), Param.degree()]
+    params: () => [0.5, 5]
   }]
 }, {
   name: 'BoundedPareto',
@@ -289,7 +245,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rangeMin(), Param.rangeMax(), Param.shape()]
+    params: () => [5, 25, 2]
   }]
 }, {
   name: 'Bradford',
@@ -301,7 +257,7 @@ export default [{
     params: () => [3, 0, 1]
   },
   cases: [{
-    params: () => [Param.shape()]
+    params: () => [2]
   }]
 }, {
   name: 'Burr',
@@ -314,7 +270,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'Categorical',
@@ -327,13 +283,13 @@ export default [{
   },
   cases: [{
     name: 'small n',
-    params: () => [Array.from({ length: 2 }, Math.random)]
+    params: () => [[0.4, 0.6]]
   }, {
     name: 'moderate n',
-    params: () => [Array.from({ length: int(10, 100) }, Math.random)]
+    params: () => [[0.1, 0.05, 0.15, 0.08, 0.12, 0.1, 0.07, 0.13, 0.09, 0.11]]
   }, {
     name: 'large n',
-    params: () => [Array.from({ length: int(101, 120) }, Math.random)]
+    params: () => [Array.from({ length: 105 }, () => 1 / 105)]
   }]
 }, {
   name: 'Cauchy',
@@ -345,7 +301,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'Chi',
@@ -361,7 +317,7 @@ export default [{
     params: () => [1]
   }, {
     name: 'k > 1',
-    params: () => [Param.degree()]
+    params: () => [5]
   }]
 }, {
   name: 'Chi2',
@@ -373,7 +329,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree()]
+    params: () => [5]
   }]
 }, {
   name: 'Dagum',
@@ -387,7 +343,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape(), Param.scale()]
+    params: () => [2, 2, 2]
   }]
 }, /*, {
   name: 'Davis',
@@ -402,7 +358,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.scale(), Param.shape()]
+    params: () => [2, 2, 2]
   }]
 } */ {
   name: 'Delaporte',
@@ -416,7 +372,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape(), Param.shape()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'DiscreteUniform',
@@ -428,7 +384,7 @@ export default [{
     params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
   },
   cases: [{
-    params: () => [int(10), int(11, 100)]
+    params: () => [5, 50]
   }]
 }, {
   name: 'DiscreteWeibull',
@@ -441,7 +397,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.prob(), Param.shape()]
+    params: () => [0.5, 2]
   }]
 }, {
   name: 'DoubleGamma',
@@ -454,7 +410,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.rate()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'DoubleWeibull',
@@ -467,7 +423,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'DoublyNoncentralBeta',
@@ -482,7 +438,7 @@ export default [{
     params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape(), Param.shape(), Param.shape()]
+    params: () => [2, 2, 2, 2]
   }]
 }, {
   name: 'DoublyNoncentralF',
@@ -497,7 +453,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree(), Param.degree(), Param.scale(), Param.scale()]
+    params: () => [5, 5, 2, 2]
   }]
 }, {
   name: 'DoublyNoncentralT',
@@ -510,7 +466,8 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree(), Param.location(), Param.shape()]
+    // mu=1 instead of 0 — mu=0 triggers a NaN bug tracked as issue #52
+    params: () => [5, 1, 2]
   }]
 }, {
   name: 'Erlang',
@@ -523,7 +480,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree(), Param.rate()]
+    params: () => [5, 2]
   }]
 }, {
   name: 'Exponential',
@@ -535,7 +492,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rate()]
+    params: () => [2]
   }]
 }, {
   name: 'ExponentialLogarithmic',
@@ -548,7 +505,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.prob(), Param.scale()]
+    params: () => [0.5, 2]
   }]
 }, {
   name: 'ExponentiatedWeibull',
@@ -562,7 +519,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape(), Param.shape()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'F',
@@ -575,7 +532,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree(), Param.degree()]
+    params: () => [5, 5]
   }]
 }, {
   name: 'FisherZ',
@@ -588,7 +545,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree(), Param.degree()]
+    params: () => [5, 5]
   }]
 }, {
   name: 'FlorySchulz',
@@ -600,7 +557,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.prob()]
+    params: () => [0.5]
   }]
 }, {
   name: 'Frechet',
@@ -613,7 +570,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.scale(), Param.location()]
+    params: () => [2, 2, 0]
   }]
 }, {
   name: 'Gamma',
@@ -626,7 +583,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.rate()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'GammaGompertz',
@@ -640,7 +597,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape(), Param.shape()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'GeneralizedExponential',
@@ -654,7 +611,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape(), Param.shape()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'GeneralizedExtremeValue',
@@ -667,10 +624,10 @@ export default [{
   },
   cases: [{
     name: 'positive shape parameter',
-    params: () => [Param.shape()]
+    params: () => [2]
   }, {
     name: 'negative shape parameter',
-    params: () => [-Param.shape()]
+    params: () => [-2]
   }]
 }, {
   name: 'GeneralizedGamma',
@@ -684,7 +641,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape(), Param.shape()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'GeneralizedHermite',
@@ -698,7 +655,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rate(), Param.rate(), Param.degree() + 1]
+    params: () => [2, 2, 6]
   }]
 }, {
   name: 'GeneralizedLogistic',
@@ -711,7 +668,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale(), Param.shape()]
+    params: () => [0, 2, 2]
   }]
 }, {
   name: 'GeneralizedNormal',
@@ -724,7 +681,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale(), Param.shape()]
+    params: () => [0, 2, 2]
   }]
 }, {
   name: 'GeneralizedPareto',
@@ -737,13 +694,13 @@ export default [{
   },
   cases: [{
     name: 'positive shape parameter',
-    params: () => [Param.location(), Param.scale(), Param.shape()]
+    params: () => [0, 2, 2]
   }, {
     name: 'negative shape parameter',
-    params: () => [Param.location(), Param.scale(), -Param.shape()]
+    params: () => [0, 2, -2]
   }, {
     name: 'zero shape parameter',
-    params: () => [Param.location(), Param.scale(), 0]
+    params: () => [0, 2, 0]
   }]
 }, {
   name: 'Geometric',
@@ -755,7 +712,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.prob()]
+    params: () => [0.5]
   }]
 }, {
   name: 'Gilbrat',
@@ -778,7 +735,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.scale()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'Gumbel',
@@ -790,7 +747,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'HalfGeneralizedNormal',
@@ -803,7 +760,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'HalfLogistic',
@@ -825,7 +782,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale()]
+    params: () => [2]
   }]
 }, {
   name: 'HeadsMinusTails',
@@ -837,7 +794,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree()]
+    params: () => [5]
   }]
 }, {
   name: 'Hoyt',
@@ -851,10 +808,10 @@ export default [{
   },
   cases: [{
     name: 'q < 0.5',
-    params: () => [Param.prob() / 2, Param.scale()]
+    params: () => [0.25, 2]
   }, {
     name: 'normal q',
-    params: () => [Param.prob(), Param.scale()]
+    params: () => [0.5, 2]
   }]
 }, {
   name: 'HyperbolicSecant',
@@ -878,7 +835,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Array.from({ length: Param.degree() + 1 }).map(() => ({ weight: Param.shape(), rate: Param.rate() }))]
+    params: () => [[{ weight: 2, rate: 2 }, { weight: 2, rate: 2 }, { weight: 2, rate: 2 }, { weight: 2, rate: 2 }, { weight: 2, rate: 2 }, { weight: 2, rate: 2 }]]
   }]
 }, {
   name: 'Hypergeometric',
@@ -892,7 +849,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [int(20, 40), int(20), int(10)]
+    params: () => [30, 10, 5]
   }]
 }, {
   name: 'InverseChi2',
@@ -904,7 +861,7 @@ export default [{
     [-1], [0] // nu > 0
   ],
   cases: [{
-    params: () => [Param.degree() + 1]
+    params: () => [6]
   }]
 }, {
   name: 'InverseGamma',
@@ -917,7 +874,7 @@ export default [{
     [1, -1], [1, 0] // beta > 0
   ],
   cases: [{
-    params: () => [Param.shape(), Param.scale()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'InverseGaussian',
@@ -930,7 +887,7 @@ export default [{
     [1, -1], [1, 0] // lambda > 0
   ],
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'InvertedWeibull',
@@ -942,7 +899,7 @@ export default [{
     [-1], [0] // c > 0
   ],
   cases: [{
-    params: () => [Param.shape()]
+    params: () => [2]
   }]
 }, {
   name: 'IrwinHall',
@@ -954,7 +911,7 @@ export default [{
     params: () => [2]
   },
   cases: [{
-    params: () => [Param.count()]
+    params: () => [10]
   }]
 }, {
   name: 'JohnsonSU',
@@ -967,7 +924,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale(), Param.scale(), Param.location()]
+    params: () => [0, 2, 2, 0]
   }]
 }, {
   name: 'JohnsonSB',
@@ -980,7 +937,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale(), Param.scale(), Param.location()]
+    params: () => [0, 2, 2, 0]
   }]
 }, {
   name: 'Kolmogorov',
@@ -1003,7 +960,7 @@ export default [{
     params: () => [0, 1]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'Laplace',
@@ -1015,7 +972,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'Levy',
@@ -1027,7 +984,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'Lindley',
@@ -1039,7 +996,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape()]
+    params: () => [2]
   }]
 }, {
   name: 'LogCauchy',
@@ -1051,7 +1008,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'LogGamma',
@@ -1065,7 +1022,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.rate(), Param.shape()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'LogLaplace',
@@ -1077,7 +1034,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'LogLogistic',
@@ -1090,7 +1047,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'LogNormal',
@@ -1102,7 +1059,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'LogSeries',
@@ -1114,7 +1071,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.prob()]
+    params: () => [0.5]
   }]
 }, {
   name: 'Logarithmic',
@@ -1128,7 +1085,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rangeMin() + 1, Param.rangeMax() + 5]
+    params: () => [6, 30]
   }]
 }, {
   name: 'Logistic',
@@ -1140,7 +1097,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'LogisticExponential',
@@ -1153,7 +1110,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'LogitNormal',
@@ -1165,7 +1122,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'Lomax',
@@ -1178,7 +1135,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'Makeham',
@@ -1192,7 +1149,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.rate(), Param.scale()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'MaxwellBoltzmann',
@@ -1204,7 +1161,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale()]
+    params: () => [2]
   }]
 }, {
   name: 'Mielke',
@@ -1217,7 +1174,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'Moyal',
@@ -1229,7 +1186,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'Muth',
@@ -1241,7 +1198,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.prob()]
+    params: () => [0.5]
   }]
 }, {
   name: 'Nakagami',
@@ -1254,7 +1211,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape() + 0.5, Param.scale()]
+    params: () => [2.5, 2]
   }]
 }, {
   name: 'NegativeHypergeometric',
@@ -1268,7 +1225,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [int(30, 40), int(10, 20), int(5, 10)]
+    params: () => [35, 15, 7]
   }]
 }, {
   name: 'NegativeBinomial',
@@ -1281,7 +1238,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.count(), Param.prob()]
+    params: () => [10, 0.5]
   }]
 }, {
   name: 'NeymanA',
@@ -1294,7 +1251,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'NoncentralBeta',
@@ -1308,7 +1265,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.shape(), Param.scale()]
+    params: () => [2, 2, 2]
   }]
 }, {
   name: 'NoncentralChi',
@@ -1321,7 +1278,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree(), Param.scale()]
+    params: () => [5, 2]
   }]
 }, {
   name: 'NoncentralChi2',
@@ -1335,10 +1292,10 @@ export default [{
   },
   cases: [{
     name: 'odd k',
-    params: () => [2 * Param.degree() + 1, Param.scale()]
+    params: () => [11, 2]
   }, {
     name: 'even k',
-    params: () => [2 * Param.degree(), Param.scale()]
+    params: () => [10, 2]
   }]
 }, {
   name: 'NoncentralF',
@@ -1352,7 +1309,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree(), Param.degree(), Param.scale()]
+    params: () => [5, 5, 2]
   }]
 }, {
   name: 'NoncentralT',
@@ -1364,7 +1321,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree(), Param.location()]
+    params: () => [5, 0]
   }]
 }, {
   name: 'Normal',
@@ -1376,7 +1333,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'Pareto',
@@ -1389,7 +1346,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'PERT',
@@ -1402,7 +1359,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rangeMin(), Param.rangeIn(), Param.rangeMax()]
+    params: () => [5, 15, 25]
   }]
 }, {
   name: 'Poisson',
@@ -1415,10 +1372,10 @@ export default [{
   },
   cases: [{
     name: 'low mean',
-    params: () => [float(20)]
+    params: () => [10]
   }, {
     name: 'high mean',
-    params: () => [float(31, 50)]
+    params: () => [40]
   }]
 }, {
   name: 'PolyaAeppli',
@@ -1431,7 +1388,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.prob()]
+    params: () => [2, 0.5]
   }]
 }, {
   name: 'PowerLaw',
@@ -1443,7 +1400,7 @@ export default [{
     params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
   },
   cases: [{
-    params: () => [Param.scale()]
+    params: () => [2]
   }]
 }, {
   name: 'QExponential',
@@ -1456,7 +1413,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [2 - Param.shape(), Param.rate()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'R',
@@ -1468,7 +1425,9 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape()]
+    // c=4 instead of 2 — at c=2 the sample distribution is too uniform-shaped
+    // for the foreign-rejection test (vs Uniform) to reject reliably
+    params: () => [4]
   }]
 }, {
   name: 'Rademacher',
@@ -1490,7 +1449,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.scale()]
+    params: () => [0, 2]
   }]
 }, {
   name: 'Rayleigh',
@@ -1502,7 +1461,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale()]
+    params: () => [2]
   }]
 }, {
   name: 'Reciprocal',
@@ -1516,7 +1475,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rangeMin(), Param.rangeMax()]
+    params: () => [5, 25]
   }]
 }, {
   name: 'ReciprocalInverseGaussian',
@@ -1529,7 +1488,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'Rice',
@@ -1542,7 +1501,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape(), Param.scale()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'ShiftedLogLogistic',
@@ -1555,13 +1514,13 @@ export default [{
   },
   cases: [{
     name: 'positive shape parameter',
-    params: () => [Param.location(), Param.scale(), float(0.1, 5)]
+    params: () => [0, 2, 2]
   }, {
     name: 'negative shape parameter',
-    params: () => [Param.location(), Param.scale(), float(-5, -0.1)]
+    params: () => [0, 2, -2]
   }, {
     name: 'zero shape parameter',
-    params: () => [Param.location(), Param.scale(), 0]
+    params: () => [0, 2, 0]
   }]
 }, {
   name: 'Skellam',
@@ -1574,7 +1533,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [float(1, 10), float(1, 10)]
+    params: () => [5, 5]
   }]
 }, {
   name: 'SkewNormal',
@@ -1587,13 +1546,13 @@ export default [{
   },
   cases: [{
     name: 'positive shape parameter',
-    params: () => [Param.location(), Param.scale(), Param.shape()]
+    params: () => [0, 2, 2]
   }, {
     name: 'negative shape parameter',
-    params: () => [Param.location(), Param.scale(), -Param.shape()]
+    params: () => [0, 2, -2]
   }, {
     name: 'zero shape parameter',
-    params: () => [Param.location(), Param.scale(), 0]
+    params: () => [0, 2, 0]
   }]
 }, {
   name: 'Slash',
@@ -1615,7 +1574,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.count()]
+    params: () => [10]
   }]
 }, {
   name: 'StudentT',
@@ -1627,7 +1586,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape()]
+    params: () => [2]
   }]
 }, {
   name: 'StudentZ',
@@ -1639,7 +1598,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape() + 1]
+    params: () => [3]
   }]
 }, {
   name: 'Trapezoidal',
@@ -1653,7 +1612,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.location(), Param.location(), Param.location(), Param.location()].sort((a, b) => a - b)
+    params: () => [-3, -1, 1, 3]
   }]
 }, {
   name: 'Triangular',
@@ -1666,7 +1625,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rangeMin(), Param.rangeMax(), Param.rangeIn()]
+    params: () => [5, 25, 15]
   }]
 }, {
   name: 'TruncatedNormal',
@@ -1679,12 +1638,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => {
-      // Choose the peak somewhere within the support to avoid a completely flat distribution.
-      const a = Param.location()
-      const b = a + float(5, 10)
-      return [float(a, b), Param.scale(), a, b]
-    }
+    params: () => [2.5, 2, 0, 5]
   }]
 }, {
   name: 'TukeyLambda',
@@ -1698,10 +1652,10 @@ export default [{
     params: () => [0]
   }, {
     name: 'positive shape parameter',
-    params: () => [Param.shape()]
+    params: () => [2]
   }, {
     name: 'negative shape parameter',
-    params: () => [-Param.shape()]
+    params: () => [-2]
   }]
 }, {
   name: 'UQuadratic',
@@ -1713,7 +1667,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.rangeMin(), Param.rangeMax()]
+    params: () => [5, 25]
   }]
 }, {
   name: 'Uniform',
@@ -1725,7 +1679,7 @@ export default [{
     params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
   },
   cases: [{
-    params: () => [Param.rangeMin(), Param.rangeMax()]
+    params: () => [5, 25]
   }]
 }, {
   name: 'UniformProduct',
@@ -1737,7 +1691,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.degree() + 1]
+    params: () => [6]
   }]
 }, {
   name: 'UniformRatio',
@@ -1759,7 +1713,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape()]
+    params: () => [2]
   }]
 }, {
   name: 'Weibull',
@@ -1772,7 +1726,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale(), Param.shape()]
+    params: () => [2, 2]
   }]
 }, {
   name: 'Wigner',
@@ -1784,7 +1738,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.scale()]
+    params: () => [2]
   }]
 }, {
   name: 'YuleSimon',
@@ -1796,7 +1750,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape() + 1]
+    params: () => [3]
   }]
 }, {
   name: 'Zeta',
@@ -1808,7 +1762,7 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape() + 1.8]
+    params: () => [3.8]
   }]
 }, {
   name: 'Zipf',
@@ -1821,6 +1775,6 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    params: () => [Param.shape() + 1]
+    params: () => [3]
   }]
 }]


### PR DESCRIPTION
## Summary

Closes #103 (Phase 1). Converts every random parameter generator in `test/dist-cases.js` into a deterministic fixed-value generator so the test suite stops being undermined by upstream randomness in fixture data. The arrow-function wrapper `params: () => [...]` is preserved, so `test/dist.js` consumes `c.params()` exactly as today — the function just now returns a fixed value.

- Replace every `Param.xxx()`, direct `float(...)`/`int(...)`, and `Math.random`-via-`Array.from` call across ~152 case entries with the mid-range literal from the plan's mapping table (e.g. `Param.shape()` → `2`, `Param.prob()` → `0.5`, `Param.rangeMin/In/Max` → `5/15/25`).
- Delete the `Param` helper object and the now-unused `import { float, int } from '../src/core'`.
- Special handling: Categorical literal probability arrays; Hyperexponential 6-component literal; TruncatedNormal multi-line inlined to `[2.5, 2, 0, 5]` with WHY-comment preserved; Trapezoidal expanded to sorted `[-3, -1, 1, 3]`; Alpha `foreign.params` converted.
- Net diff: +149/-194 (test-only; no production code touched).

## Scope notes

- "≥ 2 cases per distribution" coverage expansion is **explicitly deferred** to a follow-up issue. Phase 1 is determinism-only — single-case-per-distribution parity with today.
- `DoublyNoncentralT` keeps `mu=1` (not `mu=0`) — `mu=0` triggers a known NaN bug tracked as issue #52. Comment in place.
- `QExponential` `q=0` exercises only the finite-support branch; the `q≥1` infinite-support path coverage is part of the deferred follow-up.

## Test plan

- [x] `npm run standard` — clean
- [x] `npm test` — distribution-test failure set matches baseline; no new failures introduced; pre-existing flaky `cdf2pdf`/`pdfRange` failures (issue #104 territory) unchanged
- [x] `grep -nE '\bParam\.|\bfloat\(|\bint\(|Math\.random' test/dist-cases.js` — no output
- [x] Six-agent pre-merge `/review` — PASS after restoring TruncatedNormal WHY-comment

## Plan

`thoughts/plans/2026-05-15-1645-issue-103-fixed-params-dist-cases.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhqMkfMqoeySWdXXW2vEDB)_