### PR TITLE
Close umbrella #140: document NegativeBinomial validation fix in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `npm test` now works on Node 20+ by replacing the unmaintained `esm` loader with `@babel/register`, aligning the test and coverage execution paths.
 - `Kolmogorov.pdf(0)` and `Kolmogorov.cdf(0)` now correctly return 0. Previously the lower support bound was declared `closed: true` (contradicting the documented support x > 0), causing `cdf(0)` to evaluate a non-convergent Grandi's series and return −1.
 - `FisherZ.pdf(x)` no longer returns `Infinity` for right-tail values at default parameters (`d1=1, d2=1`). Replaced delegating computation through F→Beta with a direct log-space formula that avoids float64 precision loss when the Beta argument rounds to 1.0.
+- `NegativeBinomial` constructor now correctly rejects out-of-range parameters: `r ≤ 0`, `p < 0`, and `p > 1`. Previously some values slipped through validation.
 
 ## [1.24.6] - 2026-05-14
 


### PR DESCRIPTION
Closes #140

## Summary
- All 5 sub-issues (#102, #104, #137, #138, #139) are merged to `main`; the test suite is fully green
- Verified 10 consecutive `npm test` runs: 4069 passing, 0 failing on each run
- Adds the missing `NegativeBinomial` parameter-validation fix to the `## [Unreleased]` changelog

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added one bullet under `### Fixed` documenting that `NegativeBinomial` constructor now rejects `r ≤ 0`, `p < 0`, and `p > 1`. Wording avoids "all invalid combinations" to not overclaim scope.

</details>

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9SGZHgAChWsRtbQybizEY)_