### PR TITLE
Demote [1.24.6] changelog section back to [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced hand-rolled SVG pixel math in `.github/scripts/gen-badge.js` with `badge-maker`; removed legacy `.circleci/config.yml`.
 - Upgraded `rollup` from `^2.64.0` to `^4.x`. Replaced unmaintained `rollup-plugin-terser` with `@rollup/plugin-terser`. Upgraded `@rollup/plugin-node-resolve` from `^13.x` to `^16.x`.
 - Docs build (`npm run docs`) is now driven by a `pages` array in `docs/index.js`; adding a page is one array entry plus one Pug template that extends the new shared layout `docs/templates/_layout.pug`. The compiled SCSS is written once to `docs/styles/style.css` and linked externally from every page (previously inlined into each rendered HTML). See [ADR-0002](decisions/0002-docs-pages-array.md).
+- Removed dead `coveralls` devDependency and its `coveralls` npm script (was never wired into CI).
+- Removed `npm` from devDependencies (unconventional; runner's npm is used directly).
+- Upgraded `nodemon` from `^2.0.15` to `^3.0.0` to fix a `semver` ReDoS vulnerability in `simple-update-notifier`.
+- Fixed 24 of 41 `npm audit` vulnerabilities via `npm audit fix`.
 
 ### Fixed
 
@@ -28,15 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NegativeBinomial` constructor now correctly rejects out-of-range parameters: `r ≤ 0`, `p < 0`, and `p > 1`. Previously some values slipped through validation.
 - Gamma sampler now runs Marsaglia-Tsang directly at shape `α = 1` instead of routing through the `Gamma(α+1) · U^(1/α)` boost branch. The boost is mathematically exact but consumes an extra PRNG draw per sample, which pushed the seed-42 KS statistic just over the p=0.01 critical value at N=10000. Fix transitively repairs sampling-test failures for `Gamma`, `Chi`, `Chi2`, `Erlang`, `InverseGamma`, `LogGamma`, `Nakagami`, and `GeneralizedGamma` at their default parameters (#193).
 - `SkewNormal` sampler now draws both Box-Muller outputs from a single uniform pair instead of calling `_normal` twice (which discarded one branch per call). Halves PRNG consumption per sample and resolves the seed-12345 KS failure for the positive-shape-parameter case (#195).
-
-## [1.24.6] - 2026-05-14
-
-### Changed
-
-- Removed dead `coveralls` devDependency and its `coveralls` npm script (was never wired into CI).
-- Removed `npm` from devDependencies (unconventional; runner's npm is used directly).
-- Upgraded `nodemon` from `^2.0.15` to `^3.0.0` to fix a `semver` ReDoS vulnerability in `simple-update-notifier`.
-- Fixed 24 of 41 `npm audit` vulnerabilities via `npm audit fix`.
 
 ### Accepted risks (pending follow-up issues)
 


### PR DESCRIPTION
Closes #165

## Summary
- `[1.24.6] - 2026-05-14` was promoted prematurely — no git tag or GitHub release exists for that version
- Merged its `Changed` bullets into the existing `[Unreleased] ### Changed` block and moved `Accepted risks` under `[Unreleased]`
- Removed the `[1.24.6]` heading entirely; `CHANGELOG.md` is now valid Keep-a-Changelog format

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Folded `[1.24.6]` content into `[Unreleased]`; removed the versioned heading

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPcrqNxpEJpaFDCb96HnN2)_