### PR TITLE
Expand CI Node.js version matrix to 18, 20, and 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,37 +9,44 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v4
         id: node-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
       - run: npm ci
         if: steps.node-cache.outputs.cache-hit != 'true'
       - run: npm run lint
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v4
         id: node-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
       - run: npm ci
         if: steps.node-cache.outputs.cache-hit != 'true'
       - run: npx cross-env NODE_ENV=test nyc --reporter=lcov ./node_modules/.bin/_mocha --require @babel/register
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
+        if: matrix.node-version == 20
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-error: false


### PR DESCRIPTION
Closes #110

## Summary
- Added `strategy.matrix.node-version: [18, 20, 22]` to the `lint` and `test` jobs so CI validates all active LTS Node releases
- Updated cache keys to include the Node version to prevent cross-version cache collisions
- Gated the Coveralls upload to Node 20 only (`if: matrix.node-version == 20`) to avoid duplicate coverage reports

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`.github/workflows/ci.yml`**: Added matrix strategy to `lint` and `test` jobs; parameterized `setup-node` and cache key; gated Coveralls upload to Node 20

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpmeZCkAine15S5y84H3zb)_