### PR TITLE
Add refVals fixture format and test runner

### DIFF
--- a/test/dist.js
+++ b/test/dist.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { ksTest, chiTest, Tests } from './test-utils'
+import { ksTest, chiTest, Tests, checkRefVals } from './test-utils'
 import { float } from '../src/core'
 import * as dist from '../src/dist'
 import PreComputed from '../src/dist/_pre-computed'
@@ -127,6 +127,13 @@ const UnitTests = {
         })
       })
     })
+
+    if (tc.refVals) {
+      it('pdf and cdf should match reference values', () => {
+        const generator = new dist[tc.name](...tc.cases[0].params())
+        checkRefVals(generator, tc.refVals)
+      })
+    }
   },
 
   sample (tc) {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -195,6 +195,21 @@ export function repeat (test, times = 10) {
   }
 }
 
+export function checkRefVals (dist, refVals) {
+  for (const { x, pdf, pmf, cdf } of refVals) {
+    if (pdf !== undefined) {
+      const actual = dist.pdf(x)
+      assert(Math.abs(actual - pdf) < PRECISION, `pdf(${x}) = ${actual}, expected ${pdf}`)
+    }
+    if (pmf !== undefined) {
+      const actual = dist.pdf(x)
+      assert(Math.abs(actual - pmf) < PRECISION, `pmf(${x}) = ${actual}, expected ${pmf}`)
+    }
+    const actualCdf = dist.cdf(x)
+    assert(Math.abs(actualCdf - cdf) < PRECISION, `cdf(${x}) = ${actualCdf}, expected ${cdf}`)
+  }
+}
+
 export const Tests = {
   pdfRange (dist) {
     // Run through x values and assert PDF(x) >= 0.


### PR DESCRIPTION
Closes #131

## Summary
- Adds `checkRefVals(dist, refVals)` to `test/test-utils.js` — iterates an array of `{ x, pdf/pmf, cdf }` triples and asserts each value matches `dist.pdf(x)` / `dist.cdf(x)` within 1e-9
- Wires the check into `test/dist.js`: if a test-case entry has a `refVals` field, a new `it` block runs automatically against `tc.cases[0].params()`
- Infrastructure only — no reference values added yet; follow-up issues #125–#134 will populate `dist-cases.js`

## Non-trivial changes
- **`test/test-utils.js:198-211`**: New exported `checkRefVals` function. Accepts both `pdf` and `pmf` field names in fixtures (semantically distinguishing continuous from discrete, while both call `dist.pdf(x)` — the Distribution base class routes PMF through `.pdf()`). Tolerance is 1e-9 absolute, matching the `PRECISION` constant already used throughout `test-utils.js`.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js:3`**: `checkRefVals` added to import
- **`test/dist.js:131-136`**: Conditional `it` block wired into `UnitTests.pdf` — runs only when `tc.refVals` is defined

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01484QrFFKkkbSmAKobfy4st)_