### PR TITLE
Add build job to CI and build badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,17 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
   coverage:
     needs: test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI now runs `npm run build` on every push to `main` and every pull request; a build badge scoped to the `build` job was added to `README.md`.
 - Replaced hand-rolled SVG pixel math in `.github/scripts/gen-badge.js` with `badge-maker`; removed legacy `.circleci/config.yml`.
 - Upgraded `rollup` from `^2.64.0` to `^4.x`. Replaced unmaintained `rollup-plugin-terser` with `@rollup/plugin-terser`. Upgraded `@rollup/plugin-node-resolve` from `^13.x` to `^16.x`.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/synesenom/ran/ci.yml?branch=main)](https://github.com/synesenom/ran/actions/workflows/ci.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/synesenom/ran/ci.yml?branch=main&job=build&label=build)](https://github.com/synesenom/ran/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/synesenom/ran/badge.svg?branch=main)](https://coveralls.io/github/synesenom/ran?branch=main)
 [![npm](https://img.shields.io/npm/v/ranjs.svg)](https://www.npmjs.com/package/ranjs)
 [![Inline docs](http://inch-ci.org/github/synesenom/ran.svg?branch=main)](http://inch-ci.org/github/synesenom/ran)


### PR DESCRIPTION
Closes #159

## Summary
- Adds a `build` job to `.github/workflows/ci.yml` that runs `npm ci && npm run build` on every push to `main` and every pull request, so a broken rollup build fails CI instead of being discovered at release time.
- Adds a shields.io build badge to `README.md` scoped to the new `build` job.
- Records the change under `## [Unreleased] → Changed` in `CHANGELOG.md`.

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical (CI config + badge + changelog). No source files or tests touched._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`.github/workflows/ci.yml`**: new `build` job parallel to existing `lint` and `test` jobs; same Node 20 + npm-cache setup.
- **`README.md`**: extra badge line right after the existing CI badge, with `label=build` for visual distinction.
- **`CHANGELOG.md`**: one bullet under `[Unreleased] → Changed`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vmn3HmTDLTBtjWumgBiQvc)_