### PR TITLE
Add CONTRIBUTING.md and GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Something isn't working correctly
+labels: bug
+---
+
+## Description
+
+<!-- A clear, concise description of the bug. -->
+
+## Reproduction steps
+
+```js
+// Minimal code that reproduces the issue
+import { dist } from 'ranjs'
+```
+
+## Expected behavior
+
+<!-- What you expected to happen. -->
+
+## Actual behavior
+
+<!-- What actually happened. Include error messages or wrong output. -->
+
+## Environment
+
+- **Node version**: <!-- e.g. 20.11.0 -->
+- **ranjs version**: <!-- e.g. 1.24.6 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new distribution, statistical method, or API change
+labels: enhancement
+---
+
+## Motivation
+
+<!-- Why is this feature needed? What problem does it solve or what use case does it enable? -->
+
+## Proposed API
+
+```js
+// Show how you'd expect to call this feature once implemented.
+```
+
+## Alternatives considered
+
+<!-- What other approaches did you consider, and why did you rule them out? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+Closes #<!-- issue number -->
+
+## Checklist
+
+- [ ] `npm run standard` passes (no linter errors)
+- [ ] `npm test` passes (all tests green)
+- [ ] `npm run typecheck` passes
+- [ ] Tests added or updated for changed behavior
+- [ ] If a new distribution was added: entry added to `test/dist-cases.js`
+- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical)
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (skip for pure refactors/docs/tests)
+- [ ] Production-code diff is under ~400 lines (tests excluded)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to ranjs
+
+Thank you for your interest in contributing! Below is everything you need to get started.
+
+## Prerequisites
+
+- **Node.js** 18 or later
+- **npm** (bundled with Node)
+
+## Setup
+
+```bash
+git clone https://github.com/synesenom/ran.git
+cd ran
+npm install
+```
+
+## Verifying your environment
+
+```bash
+npm run lint       # linter check (Standard.js — no semicolons, 2-space indent)
+npm test           # Mocha test suite
+npm run typecheck  # TypeScript declaration validation
+```
+
+All three must pass before you open a PR. (`npm run standard` is the auto-fixing variant of the linter — useful during development, but `npm run lint` is what CI enforces.)
+
+## Adding a new distribution
+
+1. **Write test cases first** (TDD). Add an entry to `test/dist-cases.js` with `invalidParams`, `params`, and at least one `cases` entry before touching `src/`.
+2. Create `src/dist/<kebab-case-name>.js`. Subclass `Distribution` from `src/dist/_distribution.js` and implement `_pdf(x)` / `_pmf(x)` and `_cdf(x)`. Call `super('continuous' | 'discrete', <param-count>)`.
+3. Re-export the class from `src/dist/index.js`.
+4. Add a matching `class <Name> extends Distribution` entry to `dist/ranjs.d.ts` (alphabetical order).
+5. Run `npm run standard && npm test && npm run typecheck`.
+
+See `CLAUDE.md` for the full distribution pattern, parameter conventions, and JSDoc format.
+
+## PR conventions
+
+- **Production-code diff under ~400 lines** (tests excluded). If a feature cannot fit, decompose it into smaller issues first.
+- **One concern per PR.** Avoid titles that contain `+`, "and", or comma-separated lists.
+- **Commit messages**: short imperative subject line (`Add Gompertz distribution`), body for context if needed.
+- **Changelog**: if your change is user-visible (new feature, bug fix, dependency update), add a bullet under `## [Unreleased]` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Pure refactors, test-only, and doc-only changes do not need an entry.
+- **No force-pushing** to a PR branch once review has started.
+
+## Running a subset of tests
+
+```bash
+./node_modules/.bin/_mocha --require @babel/register test/dist.js   # distribution suite only
+./node_modules/.bin/_mocha --require @babel/register test/<file>.js # any single file
+```
+
+## Getting help
+
+Open an issue with the **question** label or start a GitHub Discussion.


### PR DESCRIPTION
Closes #112

## Summary
- Adds `CONTRIBUTING.md` covering setup, linting, testing, how to add a new distribution, PR size conventions, and commit message style
- Adds `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` for structured GitHub issues
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with a pre-merge checklist aligned to CI requirements

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

<details>
<summary>Trivial changes</summary>

- **`CONTRIBUTING.md`**: New contributor guide — setup, lint/test/typecheck commands, distribution-adding workflow (TDD-first), PR conventions
- **`.github/ISSUE_TEMPLATE/bug_report.md`**: Bug report template with description, repro steps, expected/actual behavior, Node + ranjs version fields
- **`.github/ISSUE_TEMPLATE/feature_request.md`**: Feature request template with motivation, proposed API, and alternatives fields
- **`.github/PULL_REQUEST_TEMPLATE.md`**: PR checklist covering lint, test, typecheck, dist-cases, TypeScript declarations, changelog, and diff-size limit

</details>

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZJNJbAP4y4gMXnPpy3cSh)_