### PR TITLE
Strengthen sampling assertions with 3 fixed seeds

### DIFF
--- a/test/dist.js
+++ b/test/dist.js
@@ -163,12 +163,14 @@ const UnitTests = {
         })
 
         it('sample values should be distributed correctly', () => {
-          const generator = c.generate()
-          generator.seed(0)
-          assert(generator.type() === 'continuous'
-            ? ksTest(generator.sample(SAMPLE_SIZE), x => generator.cdf(x))
-            : chiTest(generator.sample(SAMPLE_SIZE), x => generator.pdf(x),
-              Object.keys(generator.save().params).length))
+          for (const s of [0, 42, 12345]) {
+            const generator = c.generate()
+            generator.seed(s)
+            assert(generator.type() === 'continuous'
+              ? ksTest(generator.sample(SAMPLE_SIZE), x => generator.cdf(x))
+              : chiTest(generator.sample(SAMPLE_SIZE), x => generator.pdf(x),
+                Object.keys(generator.save().params).length), `seed ${s}`)
+          }
         })
       })
     })
@@ -192,17 +194,21 @@ const UnitTests = {
     cases.forEach(c => {
       describe(c.name, () => {
         it('should pass for own test', () => {
-          const generator = c.gen()
-          generator.seed(0)
-          assert(generator.test(generator.sample(SAMPLE_SIZE)).passed)
+          for (const s of [0, 42, 12345]) {
+            const generator = c.gen()
+            generator.seed(s)
+            assert(generator.test(generator.sample(SAMPLE_SIZE)).passed, `seed ${s}`)
+          }
         })
 
         it('should reject foreign distribution', () => {
-          const generator = c.gen()
-          generator.seed(0)
-          const sample = generator.sample(SAMPLE_SIZE)
-          const foreign = new dist[tc.foreign.generator](...tc.foreign.params(sample))
-          assert(!foreign.test(sample).passed)
+          for (const s of [0, 42, 12345]) {
+            const generator = c.gen()
+            generator.seed(s)
+            const sample = generator.sample(SAMPLE_SIZE)
+            const foreign = new dist[tc.foreign.generator](...tc.foreign.params(sample))
+            assert(!foreign.test(sample).passed, `seed ${s}`)
+          }
         })
       })
     })


### PR DESCRIPTION
Closes #143

## Summary
- The three sampling `it()` blocks in `test/dist.js` now loop over seeds `[0, 42, 12345]` instead of testing with seed `0` only, so a broken sampler that passes by lucky seed is far less likely to go undetected
- Assert messages include the seed (`seed ${s}`) so failures name the offending seed immediately
- **CI will fail**: this change exposes 24 pre-existing sampling bugs across 11 distributions (Categorical, Chi, Chi2, Delaporte, Erlang, Gamma, GeneralizedGamma, Hypergeometric, InverseGamma, SkewNormal, Zipf). These are real bugs revealed by seeds 42 and 12345 that seed 0 happened to mask. A follow-up issue tracks fixing the underlying samplers.

## Non-trivial changes

_No non-trivial changes — this PR is purely a test-methodology improvement with no production code changes._

## Known CI failures

The 24 new failing tests are **not regressions from this PR** — they are pre-existing sampler bugs. The Gamma-family cluster (Gamma, Chi, Chi2, Erlang, InverseGamma, GeneralizedGamma) likely shares a common root cause in the Gamma sampler. A dedicated issue has been filed to fix them.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_015kFGPvAKTTHis7rkyrPnmL)_