### PR TITLE
Remove Node.js matrix from lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,16 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
       - uses: actions/cache@v4
         id: node-cache
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - run: npm ci
         if: steps.node-cache.outputs.cache-hit != 'true'
       - run: npm run lint


### PR DESCRIPTION
## Summary
- Removes the Node.js version matrix from the `lint` job, pinning it back to Node 20
- Standard.js is a static analyzer — it produces identical results on all Node versions, so running it three times adds CI time with no signal
- The matrix stays on `test` where Node version differences actually matter (V8 behavior, built-in APIs)

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`.github/workflows/ci.yml`**: Removed `strategy.matrix` block from `lint` job; restored `node-version: 20` and original cache key

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpmeZCkAine15S5y84H3zb)_