### PR TITLE
Add docs-build job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,28 @@ jobs:
       - run: npm run check-decl
       - run: npm run typecheck
 
+  docs-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/cache@v4
+        id: node-cache
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - run: npm ci
+        if: steps.node-cache.outputs.cache-hit != 'true'
+      - run: npm run docs
+      - run: test -f docs/index.html && test -f docs/styles/style.css
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: docs/
+
   build:
     needs: [lint, test, typecheck]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #166

## Summary
- Adds a `docs-build` job to `.github/workflows/ci.yml` that runs `npm run docs` on every PR and push to `main`
- Asserts that `docs/index.html` and `docs/styles/style.css` exist after the build, so a broken docs pipeline fails CI rather than going undetected
- Uploads the rendered `docs/` folder as a workflow artifact so reviewers can inspect the output from any PR run

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`.github/workflows/ci.yml`**: New `docs-build` job added alongside existing `lint`/`test`/`typecheck`/`build` jobs. Runs on Node 20 with the same cache/npm-ci pattern. 5-minute timeout guards against the known `mjpage` callback-hang failure mode.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXcozxPEHV6HMdzLmKib2X)_