### PR TITLE
Replace trials() with seeded deterministic sampling tests (#102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ npm run docs
 
 - Tests live in `test/` and mirror `src/` module structure.
 - Mocha test runner with Chai `assert` for assertions.
-- `test/test-utils.js` — shared helpers: `trials`, `ksTest`, `chiTest`, `Tests`.
+- `test/test-utils.js` — shared helpers: `ksTest`, `chiTest`, `repeat`, `Tests`.
 - `test/dist-cases.js` — per-distribution test case definitions (`name`, `invalidParams`, `params`, `cases`).
 - `test/dist.js` — runs the full distribution test suite against all entries in `dist-cases.js`.
 - **Behavior-first assertions**: assert on the output of public methods given known inputs (hand-calculated expected values), not on internal state.

--- a/test/core.js
+++ b/test/core.js
@@ -1,12 +1,11 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { trials, ksTest, chiTest } from './test-utils'
+import { ksTest, chiTest } from './test-utils'
 import * as core from '../src/core'
 
 // Constants
 const TRIALS = 1
 const LAPS = 100
-const CHARS = '.,:;-+_!#%&/()[]{}?*0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 function add (dist, value) {
   if (typeof dist[value] === 'undefined') { dist[value] = 1 } else { dist[value]++ }
@@ -15,144 +14,128 @@ function add (dist, value) {
 describe('core', () => {
   describe('.seed()', () => {
     it('should return the same sequence of random numbers for the same numerical seed', () => {
-      trials(() => {
-        const s = Math.floor(Math.random() * 10000)
-        core.seed(s)
-        const values1 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
-        core.seed(s)
-        const values2 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
-        return values1.reduce((acc, d, i) => acc && d === values2[i], true)
-      })
+      core.seed(12345)
+      const values1 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
+      core.seed(12345)
+      const values2 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
+      assert(values1.reduce((acc, d, i) => acc && d === values2[i], true))
     })
 
     it('should return the same sequence of random numbers for the same string seed', () => {
-      trials(() => {
-        const s = Array.from({ length: 32 }, () => CHARS.charAt(Math.floor(Math.random() * CHARS.length))).join('')
-        core.seed(s)
-        const values1 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
-        core.seed(s)
-        const values2 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
-        return values1.reduce((acc, d, i) => acc && d === values2[i], true)
-      })
+      core.seed('test-seed')
+      const values1 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
+      core.seed('test-seed')
+      const values2 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
+      assert(values1.reduce((acc, d, i) => acc && d === values2[i], true))
     })
 
     it('should return different sequence of random numbers for different numerical seeds', () => {
-      trials(() => {
-        core.seed(Math.floor(Math.random() * 10000))
-        const values1 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
-        core.seed(Math.floor(Math.random() * 10000))
-        const values2 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
-        return values1.reduce((acc, d, i) => acc && d !== values2[i], true)
-      })
+      core.seed(111)
+      const values1 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
+      core.seed(999)
+      const values2 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
+      assert(values1.some((d, i) => d !== values2[i]))
     })
 
-    it('should return different sequence of random numbers for different numerical seeds', () => {
-      trials(() => {
-        core.seed(Array.from({ length: 32 }, () => CHARS.charAt(Math.floor(Math.random() * CHARS.length))).join(''))
-        const values1 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
-        core.seed(Array.from({ length: 32 }, () => CHARS.charAt(Math.floor(Math.random() * CHARS.length))).join(''))
-        const values2 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
-        return values1.reduce((acc, d, i) => acc && d !== values2[i], true)
-      })
+    it('should return different sequence of random numbers for different string seeds', () => {
+      core.seed('seed-a')
+      const values1 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
+      core.seed('seed-b')
+      const values2 = Array.from({ length: LAPS }, () => core.int(Number.MAX_SAFE_INTEGER))
+      assert(values1.some((d, i) => d !== values2[i]))
     })
   })
 
   describe('.float()', () => {
     it('should return a float uniformly distributed in [0, 1]', () => {
-      trials(() => {
-        const values = Array.from({ length: LAPS }, () => core.float())
-        return ksTest(values, x => x)
-      })
+      core.seed(0)
+      const values = Array.from({ length: LAPS }, () => core.float())
+      assert(ksTest(values, x => x))
     })
 
     it('should return a float uniformly distributed in [min, max]', () => {
-      trials(() => {
-        const max = Math.random() * 20
-        const values = Array.from({ length: LAPS }, () => core.float(max))
-        return ksTest(values, x => x / max)
-      })
+      core.seed(0)
+      const max = core.float() * 20
+      const values = Array.from({ length: LAPS }, () => core.float(max))
+      assert(ksTest(values, x => x / max))
     })
 
     it('should return multiple floats uniformly distributed in [min, max]', () => {
-      trials(() => {
-        const min = Math.random() * 20 - 10
-        const max = 10 + Math.random() * 10
-        const k = Math.floor(Math.random() * 10 - 5)
-        const values = []
-        for (let lap = 0; lap < LAPS; lap++) {
-          let r = core.float(min, max, k)
-          if (k < 2) { r = [r] }
-          r.forEach(ri => {
-            values.push(ri)
-            // Value is in range
-            assert((min < max ? min : max) <= ri && ri <= (min < max ? max : min))
-          })
-          // Length is correct
-          assert.equal(k < 2 ? 1 : k, r.length)
-        }
+      core.seed(0)
+      const min = core.float() * 20 - 10
+      const max = 10 + core.float() * 10
+      const k = Math.floor(core.float() * 10 - 5)
+      const values = []
+      for (let lap = 0; lap < LAPS; lap++) {
+        let r = core.float(min, max, k)
+        if (k < 2) { r = [r] }
+        r.forEach(ri => {
+          values.push(ri)
+          // Value is in range
+          assert((min < max ? min : max) <= ri && ri <= (min < max ? max : min))
+        })
+        // Length is correct
+        assert.equal(k < 2 ? 1 : k, r.length)
+      }
 
-        // Distribution is uniform
-        if (min < max) {
-          return ksTest(values, x => (x - min) / (max - min))
-        } else {
-          return ksTest(values, x => (x - max) / (min - max))
-        }
-      })
+      // Distribution is uniform
+      if (min < max) {
+        assert(ksTest(values, x => (x - min) / (max - min)))
+      } else {
+        assert(ksTest(values, x => (x - max) / (min - max)))
+      }
     })
   })
 
   describe('.int()', () => {
     it('should return an integer uniformly distributed in [0, max]', () => {
-      trials(() => {
-        const max = Math.floor(Math.random() * 10)
-        const values = Array.from({ length: LAPS }, () => core.int(max))
-        return chiTest(values, () => 1 / Math.abs(max + 1), 1)
-      })
+      core.seed(0)
+      const max = core.int(9)
+      const values = Array.from({ length: LAPS }, () => core.int(max))
+      assert(chiTest(values, () => 1 / Math.abs(max + 1), 1))
     })
 
     it('should return an integer uniformly distributed in [min, max]', () => {
-      trials(() => {
-        const min = Math.floor(Math.random() * 20 - 10)
-        const max = 20 + Math.floor(Math.random() * 10)
-        const values = []
-        for (let lap = 0; lap < LAPS; lap++) {
-          const r = core.int(min, max)
-          values.push(r)
+      core.seed(0)
+      const min = Math.floor(core.float() * 20 - 10)
+      const max = 20 + Math.floor(core.float() * 10)
+      const values = []
+      for (let lap = 0; lap < LAPS; lap++) {
+        const r = core.int(min, max)
+        values.push(r)
 
-          // Value is in range
-          assert((min < max ? min : max) <= r && r <= (min < max ? max : min))
+        // Value is in range
+        assert((min < max ? min : max) <= r && r <= (min < max ? max : min))
 
-          // Value is integer
-          assert.equal(r, parseInt(r, 10))
-        }
+        // Value is integer
+        assert.equal(r, parseInt(r, 10))
+      }
 
-        // Distribution is uniform
-        return chiTest(values, () => 1 / Math.abs(max - min + 1), 1)
-      })
+      // Distribution is uniform
+      assert(chiTest(values, () => 1 / Math.abs(max - min + 1), 1))
     })
 
     it('should return multiple integers uniformly distributed in [0, max]', () => {
-      trials(() => {
-        const min = Math.floor(Math.random() * 20 - 10)
-        const max = 20 + Math.floor(Math.random() * 10)
-        const k = Math.floor(Math.random() * 10 - 5)
-        const values = []
-        for (let lap = 0; lap < LAPS; lap++) {
-          let r = core.int(min, max, k)
-          if (k < 2) { r = [r] }
-          for (let i = 0; i < r.length; i++) {
-            values.push(r[i])
+      core.seed(0)
+      const min = Math.floor(core.float() * 20 - 10)
+      const max = 20 + Math.floor(core.float() * 10)
+      const k = Math.floor(core.float() * 10 - 5)
+      const values = []
+      for (let lap = 0; lap < LAPS; lap++) {
+        let r = core.int(min, max, k)
+        if (k < 2) { r = [r] }
+        for (let i = 0; i < r.length; i++) {
+          values.push(r[i])
 
-            // Value is in range
-            assert((min < max ? min : max) <= r[i] && r[i] <= (min < max ? max : min), 'Value is out of range')
-          }
-          // Length is correct
-          assert.equal(k < 2 ? 1 : k, r.length, 'Number of samples is incorrect')
+          // Value is in range
+          assert((min < max ? min : max) <= r[i] && r[i] <= (min < max ? max : min), 'Value is out of range')
         }
+        // Length is correct
+        assert.equal(k < 2 ? 1 : k, r.length, 'Number of samples is incorrect')
+      }
 
-        // Distribution is uniform
-        return chiTest(values, () => 1 / Math.abs(max - min + 1), max === min ? 1 : 2)
-      })
+      // Distribution is uniform
+      assert(chiTest(values, () => 1 / Math.abs(max - min + 1), max === min ? 1 : 2))
     })
   })
 
@@ -254,37 +237,35 @@ describe('core', () => {
 
   describe('.coin()', () => {
     it('should return head or tail with 50% chance', () => {
-      trials(() => {
-        const head = Math.floor(Math.random() * 10)
-        const tail = head + Math.floor(1 + Math.random() * 10)
-        const values = []
-        for (let lap = 0; lap < LAPS; lap++) {
-          let r = core.coin(head, tail)
-          r = [r]
-          r.forEach(ri => values.push(ri))
-        }
+      core.seed(0)
+      const head = Math.floor(core.float() * 10)
+      const tail = head + Math.floor(1 + core.float() * 10)
+      const values = []
+      for (let lap = 0; lap < LAPS; lap++) {
+        let r = core.coin(head, tail)
+        r = [r]
+        r.forEach(ri => values.push(ri))
+      }
 
-        // Distribution is uniform
-        return chiTest(values, () => 0.5, 1)
-      })
+      // Distribution is uniform
+      assert(chiTest(values, () => 0.5, 1))
     })
 
     it('should return multiple heads/tails with specific probability', () => {
-      trials(() => {
-        const p = Math.random()
-        const k = Math.floor(Math.random() * 10)
-        const head = Math.floor(Math.random() * 20)
-        const tail = head + Math.floor(1 + Math.random() * 20)
-        const values = []
-        for (let lap = 0; lap < LAPS; lap++) {
-          let r = core.coin(head, tail, p, k)
-          if (k < 2) { r = [r] }
-          r.forEach(ri => values.push(ri))
-        }
+      core.seed(0)
+      const p = core.float()
+      const k = Math.floor(core.float() * 10)
+      const head = Math.floor(core.float() * 20)
+      const tail = head + Math.floor(1 + core.float() * 20)
+      const values = []
+      for (let lap = 0; lap < LAPS; lap++) {
+        let r = core.coin(head, tail, p, k)
+        if (k < 2) { r = [r] }
+        r.forEach(ri => values.push(ri))
+      }
 
-        // Distribution is uniform
-        return chiTest(values, x => x === head ? p : 1 - p, 1)
-      })
+      // Distribution is uniform
+      assert(chiTest(values, x => x === head ? p : 1 - p, 1))
     })
   })
 })

--- a/test/dist.js
+++ b/test/dist.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { trials, ksTest, chiTest, Tests } from './test-utils'
+import { ksTest, chiTest, Tests } from './test-utils'
 import { float } from '../src/core'
 import * as dist from '../src/dist'
 import PreComputed from '../src/dist/_pre-computed'
@@ -8,7 +8,7 @@ import testCases from './dist-cases'
 
 // Constants.
 const PRECISION = 1e-10
-const SAMPLE_SIZE = 1000
+const SAMPLE_SIZE = 10000
 
 // Unit test suite.
 const UnitTests = {
@@ -156,13 +156,12 @@ const UnitTests = {
         })
 
         it('sample values should be distributed correctly', () => {
-          trials(() => {
-            const generator = c.generate()
-            return generator.type() === 'continuous'
-              ? ksTest(generator.sample(SAMPLE_SIZE), x => generator.cdf(x))
-              : chiTest(generator.sample(SAMPLE_SIZE), x => generator.pdf(x),
-                Object.keys(generator.save().params).length)
-          })
+          const generator = c.generate()
+          generator.seed(0)
+          assert(generator.type() === 'continuous'
+            ? ksTest(generator.sample(SAMPLE_SIZE), x => generator.cdf(x))
+            : chiTest(generator.sample(SAMPLE_SIZE), x => generator.pdf(x),
+              Object.keys(generator.save().params).length))
         })
       })
     })
@@ -186,26 +185,17 @@ const UnitTests = {
     cases.forEach(c => {
       describe(c.name, () => {
         it('should pass for own test', () => {
-          trials(() => {
-            const generator = c.gen()
-            return generator.test(generator.sample(SAMPLE_SIZE)).passed
-          })
+          const generator = c.gen()
+          generator.seed(0)
+          assert(generator.test(generator.sample(SAMPLE_SIZE)).passed)
         })
 
         it('should reject foreign distribution', () => {
-          trials(() => {
-            for (let i = 0; i < 10; i++) {
-              const generator = c.gen()
-              const sample = generator.sample(SAMPLE_SIZE)
-              try {
-                const foreign = new dist[tc.foreign.generator](...tc.foreign.params(sample))
-                return !foreign.test(sample).passed
-              } catch (e) {
-                // DO nothing.
-                console.log(generator.p)
-              }
-            }
-          })
+          const generator = c.gen()
+          generator.seed(0)
+          const sample = generator.sample(SAMPLE_SIZE)
+          const foreign = new dist[tc.foreign.generator](...tc.foreign.params(sample))
+          assert(!foreign.test(sample).passed)
         })
       })
     })

--- a/test/location.js
+++ b/test/location.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { repeat, equal, trials } from './test-utils'
+import { repeat, equal } from './test-utils'
 import { int } from '../src/core'
 import * as location from '../src/location'
 import * as dist from '../src/dist'
@@ -134,12 +134,10 @@ describe('location', () => {
       })
 
       it('should return the approximate mode for sample size larger than 3', () => {
-        trials(() => {
-          const mu = 10 * Math.random()
-          const sample = new dist.Normal(mu, 0.1).sample(1000)
-          const mode = location.mode(sample)
-          return equal(mode, mu, 2)
-        })
+        const mu = 3.7
+        const sample = new dist.Normal(mu, 0.1).seed(0).sample(1000)
+        const mode = location.mode(sample)
+        assert(equal(mode, mu, 2))
       })
     })
   })

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -185,14 +185,6 @@ export function chiTest (values, model, c) {
   }
 }
 
-export function trials (test) {
-  let success = 0
-  for (let t = 0; t < 5; t++) {
-    success += test(t) ? 1 : 0
-  }
-  assert(success >= 3, `Failed ${5 - success} out of ${5}`)
-}
-
 export function repeat (test, times = 10) {
   for (let i = 0; i < times; i++) {
     test()

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,8 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { int, float } from '../src/core'
+import { int, float, seed } from '../src/core'
 import { Poisson, Normal } from '../src/dist'
 import * as test from '../src/test'
-import { trials } from './test-utils'
 
 const SAMPLE_SIZE = 50
 
@@ -22,34 +21,30 @@ describe('test', () => {
     })
 
     it('should pass for discrete samples of the same variance', () => {
-      trials(() => {
-        const k = int(2, 5)
-        const lambda = int(1, 30)
-        return test.bartlett(Array.from({ length: k }, () => (new Poisson(lambda)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(2, 5)
+      const lambda = int(1, 30)
+      assert(test.bartlett(Array.from({ length: k }, (_, i) => (new Poisson(lambda)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should reject for discrete samples of different variance', () => {
-      trials(() => {
-        const k = int(3, 5)
-        return !test.bartlett(Array.from({ length: k }, () => (new Poisson(1 + Math.random() * 30)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(3, 5)
+      assert(!test.bartlett(Array.from({ length: k }, (_, i) => (new Poisson(1 + float() * 30)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should pass for continuous samples of the same variance', () => {
-      trials(() => {
-        const k = int(2, 5)
-        const mu = float(0, 5)
-        const sigma = float(1, 10)
-        return test.bartlett(Array.from({ length: k }, () => (new Normal(mu, sigma)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(2, 5)
+      const mu = float(0, 5)
+      const sigma = float(1, 10)
+      assert(test.bartlett(Array.from({ length: k }, (_, i) => (new Normal(mu, sigma)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should reject for continuous samples of different variance', () => {
-      trials(() => {
-        const k = int(3, 5)
-        return !test.bartlett(Array.from({ length: k }, () => (new Normal(float(0, 5), float(1, 10))).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(3, 5)
+      assert(!test.bartlett(Array.from({ length: k }, (_, i) => (new Normal(float(0, 5), float(1, 10))).seed(i).sample(SAMPLE_SIZE))).passed)
     })
   })
 
@@ -61,34 +56,30 @@ describe('test', () => {
     })
 
     it('should pass for discrete samples of the same variance', () => {
-      trials(() => {
-        const k = int(2, 5)
-        const lambda = int(1, 30)
-        return test.brownForsythe(Array.from({ length: k }, () => (new Poisson(lambda)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(2, 5)
+      const lambda = int(1, 30)
+      assert(test.brownForsythe(Array.from({ length: k }, (_, i) => (new Poisson(lambda)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should reject for discrete samples of different variance', () => {
-      trials(() => {
-        const k = int(3, 5)
-        return !test.brownForsythe(Array.from({ length: k }, () => (new Poisson(1 + Math.random() * 30)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(3, 5)
+      assert(!test.brownForsythe(Array.from({ length: k }, (_, i) => (new Poisson(1 + float() * 30)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should pass for continuous samples of the same variance', () => {
-      trials(() => {
-        const k = int(2, 5)
-        const mu = float(0, 5)
-        const sigma = float(1, 10)
-        return test.brownForsythe(Array.from({ length: k }, () => (new Normal(mu, sigma)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(2, 5)
+      const mu = float(0, 5)
+      const sigma = float(1, 10)
+      assert(test.brownForsythe(Array.from({ length: k }, (_, i) => (new Normal(mu, sigma)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should reject for continuous samples of different variance', () => {
-      trials(() => {
-        const k = int(3, 5)
-        return !test.brownForsythe(Array.from({ length: k }, () => (new Normal(float(0, 5), float(1, 10))).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(3, 5)
+      assert(!test.brownForsythe(Array.from({ length: k }, (_, i) => (new Normal(float(0, 5), float(1, 10))).seed(i).sample(SAMPLE_SIZE))).passed)
     })
   })
 
@@ -112,20 +103,18 @@ describe('test', () => {
     })
 
     it('should pass for independent samples', () => {
-      trials(() => {
-        const sample1 = float(0, 10, SAMPLE_SIZE)
-        const sample2 = float(0, 10, SAMPLE_SIZE)
-        return test.hsic([sample1, sample2])
-      })
+      seed(0)
+      const sample1 = float(0, 10, SAMPLE_SIZE)
+      const sample2 = float(0, 10, SAMPLE_SIZE)
+      assert(test.hsic([sample1, sample2]).passed)
     })
 
     it('should reject for dependent data sets', () => {
-      trials(() => {
-        const normal = new Normal()
-        const sample1 = Array.from({ length: SAMPLE_SIZE }, (d, i) => i)
-        const sample2 = sample1.map(d => d + normal.sample())
-        return !test.hsic([sample1, sample2]).passed
-      })
+      seed(0)
+      const normal = new Normal().seed(0)
+      const sample1 = Array.from({ length: SAMPLE_SIZE }, (d, i) => i)
+      const sample2 = sample1.map(d => d + normal.sample())
+      assert(!test.hsic([sample1, sample2]).passed)
     })
   })
 
@@ -137,34 +126,30 @@ describe('test', () => {
     })
 
     it('should pass for discrete samples of the same variance', () => {
-      trials(() => {
-        const k = int(2, 5)
-        const lambda = int(1, 30)
-        return test.levene(Array.from({ length: k }, () => (new Poisson(lambda)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(2, 5)
+      const lambda = int(1, 30)
+      assert(test.levene(Array.from({ length: k }, (_, i) => (new Poisson(lambda)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should reject for discrete samples of different variance', () => {
-      trials(() => {
-        const k = int(3, 5)
-        return !test.levene(Array.from({ length: k }, () => (new Poisson(1 + Math.random() * 30)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(3, 5)
+      assert(!test.levene(Array.from({ length: k }, (_, i) => (new Poisson(1 + float() * 30)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should pass for continuous samples of the same variance', () => {
-      trials(() => {
-        const k = int(2, 5)
-        const mu = float(0, 5)
-        const sigma = float(1, 10)
-        return test.levene(Array.from({ length: k }, () => (new Normal(mu, sigma)).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(2, 5)
+      const mu = float(0, 5)
+      const sigma = float(1, 10)
+      assert(test.levene(Array.from({ length: k }, (_, i) => (new Normal(mu, sigma)).seed(i).sample(SAMPLE_SIZE))).passed)
     })
 
     it('should reject for continuous samples of different variance', () => {
-      trials(() => {
-        const k = int(3, 5)
-        return !test.levene(Array.from({ length: k }, () => (new Normal(float(0, 5), float(1, 10))).sample(SAMPLE_SIZE))).passed
-      })
+      seed(0)
+      const k = int(3, 5)
+      assert(!test.levene(Array.from({ length: k }, (_, i) => (new Normal(float(0, 5), float(1, 10))).seed(i).sample(SAMPLE_SIZE))).passed)
     })
   })
 
@@ -176,41 +161,37 @@ describe('test', () => {
     })
 
     it('should pass for samples of the same discrete distribution', () => {
-      trials(() => {
-        const lambda = int(1, 10)
-        const sample1 = (new Poisson(lambda)).sample(SAMPLE_SIZE)
-        const sample2 = (new Poisson(lambda)).sample(SAMPLE_SIZE)
-        return test.mannWhitney([sample1, sample2]).passed
-      })
+      seed(0)
+      const lambda = int(1, 10)
+      const sample1 = (new Poisson(lambda)).seed(1).sample(SAMPLE_SIZE)
+      const sample2 = (new Poisson(lambda)).seed(2).sample(SAMPLE_SIZE)
+      assert(test.mannWhitney([sample1, sample2]).passed)
     })
 
     it('should reject for samples of different discrete distributions', () => {
-      trials(() => {
-        const lambda = int(1, 10)
-        const sample1 = (new Poisson(lambda)).sample(SAMPLE_SIZE)
-        const sample2 = (new Poisson(lambda + 10)).sample(SAMPLE_SIZE)
-        return !test.mannWhitney([sample1, sample2]).passed
-      })
+      seed(0)
+      const lambda = int(1, 10)
+      const sample1 = (new Poisson(lambda)).seed(1).sample(SAMPLE_SIZE)
+      const sample2 = (new Poisson(lambda + 10)).seed(2).sample(SAMPLE_SIZE)
+      assert(!test.mannWhitney([sample1, sample2]).passed)
     })
 
     it('should pass for samples of the same continuous distribution', () => {
-      trials(() => {
-        const mu = float(0, 5)
-        const sigma = float(1, 10)
-        const sample1 = (new Normal(mu, sigma)).sample(SAMPLE_SIZE)
-        const sample2 = (new Normal(mu, sigma)).sample(SAMPLE_SIZE)
-        return test.mannWhitney([sample1, sample2]).passed
-      })
+      seed(0)
+      const mu = float(0, 5)
+      const sigma = float(1, 10)
+      const sample1 = (new Normal(mu, sigma)).seed(1).sample(SAMPLE_SIZE)
+      const sample2 = (new Normal(mu, sigma)).seed(2).sample(SAMPLE_SIZE)
+      assert(test.mannWhitney([sample1, sample2]).passed)
     })
 
     it('should reject for samples of different continuous distributions', () => {
-      trials(() => {
-        const mu = float(0, 5)
-        const sigma = float(1, 10)
-        const sample1 = (new Normal(mu, sigma)).sample(SAMPLE_SIZE)
-        const sample2 = (new Normal(mu + 10, sigma)).sample(SAMPLE_SIZE)
-        return !test.mannWhitney([sample1, sample2]).passed
-      })
+      seed(0)
+      const mu = float(0, 5)
+      const sigma = float(1, 10)
+      const sample1 = (new Normal(mu, sigma)).seed(1).sample(SAMPLE_SIZE)
+      const sample2 = (new Normal(mu + 10, sigma)).seed(2).sample(SAMPLE_SIZE)
+      assert(!test.mannWhitney([sample1, sample2]).passed)
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,6 +1089,11 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz"
   integrity sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==
 
+"@rollup/rollup-linux-x64-musl@4.60.4":
+  version "4.60.4"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz"
+  integrity sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"


### PR DESCRIPTION
## Summary

- Delete `trials()` (5-retry wrapper) from `test/test-utils.js` and remove all 36 call sites across `test/dist.js` (×3), `test/core.js` (×12), `test/test.js` (×20), and `test/location.js` (×1)
- Raise `SAMPLE_SIZE` in `test/dist.js` from 1000 → 10000; KS critical value at N=10000 is 0.01628, well below typical D ≈ 0.008 for correct implementations
- Seed each distribution with `.seed(0)` before sampling; seed the global core PRNG with `core.seed(0)` at the start of each former `trials()` block
- Collapse the dead 10-iteration loop and silent `try/catch` in the foreign-rejection test (all iterations were identical under deterministic seeding; removing the catch surfaces real constructor bugs)
- Fix different-seed reproducibility assertion from `reduce(acc && d !== values2[i])` to `some(d !== values2[i])` — correct semantics for "sequences differ"

## Test plan

- [ ] `npm run standard` passes (no lint errors)
- [ ] `npm test` shows 4043 passing, 4 failing (FisherZ ×2, NegativeBinomial, VonMises — all pre-existing bugs tracked in #137, #138, #139)
- [ ] No `trials` import or call in any test file
- [ ] `SAMPLE_SIZE === 10000` in `test/dist.js`

https://claude.ai/code/session_01VSBys2iFyGzQCJp73fDZZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSBys2iFyGzQCJp73fDZZN)_