### PR TITLE
Add TypeScript type declarations for all public API (#108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run check-decl
       - run: npm run typecheck
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
   build:
-    needs: [lint, test]
+    needs: [lint, test, typecheck]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 /.nyc_output
 /coverage
 /.circleci/
-/dist/
+/dist/*.js
+/dist/*.map
 /docs/styles/style.css
 
 # Idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- TypeScript type declarations added (`dist/ranjs.d.ts`). All 135 distribution classes, the `Distribution` base class (17 public methods), and the `core`, `location`, `dispersion`, `shape`, `dependence`, and `test` namespaces are now fully typed. `"types": "./dist/ranjs.d.ts"` added to `package.json` at the top level and inside `"exports"` for full compatibility with all TypeScript `moduleResolution` modes. See [ADR-0003](decisions/0003-typescript-declarations.md).
 - Build now produces three artifacts: `dist/ranjs.esm.js` (ES module), `dist/ranjs.cjs.js` (CommonJS), and `dist/ranjs.min.js` (UMD, minified, CDN). `"exports"` field added to `package.json` routing `import` to ESM and `require` to CJS. `"sideEffects": false` added to enable tree-shaking across the 130+ distribution classes.
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@ npm run build
 
 # Generate docs
 npm run docs
+
+# Validate TypeScript declarations
+npm run typecheck
 ```
 
 ## Architecture
@@ -102,6 +105,17 @@ When a change touches many files (new base class method, convention rename acros
 - When adding, removing, or modifying files in `.claude/skills/` or `.claude/agents/`, update `.claude/README.md` to reflect the change.
 - Keep `README.md` up to date whenever changes warrant it (new distributions, changed API, new modules).
 - JSDoc-style comments on the `Distribution` base class and major public methods follow the existing format in `src/dist/_distribution.js` (class/method tags, `@param`, `@returns`, `@memberof`).
+
+## TypeScript Declarations
+
+`dist/ranjs.d.ts` is a **hand-written** ambient module declaration (not generated). It is exempted from the `/dist/` gitignore rule via `!dist/ranjs.d.ts`.
+
+**Maintenance rules:**
+- When adding a new distribution class, add a corresponding `class <Name> extends Distribution { constructor(...) }` line to `dist/ranjs.d.ts` in alphabetical order.
+- When adding a new public method to the `Distribution` base class, add the matching signature to the `class Distribution { ... }` block.
+- When adding a function to a statistical namespace (`core`, `location`, `dispersion`, `shape`, `dependence`, `test`), add its typed signature in the matching `export namespace` block.
+- Run `npm run typecheck` after every edit to `dist/ranjs.d.ts` to confirm the file compiles correctly.
+- `tsconfig.json` is for typecheck only (`"noEmit": true`) and resolves `ranjs` imports via `paths` pointing at `dist/ranjs.d.ts`.
 
 ## Communication Style
 

--- a/decisions/0003-typescript-declarations.md
+++ b/decisions/0003-typescript-declarations.md
@@ -1,0 +1,37 @@
+# ADR-0003: TypeScript Type Declarations Strategy
+
+**Date**: 2026-05-16
+**Status**: Accepted
+
+## Context
+
+ranjs has no `.d.ts` file. TypeScript consumers get no autocomplete, no parameter checking, and no return-type inference — a hard adoption blocker for any TypeScript project. The fix is a hand-written declaration file rather than migrating the source to TypeScript, which would be a separate, major undertaking.
+
+Three decisions needed resolving:
+
+1. **Where to place `"types"` in `package.json`**: The package already has an `"exports"` field (ADR-0001). TypeScript 4.7+ with `moduleResolution: "node16"`, `"nodenext"`, or `"bundler"` ignores the top-level `"types"` field entirely when `"exports"` is present — it reads only from `"exports"`. A top-level `"types"` entry alone is silently broken for all modern TypeScript consumers.
+
+2. **How to type `Distribution.sample(n?)`**: The runtime returns a single `number` when `n < 2` and `number[]` when `n >= 2`. A generic conditional type (`N extends 0 | 1 ? number : number[]`) has a correctness bug: when `n` is a non-literal `number`, the conditional resolves to `number[]` only, which is false for `n = 0` or `n = 1`.
+
+3. **TypeScript as devDependency**: The acceptance criteria require `tsc --noEmit` to pass, which needs `typescript` installed.
+
+## Decision
+
+1. **`"types"` in both locations**: Add `"types": "./dist/ranjs.d.ts"` at the top level of `package.json` (for legacy `moduleResolution: "node"` consumers) AND as the **first** condition inside `"exports"."."`  (for `"node16"`, `"nodenext"`, and `"bundler"` consumers). The `"types"` entry must be first in the exports object because Node.js and TypeScript match conditions in declaration order.
+
+2. **Three-overload pattern for `sample()`**:
+   ```typescript
+   sample(): number;
+   sample(n: 1): number;
+   sample(n: number): number | number[];
+   ```
+   This gives correct narrow types for the dominant use case (no-arg → `number`) and the literal-1 case, and degrades correctly to `number | number[]` for dynamic arguments. The same overload pattern applies to `core.float()`, `core.int()`, and similar dual-return functions.
+
+3. **`typescript` as devDependency only**: `typescript` is listed under `devDependencies` in `package.json`. It is not needed at runtime and is not in `dependencies`. A minimal `tsconfig.json` for `tsc --noEmit` validation is committed to the repository root.
+
+## Consequences
+
+- All TypeScript consumers — regardless of `moduleResolution` setting or TypeScript version — receive working autocomplete and type checking for ranjs.
+- `tsc --noEmit` becomes part of the validation story (can be wired into CI later).
+- The `.d.ts` file is hand-maintained and must be updated whenever the public API changes. It is not generated from source.
+- `dist/ranjs.d.ts` is tracked in git alongside the built JS artifacts.

--- a/dist/ranjs.d.ts
+++ b/dist/ranjs.d.ts
@@ -198,7 +198,8 @@ declare module 'ranjs' {
     function char(string: string): string | undefined
     function char(string: string, n: number): string | string[] | undefined
     function shuffle<T>(values: T[]): T[]
-    function coin<H, T>(head: H, tail: T, p?: number, n?: number): H | T | Array<H | T>
+    function coin<H, T>(head: H, tail: T, p?: number): H | T
+    function coin<H, T>(head: H, tail: T, p: number, n: number): H | T | Array<H | T>
   }
 
   // ---- ran.location ---------------------------------------------------

--- a/dist/ranjs.d.ts
+++ b/dist/ranjs.d.ts
@@ -1,0 +1,276 @@
+declare module 'ranjs' {
+  // ---- ran.dist -------------------------------------------------------
+
+  export namespace dist {
+    type DistributionType = 'continuous' | 'discrete'
+
+    interface SupportBound {
+      value: number
+      closed: boolean
+    }
+
+    interface DistributionState {
+      prngState: unknown
+      params: Record<string, unknown>
+      constants: unknown[]
+      support: SupportBound[]
+    }
+
+    interface TestResult {
+      statistics: number
+      passed: boolean
+    }
+
+    class Distribution {
+      type(): DistributionType
+      support(): SupportBound[]
+      seed(value: number | string): this
+      save(): DistributionState
+      load(state: DistributionState): this
+      sample(): number
+      sample(n: 1): number
+      sample(n: number): number | number[]
+      pdf(x: number): number
+      cdf(x: number): number
+      q(p: number): number | undefined
+      survival(x: number): number
+      hazard(x: number): number
+      cHazard(x: number): number
+      lnPdf(x: number): number
+      lnL(data: number[]): number
+      aic(data: number[]): number
+      bic(data: number[]): number
+      test(values: number[]): TestResult
+    }
+
+    // Distribution classes — alphabetical
+
+    class Alpha extends Distribution { constructor(alpha?: number, beta?: number) }
+    class Anglit extends Distribution { constructor() }
+    class Arcsine extends Distribution { constructor(a?: number, b?: number) }
+    class BaldingNichols extends Distribution { constructor(F?: number, p?: number) }
+    class Bates extends Distribution { constructor(n?: number, a?: number, b?: number) }
+    class Benini extends Distribution { constructor(alpha?: number, beta?: number, sigma?: number) }
+    class BenktanderII extends Distribution { constructor(a?: number, b?: number) }
+    class Bernoulli extends Distribution { constructor(p?: number) }
+    class Beta extends Distribution { constructor(alpha?: number, beta?: number) }
+    class BetaBinomial extends Distribution { constructor(n?: number, alpha?: number, beta?: number) }
+    class BetaPrime extends Distribution { constructor(alpha?: number, beta?: number) }
+    class BetaRectangular extends Distribution { constructor(alpha?: number, beta?: number, theta?: number, a?: number, b?: number) }
+    class Binomial extends Distribution { constructor(n?: number, p?: number) }
+    class BirnbaumSaunders extends Distribution { constructor(mu?: number, beta?: number, gamma?: number) }
+    class Borel extends Distribution { constructor(mu?: number) }
+    class BorelTanner extends Distribution { constructor(mu?: number, n?: number) }
+    class BoundedPareto extends Distribution { constructor(L?: number, H?: number, alpha?: number) }
+    class Bradford extends Distribution { constructor(c?: number) }
+    class Burr extends Distribution { constructor(c?: number, k?: number) }
+    class Categorical extends Distribution { constructor(weights?: number[], min?: number) }
+    class Cauchy extends Distribution { constructor(x0?: number, gamma?: number) }
+    class Chi extends Distribution { constructor(k?: number) }
+    class Chi2 extends Distribution { constructor(k?: number) }
+    class Dagum extends Distribution { constructor(p?: number, a?: number, b?: number) }
+    class Degenerate extends Distribution { constructor(x0?: number) }
+    class Delaporte extends Distribution { constructor(alpha?: number, beta?: number, lambda?: number) }
+    class DiscreteUniform extends Distribution { constructor(xmin?: number, xmax?: number) }
+    class DiscreteWeibull extends Distribution { constructor(q?: number, beta?: number) }
+    class DoubleGamma extends Distribution { constructor(alpha?: number, beta?: number) }
+    class DoubleWeibull extends Distribution { constructor(lambda?: number, k?: number) }
+    class DoublyNoncentralBeta extends Distribution { constructor(alpha?: number, beta?: number, lambda1?: number, lambda2?: number) }
+    class DoublyNoncentralF extends Distribution { constructor(d1?: number, d2?: number, lambda1?: number, lambda2?: number) }
+    class DoublyNoncentralT extends Distribution { constructor(nu?: number, mu?: number, theta?: number) }
+    class Erlang extends Distribution { constructor(k?: number, lambda?: number) }
+    class Exponential extends Distribution { constructor(lambda?: number) }
+    class ExponentialLogarithmic extends Distribution { constructor(p?: number, beta?: number) }
+    class ExponentiatedWeibull extends Distribution { constructor(lambda?: number, k?: number, alpha?: number) }
+    class F extends Distribution { constructor(d1?: number, d2?: number) }
+    class FisherZ extends Distribution { constructor(d1?: number, d2?: number) }
+    class FlorySchulz extends Distribution { constructor(a?: number) }
+    class Frechet extends Distribution { constructor(alpha?: number, s?: number, m?: number) }
+    class Gamma extends Distribution { constructor(alpha?: number, beta?: number) }
+    class GammaGompertz extends Distribution { constructor(b?: number, s?: number, beta?: number) }
+    class GeneralizedExponential extends Distribution { constructor(a?: number, b?: number, c?: number) }
+    class GeneralizedExtremeValue extends Distribution { constructor(c?: number) }
+    class GeneralizedGamma extends Distribution { constructor(a?: number, d?: number, p?: number) }
+    class GeneralizedHermite extends Distribution { constructor(a1?: number, a2?: number, m?: number) }
+    class GeneralizedLogistic extends Distribution { constructor(mu?: number, s?: number, c?: number) }
+    class GeneralizedNormal extends Distribution { constructor(mu?: number, alpha?: number, beta?: number) }
+    class GeneralizedPareto extends Distribution { constructor(mu?: number, sigma?: number, xi?: number) }
+    class Geometric extends Distribution { constructor(p?: number) }
+    class Gilbrat extends Distribution { constructor() }
+    class Gompertz extends Distribution { constructor(eta?: number, b?: number) }
+    class Gumbel extends Distribution { constructor(mu?: number, beta?: number) }
+    class HalfGeneralizedNormal extends Distribution { constructor(alpha?: number, beta?: number) }
+    class HalfLogistic extends Distribution { constructor() }
+    class HalfNormal extends Distribution { constructor(sigma?: number) }
+    class HeadsMinusTails extends Distribution { constructor(n?: number) }
+    class Hoyt extends Distribution { constructor(q?: number, omega?: number) }
+    class HyperbolicSecant extends Distribution { constructor() }
+    class Hyperexponential extends Distribution { constructor(parameters?: Array<{ weight: number; rate: number }>) }
+    class Hypergeometric extends Distribution { constructor(N?: number, K?: number, n?: number) }
+    class InvalidDiscrete extends Distribution { constructor() }
+    class InverseChi2 extends Distribution { constructor(nu?: number) }
+    class InverseGamma extends Distribution { constructor(alpha?: number, beta?: number) }
+    class InverseGaussian extends Distribution { constructor(mu?: number, lambda?: number) }
+    class InvertedWeibull extends Distribution { constructor(c?: number) }
+    class IrwinHall extends Distribution { constructor(n?: number) }
+    class JohnsonSB extends Distribution { constructor(gamma?: number, delta?: number, lambda?: number, xi?: number) }
+    class JohnsonSU extends Distribution { constructor(gamma?: number, delta?: number, lambda?: number, xi?: number) }
+    class Kolmogorov extends Distribution { constructor() }
+    class Kumaraswamy extends Distribution { constructor(a?: number, b?: number) }
+    class Laplace extends Distribution { constructor(mu?: number, b?: number) }
+    class Levy extends Distribution { constructor(mu?: number, c?: number) }
+    class Lindley extends Distribution { constructor(theta?: number) }
+    class Logarithmic extends Distribution { constructor(a?: number, b?: number) }
+    class LogCauchy extends Distribution { constructor(mu?: number, sigma?: number) }
+    class LogGamma extends Distribution { constructor(alpha?: number, beta?: number, mu?: number) }
+    class Logistic extends Distribution { constructor(mu?: number, s?: number) }
+    class LogisticExponential extends Distribution { constructor(lambda?: number, kappa?: number) }
+    class LogitNormal extends Distribution { constructor(mu?: number, sigma?: number) }
+    class LogLaplace extends Distribution { constructor(mu?: number, b?: number) }
+    class LogLogistic extends Distribution { constructor(alpha?: number, beta?: number) }
+    class LogNormal extends Distribution { constructor(mu?: number, sigma?: number) }
+    class LogSeries extends Distribution { constructor(p?: number) }
+    class Lomax extends Distribution { constructor(lambda?: number, alpha?: number) }
+    class Makeham extends Distribution { constructor(alpha?: number, beta?: number, lambda?: number) }
+    class MaxwellBoltzmann extends Distribution { constructor(a?: number) }
+    class Mielke extends Distribution { constructor(k?: number, s?: number) }
+    class Moyal extends Distribution { constructor(mu?: number, sigma?: number) }
+    class Muth extends Distribution { constructor(alpha?: number) }
+    class Nakagami extends Distribution { constructor(m?: number, omega?: number) }
+    class NegativeBinomial extends Distribution { constructor(r?: number, p?: number) }
+    class NegativeHypergeometric extends Distribution { constructor(N?: number, K?: number, r?: number) }
+    class NeymanA extends Distribution { constructor(lambda?: number, phi?: number) }
+    class NoncentralBeta extends Distribution { constructor(alpha?: number, beta?: number, lambda?: number) }
+    class NoncentralChi extends Distribution { constructor(k?: number, lambda?: number) }
+    class NoncentralChi2 extends Distribution { constructor(k?: number, lambda?: number) }
+    class NoncentralF extends Distribution { constructor(d1?: number, d2?: number, lambda?: number) }
+    class NoncentralT extends Distribution { constructor(nu?: number, mu?: number) }
+    class Normal extends Distribution { constructor(mu?: number, sigma?: number) }
+    class Pareto extends Distribution { constructor(xmin?: number, alpha?: number) }
+    class PERT extends Distribution { constructor(a?: number, b?: number, c?: number) }
+    class Poisson extends Distribution { constructor(lambda?: number) }
+    class PolyaAeppli extends Distribution { constructor(lambda?: number, theta?: number) }
+    class PowerLaw extends Distribution { constructor(a?: number) }
+    class QExponential extends Distribution { constructor(q?: number, lambda?: number) }
+    class R extends Distribution { constructor(c?: number) }
+    class Rademacher extends Distribution { constructor() }
+    class RaisedCosine extends Distribution { constructor(mu?: number, s?: number) }
+    class Rayleigh extends Distribution { constructor(sigma?: number) }
+    class Reciprocal extends Distribution { constructor(a?: number, b?: number) }
+    class ReciprocalInverseGaussian extends Distribution { constructor(mu?: number, lambda?: number) }
+    class Rice extends Distribution { constructor(nu?: number, sigma?: number) }
+    class ShiftedLogLogistic extends Distribution { constructor(mu?: number, sigma?: number, xi?: number) }
+    class Skellam extends Distribution { constructor(mu1?: number, mu2?: number) }
+    class SkewNormal extends Distribution { constructor(xi?: number, omega?: number, alpha?: number) }
+    class Slash extends Distribution { constructor() }
+    class Soliton extends Distribution { constructor(N?: number) }
+    class StudentT extends Distribution { constructor(nu?: number) }
+    class StudentZ extends Distribution { constructor(n?: number) }
+    class Trapezoidal extends Distribution { constructor(a?: number, b?: number, c?: number, d?: number) }
+    class Triangular extends Distribution { constructor(a?: number, b?: number, c?: number) }
+    class TruncatedNormal extends Distribution { constructor(mu?: number, sigma?: number, a?: number, b?: number) }
+    class TukeyLambda extends Distribution { constructor(lambda?: number) }
+    class Uniform extends Distribution { constructor(xmin?: number, xmax?: number) }
+    class UniformProduct extends Distribution { constructor(n?: number) }
+    class UniformRatio extends Distribution { constructor() }
+    class UQuadratic extends Distribution { constructor(a?: number, b?: number) }
+    class VonMises extends Distribution { constructor(kappa?: number) }
+    class Weibull extends Distribution { constructor(lambda?: number, k?: number) }
+    class Wigner extends Distribution { constructor(R?: number) }
+    class YuleSimon extends Distribution { constructor(rho?: number) }
+    class Zeta extends Distribution { constructor(s?: number) }
+    class Zipf extends Distribution { constructor(s?: number, N?: number) }
+  }
+
+  // ---- ran.core -------------------------------------------------------
+
+  export namespace core {
+    function seed(value: number | string): void
+    function float(): number
+    function float(min: number): number
+    function float(min: number, max: number): number
+    function float(min: number, max: number, n: number): number | number[]
+    function int(min: number): number
+    function int(min: number, max: number): number
+    function int(min: number, max: number, n: number): number | number[]
+    function choice<T>(values: T[]): T | undefined
+    function choice<T>(values: T[], n: number): T | T[] | undefined
+    function char(string: string): string | undefined
+    function char(string: string, n: number): string | string[] | undefined
+    function shuffle<T>(values: T[]): T[]
+    function coin<H, T>(head: H, tail: T, p?: number, n?: number): H | T | Array<H | T>
+  }
+
+  // ---- ran.location ---------------------------------------------------
+
+  export namespace location {
+    function geometricMean(values: number[]): number | undefined
+    function harmonicMean(values: number[]): number | undefined
+    function mean(values: number[]): number | undefined
+    function median(values: number[]): number | undefined
+    function midrange(values: number[]): number | undefined
+    function mode(values: number[]): number | undefined
+    function trimean(values: number[]): number | undefined
+  }
+
+  // ---- ran.dispersion -------------------------------------------------
+
+  export namespace dispersion {
+    function cv(values: number[]): number | undefined
+    function dVar(x: number[]): number | undefined
+    function entropy(probabilities: number[], base?: number): number | undefined
+    function gini(values: number[]): number | undefined
+    function iqr(values: number[]): number | undefined
+    function md(values: number[]): number | undefined
+    function midhinge(values: number[]): number | undefined
+    function range(values: number[]): number | undefined
+    function rmd(values: number[]): number | undefined
+    function stdev(values: number[]): number | undefined
+    function qcd(values: number[]): number | undefined
+    function variance(values: number[]): number | undefined
+    function vmr(values: number[]): number | undefined
+  }
+
+  // ---- ran.shape ------------------------------------------------------
+
+  export namespace shape {
+    function kurtosis(values: number[]): number | undefined
+    function moment(values: number[], k: number, c?: number): number | undefined
+    function quantile(values: number[], p: number): number | undefined
+    function rank(values: number[]): number[] | undefined
+    function skewness(values: number[]): number | undefined
+    function yule(values: number[]): number | undefined
+  }
+
+  // ---- ran.dependence -------------------------------------------------
+
+  export namespace dependence {
+    function covariance(x: number[], y: number[]): number | undefined
+    function dCov(x: number[], y: number[]): number | undefined
+    function dCor(x: number[], y: number[]): number | undefined
+    function kendall(x: number[], y: number[]): number | undefined
+    function kullbackLeibler(p: number[], q: number[]): number | undefined
+    function oddsRatio(p00: number, p01: number, p10: number, p11: number): number | undefined
+    function pearson(x: number[], y: number[]): number | undefined
+    function pointBiserial(x: number[], y: number[]): number | undefined
+    function somersD(x: number[], y: number[]): number | undefined
+    function spearman(x: number[], y: number[]): number | undefined
+    function yuleQ(p00: number, p01: number, p10: number, p11: number): number | undefined
+    function yuleY(p00: number, p01: number, p10: number, p11: number): number | undefined
+  }
+
+  // ---- ran.test -------------------------------------------------------
+
+  interface StatTestResult {
+    stat: number
+    passed: boolean
+  }
+
+  export namespace test {
+    function bartlett(dataSets: number[][], alpha?: number): StatTestResult
+    function brownForsythe(dataSets: number[][], alpha?: number): StatTestResult
+    function hsic(dataSets: number[][], alpha?: number): StatTestResult
+    function levene(dataSets: number[][], alpha?: number): StatTestResult
+    function mannWhitney(dataSets: number[][], alpha?: number): StatTestResult
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "rollup": "^4.60.4",
         "sass": "^1.77.8",
         "seedrandom": "^3.0.5",
-        "standard": "^16.0.4"
+        "standard": "^16.0.4",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -13872,6 +13873,20 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "docs": "node ./docs/index.js",
     "build": "./node_modules/.bin/rollup -c",
     "typecheck": "./node_modules/.bin/tsc --noEmit",
+    "check-decl": "node scripts/check-declarations.js",
     "prepublishOnly": "npm run build",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=html _mocha --require @babel/register"
   },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   "license": "MIT",
   "main": "./dist/ranjs.min.js",
   "module": "./dist/ranjs.esm.js",
+  "types": "./dist/ranjs.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/ranjs.d.ts",
       "import": "./dist/ranjs.esm.js",
       "require": "./dist/ranjs.cjs.js",
       "default": "./dist/ranjs.min.js"
@@ -41,6 +43,7 @@
     "test": "./node_modules/.bin/_mocha --require @babel/register",
     "docs": "node ./docs/index.js",
     "build": "./node_modules/.bin/rollup -c",
+    "typecheck": "./node_modules/.bin/tsc --noEmit",
     "prepublishOnly": "npm run build",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=html _mocha --require @babel/register"
   },
@@ -69,7 +72,8 @@
     "rollup": "^4.60.4",
     "sass": "^1.77.8",
     "seedrandom": "^3.0.5",
-    "standard": "^16.0.4"
+    "standard": "^16.0.4",
+    "typescript": "^6.0.3"
   },
   "babel": {
     "presets": [

--- a/scripts/check-declarations.js
+++ b/scripts/check-declarations.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Verifies dist/ranjs.d.ts declares every export from ranjs source.
+ *
+ * Catches:
+ *   - New distributions added to src/dist/index.js but missing from .d.ts
+ *   - Functions added to a namespace index but missing from the .d.ts namespace block
+ *   - Classes declared in .d.ts that no longer exist in source (stale)
+ *
+ * Does NOT catch: behavioral drift (wrong parameter or return types). That
+ * requires either JSDoc-driven tsc --declaration or a TypeScript source migration.
+ */
+
+const fs = require('fs')
+
+let exitCode = 0
+
+function fail (msg) {
+  console.error(`  MISSING: ${msg}`)
+  exitCode = 1
+}
+
+const dts = fs.readFileSync('dist/ranjs.d.ts', 'utf8')
+
+// Returns the full text of `export namespace <ns> { ... }` using bracket counting.
+function extractNamespaceBlock (ns) {
+  const marker = `export namespace ${ns} {`
+  const start = dts.indexOf(marker)
+  if (start === -1) return null
+  let depth = 0
+  for (let pos = start; pos < dts.length; pos++) {
+    if (dts[pos] === '{') depth++
+    else if (dts[pos] === '}') {
+      depth--
+      if (depth === 0) return dts.slice(start, pos + 1)
+    }
+  }
+  return null
+}
+
+// ---- 1. Distribution classes ------------------------------------------------
+
+console.log('Checking dist classes...')
+
+const distSrc = fs.readFileSync('src/dist/index.js', 'utf8')
+const srcClasses = new Set(
+  [...distSrc.matchAll(/^export\s*\{\s*default\s+as\s+(\w+)\s*\}/gm)]
+    .map(m => m[1])
+)
+
+const dtsClasses = new Set(
+  [...dts.matchAll(/\bclass\s+(\w+)\s+extends\s+Distribution\b/g)]
+    .map(m => m[1])
+)
+
+for (const name of srcClasses) {
+  if (!dtsClasses.has(name)) fail(`dist.${name} — exported from source but missing from .d.ts`)
+}
+for (const name of dtsClasses) {
+  if (!srcClasses.has(name)) fail(`dist.${name} — declared in .d.ts but not exported from source`)
+}
+if (srcClasses.size === dtsClasses.size && exitCode === 0) {
+  console.log(`  OK: ${srcClasses.size} distribution classes`)
+}
+
+// ---- 2. core namespace (named exports, not re-exports) ----------------------
+
+console.log('Checking core namespace...')
+
+const coreSrc = fs.readFileSync('src/core/index.js', 'utf8')
+const coreNames = new Set([
+  ...[...coreSrc.matchAll(/^export\s+(?:const|function)\s+(\w+)/gm)].map(m => m[1])
+])
+
+const coreBlock = extractNamespaceBlock('core')
+if (!coreBlock) {
+  fail('export namespace core is missing from dist/ranjs.d.ts')
+} else {
+  const dtsCoreNames = new Set(
+    [...coreBlock.matchAll(/\bfunction\s+(\w+)/g)].map(m => m[1])
+  )
+  for (const name of coreNames) {
+    if (!dtsCoreNames.has(name)) fail(`core.${name} — in source but missing from .d.ts`)
+  }
+  if (exitCode === 0) console.log(`  OK: ${coreNames.size} core exports`)
+}
+
+// ---- 3. Statistical namespaces (re-export style) ----------------------------
+
+const namespaceSources = {
+  location: 'src/location/index.js',
+  dispersion: 'src/dispersion/index.js',
+  shape: 'src/shape/index.js',
+  dependence: 'src/dependence/index.js',
+  test: 'src/test/index.js'
+}
+
+for (const [ns, srcFile] of Object.entries(namespaceSources)) {
+  console.log(`Checking ${ns} namespace...`)
+  const srcContent = fs.readFileSync(srcFile, 'utf8')
+
+  // Handles both: `export { default as name }` and `export { name }`
+  const srcNames = new Set(
+    [...srcContent.matchAll(/^export\s*\{[^}]*\}/gm)]
+      .flatMap(m => [...m[0].matchAll(/(?:default\s+as\s+|(?<![a-z]\s))(\b\w+\b)(?=\s*[,}])/g)])
+      .map(m => m[1])
+      .filter(name => name !== 'default')
+  )
+
+  const block = extractNamespaceBlock(ns)
+  if (!block) {
+    fail(`export namespace ${ns} is missing from dist/ranjs.d.ts`)
+    continue
+  }
+
+  const dtsFunctions = new Set(
+    [...block.matchAll(/\bfunction\s+(\w+)/g)].map(m => m[1])
+  )
+
+  for (const name of srcNames) {
+    if (!dtsFunctions.has(name)) fail(`${ns}.${name} — in source but missing from .d.ts`)
+  }
+  if (exitCode === 0) console.log(`  OK: ${srcNames.size} ${ns} exports`)
+}
+
+process.exit(exitCode)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "module": "commonjs",
+    "target": "ES2017",
+    "baseUrl": ".",
+    "paths": {
+      "ranjs": ["./dist/ranjs.d.ts"]
+    },
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["types-test.ts"]
+}

--- a/types-test.ts
+++ b/types-test.ts
@@ -1,0 +1,91 @@
+import * as ran from 'ranjs'
+
+// Distribution instantiation
+const n = new ran.dist.Normal(0, 1)
+const _p = new ran.dist.Pareto(1, 2)
+const _cat = new ran.dist.Categorical([1, 2, 3])
+const _cat2 = new ran.dist.Categorical([1, 2, 3], 0)
+const _hyp = new ran.dist.Hyperexponential([{ weight: 1, rate: 2 }])
+
+// Base class methods
+const s1: number = n.sample()
+const s2: number | number[] = n.sample(5)
+const _s3: number = n.sample(1)
+const _pdf: number = n.pdf(0)
+const _cdf: number = n.cdf(0)
+const _q: number | undefined = n.q(0.5)
+const _surv: number = n.survival(0)
+const _haz: number = n.hazard(0)
+const _ch: number = n.cHazard(0)
+const _lp: number = n.lnPdf(0)
+const _ll: number = n.lnL([1, 2, 3])
+const _aic: number = n.aic([1, 2, 3])
+const _bic: number = n.bic([1, 2, 3])
+const t = n.test([1, 2, 3])
+const _tstat: number = t.statistics
+const _tpass: boolean = t.passed
+const _tp: 'continuous' | 'discrete' = n.type()
+const sp = n.support()
+const _sv: number = sp[0].value
+const _sc: boolean = sp[0].closed
+const state = n.save()
+n.load(state)
+n.seed(42)
+n.seed('test')
+
+// core namespace — all overloads
+ran.core.seed(42)
+const f1: number = ran.core.float()
+const f2: number = ran.core.float(2)
+const _f3: number = ran.core.float(0, 1)
+const _f4: number | number[] = ran.core.float(0, 1, 5)
+const _i1: number = ran.core.int(10)
+const _i2: number = ran.core.int(1, 10)
+const _i3: number | number[] = ran.core.int(1, 10, 5)
+const _choice1 = ran.core.choice([1, 2, 3])
+const _choice2 = ran.core.choice([1, 2, 3], 2)
+const _ch2 = ran.core.char('abc')
+const _ch3 = ran.core.char('abc', 3)
+const _shuffled = ran.core.shuffle([1, 2, 3])
+const _coin: string | Array<string> = ran.core.coin('H', 'T', 0.5, 3)
+
+// Statistical namespaces — location
+const _mean: number | undefined = ran.location.mean([1, 2, 3])
+const _gm: number | undefined = ran.location.geometricMean([1, 2, 3])
+const _hm: number | undefined = ran.location.harmonicMean([1, 2, 3])
+const _med: number | undefined = ran.location.median([1, 2, 3])
+
+// Statistical namespaces — dispersion
+const _var: number | undefined = ran.dispersion.variance([1, 2, 3])
+const _sd: number | undefined = ran.dispersion.stdev([1, 2, 3])
+const _iqr: number | undefined = ran.dispersion.iqr([1, 2, 3])
+
+// Statistical namespaces — shape
+const _skew: number | undefined = ran.shape.skewness([1, 2, 3])
+const _kurt: number | undefined = ran.shape.kurtosis([1, 2, 3])
+const _q50: number | undefined = ran.shape.quantile([1, 2, 3], 0.5)
+
+// Statistical namespaces — dependence
+const _pear: number | undefined = ran.dependence.pearson([1, 2], [3, 4])
+const _spear: number | undefined = ran.dependence.spearman([1, 2], [3, 4])
+const _kend: number | undefined = ran.dependence.kendall([1, 2], [3, 4])
+const _cov: number | undefined = ran.dependence.covariance([1, 2], [3, 4])
+
+// test namespace — all 5 functions
+const _bart = ran.test.bartlett([[1, 2, 3], [4, 5, 6]])
+const _bstat: number = _bart.stat
+const _bpass: boolean = _bart.passed
+const _bf = ran.test.brownForsythe([[1, 2, 3], [4, 5, 6]])
+const _lev = ran.test.levene([[1, 2, 3], [4, 5, 6]])
+const _mw = ran.test.mannWhitney([[1, 2, 3], [4, 5, 6]])
+const _hsic = ran.test.hsic([[1, 2, 3], [4, 5, 6]])
+
+// Suppress unused variable warnings
+void s1; void s2; void _s3; void f1; void f2; void _p; void _cat; void _cat2; void _hyp
+void _pdf; void _cdf; void _q; void _surv; void _haz; void _ch
+void _lp; void _ll; void _aic; void _bic; void _tstat; void _tpass
+void _tp; void sp; void _sv; void _sc; void state; void _f3; void _f4; void _i1; void _i2; void _i3
+void _choice1; void _choice2; void _ch2; void _ch3; void _shuffled; void _coin; void _mean
+void _gm; void _hm; void _med; void _var; void _sd; void _iqr
+void _skew; void _kurt; void _q50; void _pear; void _spear; void _kend; void _cov
+void _bstat; void _bpass; void _bf; void _lev; void _mw; void _hsic

--- a/types-test.ts
+++ b/types-test.ts
@@ -47,6 +47,8 @@ const _choice2 = ran.core.choice([1, 2, 3], 2)
 const _ch2 = ran.core.char('abc')
 const _ch3 = ran.core.char('abc', 3)
 const _shuffled = ran.core.shuffle([1, 2, 3])
+const _coinSingle: string = ran.core.coin('H', 'T')
+const _coinP: string = ran.core.coin('H', 'T', 0.5)
 const _coin: string | Array<string> = ran.core.coin('H', 'T', 0.5, 3)
 
 // Statistical namespaces — location
@@ -85,7 +87,7 @@ void s1; void s2; void _s3; void f1; void f2; void _p; void _cat; void _cat2; vo
 void _pdf; void _cdf; void _q; void _surv; void _haz; void _ch
 void _lp; void _ll; void _aic; void _bic; void _tstat; void _tpass
 void _tp; void sp; void _sv; void _sc; void state; void _f3; void _f4; void _i1; void _i2; void _i3
-void _choice1; void _choice2; void _ch2; void _ch3; void _shuffled; void _coin; void _mean
+void _choice1; void _choice2; void _ch2; void _ch3; void _shuffled; void _coinSingle; void _coinP; void _coin; void _mean
 void _gm; void _hm; void _med; void _var; void _sd; void _iqr
 void _skew; void _kurt; void _q50; void _pear; void _spear; void _kend; void _cov
 void _bstat; void _bpass; void _bf; void _lev; void _mw; void _hsic

--- a/yarn.lock
+++ b/yarn.lock
@@ -6804,6 +6804,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+
 uglify-js@^3.1.4:
   version "3.10.2"
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.2.tgz"


### PR DESCRIPTION
## Summary

- Adds hand-written ambient module declaration `dist/ranjs.d.ts` covering the `Distribution` base class (17 public methods, correct `sample()` overloads), all 135 active distribution classes with constructor signatures, and 7 module namespaces (`core`, `location`, `dispersion`, `shape`, `dependence`, `test`)
- Adds `"types": "./dist/ranjs.d.ts"` at both the top-level and inside `"exports"."."` in `package.json` for full compatibility across all TypeScript `moduleResolution` modes
- Adds `npm run typecheck` script (`tsc --noEmit`) and `tsconfig.json` for validating the declarations
- Exempts `dist/ranjs.d.ts` from the `/dist/` gitignore by changing it to `/dist/*.js` + `/dist/*.map`
- Adds ADR-0003 documenting the declaration approach and `package.json` placement rationale
- Updates `CLAUDE.md` with `typecheck` command and maintenance rules for keeping `dist/ranjs.d.ts` in sync

## Test plan

- [ ] `npm run typecheck` passes with zero errors
- [ ] `npm test` passes (4069 tests)
- [ ] `npm run standard` passes
- [ ] `dist/ranjs.d.ts` is tracked by git (not ignored)
- [ ] `types-test.ts` exercises all namespaces, all `sample()` overloads, all 5 `test.*` functions, and `Categorical`/`Hyperexponential` special constructors

## ADR

See [decisions/0003-typescript-declarations.md](decisions/0003-typescript-declarations.md)

Closes #108

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWXkWPKEWawxZFUrjsq9Cx)_