### PR TITLE
Replace CircleCI badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://img.shields.io/circleci/build/github/synesenom/ran)](https://app.circleci.com/pipelines/github/synesenom/ran)
+[![CI](https://img.shields.io/github/actions/workflow/status/synesenom/ran/ci.yml?branch=main)](https://github.com/synesenom/ran/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/synesenom/ran/badge.svg?branch=main)](https://coveralls.io/github/synesenom/ran?branch=main)
 [![npm](https://img.shields.io/npm/v/ranjs.svg)](https://www.npmjs.com/package/ranjs)
 [![Inline docs](http://inch-ci.org/github/synesenom/ran.svg?branch=main)](http://inch-ci.org/github/synesenom/ran)


### PR DESCRIPTION
Closes #94

## Summary
- Replaces the defunct CircleCI badge on `README.md:1` with a shields.io GitHub Actions workflow status badge pointing to `.github/workflows/ci.yml` on `main`

## Design decisions

_No design decisions — single-line doc-only substitution._

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`README.md:1`**: CircleCI badge URL replaced with `https://img.shields.io/github/actions/workflow/status/synesenom/ran/ci.yml?branch=main`, linked to `https://github.com/synesenom/ran/actions/workflows/ci.yml`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFFhdhuYfEvafVziDtKSnQ)_