### PR TITLE
Fix DoublyNoncentralT pdf returning NaN at mu = 0

### DIFF
--- a/src/dist/doubly-noncentral-t.js
+++ b/src/dist/doubly-noncentral-t.js
@@ -168,6 +168,13 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
+    // When mu = 0, all j > 0 terms in the series carry a factor of mu^j = 0, so only j = 0 survives.
+    if (this.p.mu === 0) {
+      const tk = 1 + x * x / this.p.nu
+      const kj0 = (this.p.nu + 1) / 2
+      return Math.exp(this.c[0]) * gamma(kj0) * f11(kj0, this.p.nu / 2, this.p.theta / (2 * tk)) / Math.pow(tk, kj0)
+    }
+
     // Some pre-computed constants
     const nu2 = this.p.nu / 2
     const tk = 1 + x * x / this.p.nu

--- a/test/dist-cases.js
+++ b/test/dist-cases.js
@@ -466,8 +466,9 @@ export default [{
     params: s => [Math.min(...s), Math.max(...s)]
   },
   cases: [{
-    // mu=1 instead of 0 — mu=0 triggers a NaN bug tracked as issue #52
     params: () => [5, 1, 2]
+  }, {
+    params: () => [5, 0, 2]
   }]
 }, {
   name: 'Erlang',


### PR DESCRIPTION
Closes #52

## Summary
- `_pdf` returned `NaN` when `mu = 0` because `Math.log(0) = -Infinity` propagated through `_logA` as `0 * -Infinity = NaN`, breaking the `_findStartIndex` bisection loop
- When `mu = 0`, all `j > 0` series terms carry a factor of `mu^j = 0`, so only the `j = 0` term survives — added an early-exit special case that evaluates this closed form directly
- Added a `mu = 0` test case to `test/dist-cases.js` and removed the old workaround comment

## Non-trivial changes
- **`src/dist/doubly-noncentral-t.js`**: New branch at the top of `_pdf` for `mu === 0` that returns `exp(c[0]) * Γ((ν+1)/2) / tk^((ν+1)/2) * ₁F₁((ν+1)/2, ν/2; θ/(2tk))` — the exact j=0 term from the Paolella (2007) series, verified correct by the correctness reviewer

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases.js`**: Removed workaround comment, added `[5, 0, 2]` parameter case for `mu = 0`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaTZ3rhHm5rQcgGEq9PTYS)_