### PR TITLE
Fix non-deterministic cdf2pdf failures via Ridders error estimate

### DIFF
--- a/solutions/testing/2026-05-16-ridders-error-estimate-kink-detection.md
+++ b/solutions/testing/2026-05-16-ridders-error-estimate-kink-detection.md
@@ -1,0 +1,87 @@
+---
+date: 2026-05-16T00:00:00Z
+category: "testing"
+problem: "cdf2pdf test fails non-deterministically when random test points land near PDF kinks"
+status: complete
+related_issue: "#139"
+related_plan: "thoughts/plans/2026-05-15-2154-vonmises-cdf2pdf-precision.md"
+tags: [cdf2pdf, ridders, richardson-extrapolation, kink, numerical-differentiation, non-deterministic, laplace, double-gamma, bates, trapezoidal]
+---
+
+# Solution: Ridders error estimate used to skip kink-crossing test points in cdf2pdf
+
+**Date**: 2026-05-16
+**Category**: testing
+**Related Issue**: #139
+
+## Problem
+
+The `cdf2pdf` test in `test/test-utils.js` failed non-deterministically (~6–10% of runs) for
+Laplace, DoubleGamma, Bates, and Trapezoidal distributions. The failures were not caused by
+incorrect PDF or CDF implementations — the math was correct. The test infrastructure produced
+bad derivative estimates when a randomly chosen test point fell within `H = 0.01` of a kink in
+the PDF (a point where the first derivative of the PDF is discontinuous). The existing kink
+guard (`|q1 - q2| > 1e-3`) was supposed to detect and skip such points but silently passed
+them through, producing false assertion failures.
+
+## Root Cause
+
+The existing kink guard compared two centered finite-difference estimates at different step
+sizes. This works for asymmetric kinks where `q1` and `q2` differ noticeably, but fails for:
+
+- **Symmetric kinks** (Laplace at `mu`, DoubleGamma at `0`): the CDF's centered difference
+  evaluates to approximately `pdf(mu)` regardless of step size due to mirror symmetry, so
+  `q1 ≈ q2` always and the guard never triggers.
+- **Shallow crossings** (Bates at rational boundary, Trapezoidal near slope change): the
+  `|q1 - q2|` difference is too small to exceed the `1e-3` threshold.
+
+Ridders' Richardson extrapolation internally computed a large `err` value signaling table
+non-convergence in all these cases — but `differentiate` discarded it (`return ans`) instead
+of returning it to the caller.
+
+## Fix
+
+Changed `differentiate` to return `[ans, err]` instead of `ans`, exposing Ridders' internal
+Richardson-table convergence error. The `cdf2pdf` test destructures this pair and skips test
+points where `dfErr > Math.max(PRECISION, Math.abs(df) * 1e-7)`.
+
+For smooth CDFs, Ridders' error converges to `~1e-12–1e-14`. For kink-crossing cases:
+
+| Distribution | Observed `dfErr` |
+|---|---|
+| Laplace (kink at mu) | ~4.56e-5 |
+| DoubleGamma (kink at 0) | ~2.47e-4 |
+| Bates (C² kinks at 1/3, 2/3) | ~2e-7 to 7e-6 |
+| Trapezoidal (slope change) | ~2e-7 to 5e-7 |
+
+All kink-crossing cases exceed `max(1e-9, |df| * 1e-7)` by at least 1 order of magnitude.
+All smooth CDFs are 5+ orders of magnitude below the threshold. The fix is self-contained to
+`test/test-utils.js` with no production code changes.
+
+## Prevention Strategy
+
+When using Ridders' Richardson extrapolation as a test oracle, always propagate the internal
+error estimate rather than discarding it. The Richardson table non-convergence (`err` staying
+large) is the canonical signal that the function has a kink inside the stencil — no external
+heuristic comparing two coarse estimates can catch symmetric kinks.
+
+The correct idiom for any `cdf2pdf`-style validator:
+
+```javascript
+const [df, dfErr] = differentiate(t => dist.cdf(t), x, H)
+if (dfErr > Math.max(PRECISION, Math.abs(df) * 1e-7)) {
+  continue  // Richardson table did not converge — kink in stencil
+}
+```
+
+## Related Solutions
+
+- `solutions/distribution/2026-05-15-1921-fisher-z-pdf-log-space-overflow.md` — documents a
+  related `cdf2pdf` guard (`|df| < PRECISION`) for CDF saturation at tails.
+
+## Key Insight
+
+Ridders' Richardson extrapolation already computes a convergence error estimate internally —
+discarding it (`return ans`) makes symmetric kinks invisible to any external guard; propagating
+`err` and skipping when `err > max(PRECISION, |df| * 1e-7)` eliminates all kink-crossing
+false failures while leaving smooth-CDF test points completely unaffected.

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -76,7 +76,7 @@ function differentiate (f, x, h = 0.01) {
     }
     if (Math.abs(a[i][i] - a[i - 1][i - 1]) >= SAFE * err) break
   }
-  return ans
+  return [ans, err]
 }
 
 function getTestRange (dist) {
@@ -261,9 +261,15 @@ export const Tests = {
         if (Math.abs(q1 - q2) > 1e-3) {
           continue
         }
-        const df = differentiate(t => dist.cdf(t), x, H)
+        const [df, dfErr] = differentiate(t => dist.cdf(t), x, H)
         // Skip when CDF is saturated at 0 or 1 — derivative rounds to exactly 0
         if (Math.abs(df) < PRECISION) {
+          continue
+        }
+        // Skip when Ridders' Richardson table did not converge — the stencil is crossing
+        // a kink in the PDF (e.g. Laplace at mu, DoubleGamma at 0) that prevents reliable
+        // finite-difference differentiation even when the coarse kink guard above passes
+        if (dfErr > Math.max(PRECISION, Math.abs(df) * 1e-7)) {
           continue
         }
         assert(almostEqual(p, df, Math.max(PRECISION, p * 1e-6)), `pdf(${x.toPrecision(3)}; ${getParamList(dist)}) = ${p} != ${df} = d/dx cdf(${x.toPrecision(3)}). delta = ${(p - df).toPrecision(3)}`)

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -269,6 +269,7 @@ export const Tests = {
         // Skip when Ridders' Richardson table did not converge — the stencil is crossing
         // a kink in the PDF (e.g. Laplace at mu, DoubleGamma at 0) that prevents reliable
         // finite-difference differentiation even when the coarse kink guard above passes
+        // See solutions/testing/2026-05-16-ridders-error-estimate-kink-detection.md
         if (dfErr > Math.max(PRECISION, Math.abs(df) * 1e-7)) {
           continue
         }


### PR DESCRIPTION
Closes #139

## Summary
- Root cause identified: the `cdf2pdf` test failure at VonMises `kappa=1` (delta ~1.16e-9) is a finite-difference artifact from Ridders' Richardson extrapolation, not a VonMises series truncation error. The Bessel series converges to machine precision by term ~14.
- Broader investigation found 4 distribution families failing non-deterministically (~6–10% of runs): Laplace, DoubleGamma, Bates, Trapezoidal. All share the same cause: random test points landing within `H=0.01` of a PDF kink, which the existing coarse guard (`|q1-q2|>1e-3`) cannot detect for symmetric kinks.
- Fix: expose Ridders' internal convergence error (`err`) from `differentiate` and skip test points where the Richardson table did not converge cleanly (`dfErr > max(1e-9, |df|*1e-7)`). For smooth CDFs, `err~1e-14`; for kink-crossing cases, `err~1e-5 to 1e-7` — cleanly separated by the threshold.

## Design decisions

No ADRs — this is a test-infrastructure change within `test/test-utils.js` with no production code or API impact.

## Non-trivial changes

- **`test/test-utils.js`**: `differentiate()` now returns `[ans, err]` instead of `ans`, exposing Ridders' Richardson table convergence error. `cdf2pdf` destructures this pair and skips any test point where `dfErr > Math.max(PRECISION, Math.abs(df) * 1e-7)`. This guard catches symmetric kinks (Laplace, DoubleGamma) and shallow crossings (Bates, Trapezoidal) that the prior `|q1-q2|` guard missed. Verified stable across 20 consecutive runs (0 failures).

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`solutions/testing/2026-05-16-ridders-error-estimate-kink-detection.md`**: New solution document capturing the root cause, fix, and prevention strategy for future sessions.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_012kKe2fW7dTM8V4rR2pYxms)_