### PR TITLE
Add automated npm publish workflow on git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+# Requires an NPM_TOKEN secret in GitHub repository settings (Settings > Secrets)
+# with npm publish permission. Tag protection rules should restrict v* tag
+# creation to maintainers only (Settings > Rules > Tag protection).
+on:
+  push:
+    tags: ['v*']
+
+# id-token: write is required for npm provenance attestation generation.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - uses: actions/cache@v4
+        id: node-cache
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - run: npm ci
+        if: steps.node-cache.outputs.cache-hit != 'true'
+      - run: npm run lint
+      - run: npm run check-decl && npm run typecheck
+      - run: npx cross-env NODE_ENV=test ./node_modules/.bin/_mocha --require @babel/register
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Automated npm publish workflow (`.github/workflows/release.yml`): pushing a `v*` tag now runs lint, typecheck, and tests before publishing to npm with provenance attestation. Requires an `NPM_TOKEN` secret in repository settings.
 - TypeScript type declarations added (`dist/ranjs.d.ts`). All 135 distribution classes, the `Distribution` base class (17 public methods), and the `core`, `location`, `dispersion`, `shape`, `dependence`, and `test` namespaces are now fully typed. `"types": "./dist/ranjs.d.ts"` added to `package.json` at the top level and inside `"exports"` for full compatibility with all TypeScript `moduleResolution` modes. See [ADR-0003](decisions/0003-typescript-declarations.md).
 - Build now produces three artifacts: `dist/ranjs.esm.js` (ES module), `dist/ranjs.cjs.js` (CommonJS), and `dist/ranjs.min.js` (UMD, minified, CDN). `"exports"` field added to `package.json` routing `import` to ESM and `require` to CJS. `"sideEffects": false` added to enable tree-shaking across the 130+ distribution classes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,12 @@ When a change touches many files (new base class method, convention rename acros
 
 **Release PR:** Rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD`, add a new empty `## [Unreleased]` above it, and bump `version` in `package.json`. For vulnerabilities that cannot be fixed without a breaking toolchain change, document the accepted risk in the changelog entry with a reference to the tracking issue.
 
+**Triggering a release:** After the release PR is merged, create and push a tag:
+```bash
+git tag v1.25.0 && git push origin v1.25.0
+```
+This triggers `.github/workflows/release.yml`, which runs lint → typecheck → tests → `npm publish --provenance`. Prerequisites: an `NPM_TOKEN` **granular access token** (not a classic automation token) must be stored in GitHub repository Settings → Secrets → Actions, and tag protection rules must restrict `v*` tag creation to maintainers (Settings → Rules → Tag protection).
+
 ## Documentation
 
 - When adding, removing, or modifying files in `.claude/skills/` or `.claude/agents/`, update `.claude/README.md` to reflect the change.


### PR DESCRIPTION
Closes #111

## Summary
- Adds `.github/workflows/release.yml` triggered on `v*` tags: runs lint → typecheck → tests → `npm publish --provenance` in sequence, aborting on any failure
- Adds `permissions: id-token: write` (required for npm provenance attestation) and `contents: read` (least-privilege for the GITHUB_TOKEN)
- Documents the required setup (NPM_TOKEN granular token, tag protection rules) in the workflow file and in CLAUDE.md

## Non-trivial changes

- **`.github/workflows/release.yml`**: New release gate. Three decisions worth reviewing:
  1. `permissions: id-token: write` — without this, `npm publish --provenance` fails at runtime; explicit least-privilege over GitHub's broad defaults.
  2. Test step uses `npx cross-env NODE_ENV=test ./node_modules/.bin/_mocha --require @babel/register` (not `npm test`) to match the same Babel transform CI uses, ensuring the release gate validates under identical conditions.
  3. Lint (`npm run lint`) and typecheck (`npm run check-decl && npm run typecheck`) run before publish — a lint or type error that slipped through a PR review cannot ship in a release.

## Setup required before first use

Two manual steps are needed in GitHub repository settings before a release tag will succeed:

1. **NPM_TOKEN secret** — Settings → Secrets → Actions → New repository secret. Must be a **granular access token** (not a classic automation token) with publish permission for this package.
2. **Tag protection rule** — Settings → Rules → Tag protection, pattern `v*`, restricted to maintainers. Without this, any contributor with push access can trigger a publish.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added [Unreleased] entry for the new release workflow
- **`CLAUDE.md`**: Added "Triggering a release" runbook under the Versioning section

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBbYmAMfvUMDcBwnpSAQ4C)_