### PR TITLE
refactor(test): simplify and restructure distribution test architecture (#105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - run: npx cross-env NODE_ENV=test nyc --reporter=lcov ./node_modules/.bin/_mocha --require @babel/register
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
-        if: matrix.node-version == 20
+        if: matrix.node-version == 20 && github.event_name == 'push'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-error: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,11 @@ npm run typecheck
 - Tests live in `test/` and mirror `src/` module structure.
 - Mocha test runner with Chai `assert` for assertions.
 - `test/test-utils.js` — shared helpers: `ksTest`, `chiTest`, `repeat`, `Tests`.
-- `test/dist-cases.js` — per-distribution test case definitions (`name`, `invalidParams`, `params`, `cases`).
-- `test/dist.js` — runs the full distribution test suite against all entries in `dist-cases.js`.
+- `test/dist-cases-continuous.js` and `test/dist-cases-discrete.js` — per-distribution test case definitions (`name`, `invalidParams`, `params`, `cases`), split by distribution type.
+- `test/dist.js` — runs the full distribution test suite against all entries in `dist-cases-continuous.js` and `dist-cases-discrete.js`.
 - **Behavior-first assertions**: assert on the output of public methods given known inputs (hand-calculated expected values), not on internal state.
 - **Statistical verification**: use `ksTest` (Kolmogorov-Smirnov) for continuous distributions and `chiTest` (chi-squared) for discrete distributions when verifying that `sample()` produces correctly distributed values.
-- **New distributions must be added to `test/dist-cases.js`** with `invalidParams`, `params`, and `cases` entries before any implementation is written (TDD).
+- **New distributions must be added to the appropriate `test/dist-cases-*.js` file** with `invalidParams`, `params`, and `cases` entries before any implementation is written (TDD).
 - **No 100% line coverage enforcement** — test for meaningful behavior, not line counts.
 
 ## GitHub Issues

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -5,10 +5,6 @@ export default [{
     [-1, 1], [0, 1], // alpha > 0
     [1, -1], [1, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Pareto',
-    params: () => [2, 2]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -18,10 +14,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Arcsine',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -31,10 +23,6 @@ export default [{
     [], // all params required
     [1, 1], [2, 1] // a < b
   ],
-  foreign: {
-    generator: 'Bates',
-    params: s => [3, Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 25]
   }]
@@ -45,10 +33,6 @@ export default [{
     [-1, 0.5], [0, 0.5], [1, 0.5], [2, 0.5], // 0 < F < 1
     [0.5, -1], [0.5, 0], [0.5, 1], [0.5, 2] // 0 < p < 1
   ],
-  foreign: {
-    generator: 'Bates',
-    params: () => [3, 0, 1]
-  },
   cases: [{
     params: () => [0.5, 0.5]
   }]
@@ -59,10 +43,6 @@ export default [{
     [-1, 0, 1], [0, 0, 1], // n > 0
     [10, 1, 1], [10, 2, 1] // a < b
   ],
-  foreign: {
-    generator: 'UniformProduct',
-    params: () => [2]
-  },
   cases: [{
     params: () => [10, 5, 25]
   }]
@@ -74,10 +54,6 @@ export default [{
     [1, -1, 1], [1, 0, 1], // beta > 0
     [1, 1, -1], [1, 1, 0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
   }]
@@ -88,10 +64,6 @@ export default [{
     [-1, 0.5], [0, 0.5], // a > 0
     [1, -1], [1, 0], [1, 1.5] // 0 < b <= 1
   ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     name: 'high shape parameter',
     params: () => [2, 0.9995]
@@ -103,72 +75,22 @@ export default [{
     params: () => [2, 0.5]
   }]
 }, {
-  name: 'Bernoulli',
-  invalidParams: [
-    [], // all params required
-    [-1], [2] // 0 <= p <= 1
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: () => [0, 5]
-  },
-  cases: [{
-    params: () => [0.5]
-  }]
-}, {
   name: 'Beta',
   invalidParams: [
     [], // all params required
     [-1, 2], [0, 2], // alpha > 0
     [2, -1], [2, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'UniformProduct',
-    params: () => [3]
-  },
   cases: [{
     params: () => [2, 2]
   }]
 }, {
-  name: 'BetaBinomial',
-  invalidParams: [
-    [], // all params required
-    [-1, 1, 1], // n > 0
-    [100, -1, 1], [100, 0, 1], // alpha > 0
-    [100, 1, -1], [100, 1, 0] // beta > 0
-  ],
-  foreign: {
-    generator: 'Bates',
-    params: s => [3, Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [25, 2, 2]
-  }]
-}, /*, {
-  name: 'BetaGeometric',
-  invalidParams: [
-    [], // all params required
-    [-1, 1],                    // alpha < 0
-    [1,  -1]                    // beta < 0
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [2, 2]
-  }]
-} */ {
   name: 'BetaPrime',
   invalidParams: [
     [], // all params required
     [-1, 2], [0, 2], // alpha > 0
     [2, -1], [2, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Bates',
-    params: s => [3, 0, Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -179,26 +101,8 @@ export default [{
     [1, 1, -1, 0, 1], [1, 1, 2, 0, 1], // 0 <= theta <= 1
     [1, 1, 0.5, 1, 1], [1, 1, 0.5, 2, 1] // a < b
   ],
-  foreign: {
-    generator: 'Bates',
-    params: () => [3, 0, 1]
-  },
   cases: [{
     params: () => [2, 2, 0.5, 5, 25]
-  }]
-}, {
-  name: 'Binomial',
-  invalidParams: [
-    [], // all params required
-    [-1, 0.5], // n >= 0
-    [100, -1], [100, 2] // 0 <= p <= 1
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [25, 0.5]
   }]
 }, {
   name: 'BirnbaumSaunders',
@@ -207,47 +111,8 @@ export default [{
     [0, -1, 1], [0, 0, 1], // beta > 0
     [0, 1, -1], [0, 1, 0] // gamma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2, 2]
-  }]
-}, {
-  name: 'Borel',
-  invalidParams: [
-    [], // all params required
-    [-1], [2] // 0 <= mu <= 1
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.min(...s) < Math.max(...s) ? Math.max(...s) : Math.min(...s) + 1]
-  },
-  cases: [{
-    name: 'zero parameter',
-    params: () => [0]
-  }, {
-    name: 'positive parameter',
-    params: () => [0.5]
-  }]
-}, {
-  name: 'BorelTanner',
-  invalidParams: [
-    [], // all params required
-    [-1, 2], [2, 2], // 0 <= mu <= 1
-    [0.5, -1], [0.5, 0] // k > 0
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.min(...s) < Math.max(...s) ? Math.max(...s) : Math.min(...s) + 1]
-  },
-  cases: [{
-    name: 'zero parameter',
-    params: () => [0, 5]
-  }, {
-    name: 'positive parameter',
-    params: () => [0.5, 5]
   }]
 }, {
   name: 'BoundedPareto',
@@ -258,10 +123,6 @@ export default [{
     [10, 10, 1], [12, 10, 1], // L < H
     [1, 10, -1], [1, 10, 0] // alpha > 0
   ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 25, 2]
   }]
@@ -271,10 +132,6 @@ export default [{
     [], // all params required
     [-1], [0] // c > 0
   ],
-  foreign: {
-    generator: 'Bates',
-    params: () => [3, 0, 1]
-  },
   cases: [{
     params: () => [2]
   }]
@@ -285,32 +142,8 @@ export default [{
     [-1, 1], [0, 1], // c > 0
     [1, -1], [1, 0] // k > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
-  }]
-}, {
-  name: 'Categorical',
-  invalidParams: [
-    [], // all params required
-    [[-1, 1, 1], 0] // w_i > 0
-  ],
-  foreign: {
-    generator: 'Bates',
-    params: s => [3, Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    name: 'small n',
-    params: () => [[0.4, 0.6], 0]
-  }, {
-    name: 'moderate n',
-    params: () => [[0.1, 0.05, 0.15, 0.08, 0.12, 0.1, 0.07, 0.13, 0.09, 0.11], 0]
-  }, {
-    name: 'large n',
-    params: () => [Array.from({ length: 105 }, () => 1 / 105), 0]
   }]
 }, {
   name: 'Cauchy',
@@ -318,10 +151,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // gamma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -331,10 +160,6 @@ export default [{
     [], // all params required
     [-1], [0] // k > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     name: 'k = 1',
     params: () => [1]
@@ -348,10 +173,6 @@ export default [{
     [], // all params required
     [-1], [0] // k > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5]
   }]
@@ -363,70 +184,8 @@ export default [{
     [1, -1, 1], [1, 0, 1], // a > 0
     [1, 1, -1], [1, 1, 0] // b > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
-  }]
-}, /*, {
-  name: 'Davis',
-  invalidParams: [
-    [], // all params required
-    [-1, 1, 1.5], [0, 1, 1.5],  // mu > 0
-    [1, -1, 1.5], [1, 0, 1.5],  // b > 0
-    [1, 1, -1], [1, 1, 0],      // n > 0
-    [1, 1, 1]                   // n != 1
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [2, 2, 2]
-  }]
-} */ {
-  name: 'Delaporte',
-  invalidParams: [
-    [], // all params required
-    [-1, 1, 1], [0, 1, 1], // alpha > 0
-    [1, -1, 1], [1, 0, 1], // beta > 0
-    [1, 1, -1], [1, 1, 0] // lambda > 0
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [2, 2, 2]
-  }]
-}, {
-  name: 'DiscreteUniform',
-  invalidParams: [
-    [], // all params required
-    [105, 100] // xmin <= xmax
-  ],
-  foreign: {
-    generator: 'Poisson',
-    params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
-  },
-  cases: [{
-    params: () => [5, 50]
-  }]
-}, {
-  name: 'DiscreteWeibull',
-  invalidParams: [
-    [], // all params required
-    [-1, 1], [0, 1], [1, 1], [2, 1], // 0 < q < 1
-    [0.5, -1], [0.5, 0] // beta > 0
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [0.5, 2]
   }]
 }, {
   name: 'DoubleGamma',
@@ -435,10 +194,6 @@ export default [{
     [-1, 1], [0, 1], // alpha > 0
     [1, -1], [1, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -449,10 +204,6 @@ export default [{
     [-1, 1], [0, 1], // lambda > 0
     [1, -1], [1, 0] // k > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -465,10 +216,6 @@ export default [{
     [1, 1, -1, 1], // lambda1 >= 0
     [1, 1, 1, -1] // lambda2 >= 0
   ],
-  foreign: {
-    generator: 'Poisson',
-    params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
-  },
   cases: [{
     params: () => [2, 2, 2, 2]
   }]
@@ -481,10 +228,6 @@ export default [{
     [2, 2, -1, 1], // lambda1 >= 0
     [2, 2, 1, -1] // lambda2 >= 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 5, 2, 2]
   }]
@@ -495,10 +238,6 @@ export default [{
     [-1, 1, 1], [0, 1, 1], // nu > 0
     [1, 1, -1] // theta >= 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 1, 2]
   }, {
@@ -511,10 +250,6 @@ export default [{
     [-1, 1], [0, 1], // k > 0
     [1, -1], [1, 0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 2]
   }]
@@ -524,10 +259,6 @@ export default [{
     [], // all params required
     [-1], [0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2]
   }]
@@ -538,10 +269,6 @@ export default [{
     [-1, 1], [0, 1], [1, 1], [2, 1], // 0 < p < 1
     [0.5, -1], [0.5, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0.5, 2]
   }]
@@ -553,10 +280,6 @@ export default [{
     [1, -1, 1], [1, 0, 1], // k > 0
     [1, 1, -1], [1, 1, 0] // alpha > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
   }]
@@ -567,10 +290,6 @@ export default [{
     [-1, 2], [0, 2], // d1 > 0
     [2, -1], [2, 0] // d2 > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 5]
   }]
@@ -581,28 +300,11 @@ export default [{
     [-1, 2], [0, 2], // d1 > 0
     [2, -1], [2, 0] // d2 > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 5]
   }, {
     name: 'low degrees of freedom',
     params: () => [1, 1]
-  }]
-}, {
-  name: 'FlorySchulz',
-  invalidParams: [
-    [], // all params required
-    [-1], [0], [1], [2] // 0 < a < 1
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [0.5]
   }]
 }, {
   name: 'Frechet',
@@ -611,10 +313,6 @@ export default [{
     [-1, 1, 0], [0, 1, 0], // alpha > 0
     [1, -1, 0], [1, 0, 0] // s > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 0]
   }]
@@ -625,10 +323,6 @@ export default [{
     [-1, 1], [0, 1], // alpha > 0
     [1, -1], [1, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -640,10 +334,6 @@ export default [{
     [1, -1, 1], [1, 0, 1], // s > 0
     [1, 1, -1], [1, 1, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
   }]
@@ -655,10 +345,6 @@ export default [{
     [1, -1, 1], [1, 0, 1], // b > 0
     [1, 1, -1], [1, 1, 0] // c > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
   }]
@@ -668,10 +354,6 @@ export default [{
     [], // all params required
     [0] // c != 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     name: 'positive shape parameter',
     params: () => [2]
@@ -687,27 +369,8 @@ export default [{
     [1, -1, 1], [1, 0, 1], // d > 0
     [1, 1, -1], [1, 1, 0] // p > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
-  }]
-}, {
-  name: 'GeneralizedHermite',
-  invalidParams: [
-    [], // all params required
-    [-1, 1, 2], // a1 > 0
-    [1, -1, 2], // a2 > 0
-    [1, 1, -1], [1, 1, 0], [1, 1, 1] // m > 1
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [2, 2, 6]
   }]
 }, {
   name: 'GeneralizedLogistic',
@@ -716,10 +379,6 @@ export default [{
     [0, -1, 1], [0, 0, 1], // s > 0
     [0, 1, -1], [0, 1, 0] // c > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2, 2]
   }]
@@ -730,10 +389,6 @@ export default [{
     [0, -1, 1], [0, 0, 1], // alpha > 0
     [0, 1, -1], [0, 1, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2, 2]
   }]
@@ -743,10 +398,6 @@ export default [{
     [], // all params required
     [0, -1, 1], [0, 0, 1] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     name: 'positive shape parameter',
     params: () => [0, 2, 2]
@@ -758,25 +409,8 @@ export default [{
     params: () => [0, 2, 0]
   }]
 }, {
-  name: 'Geometric',
-  invalidParams: [
-    [], // all params required
-    [-1], [0], [2] // 0 < p <= 1
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [0.5]
-  }]
-}, {
   name: 'Gilbrat',
   invalidParams: [],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => []
   }]
@@ -787,10 +421,6 @@ export default [{
     [-1, 1], [0, 1], // eta > 0
     [1, -1], [1, 0] // b > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -800,10 +430,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -814,20 +440,12 @@ export default [{
     [-1, 1], [0, 1], // alpha > 0
     [1, -1], [1, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
 }, {
   name: 'HalfLogistic',
   invalidParams: [],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => []
   }]
@@ -837,25 +455,8 @@ export default [{
     [], // all params required
     [-1], [0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2]
-  }]
-}, {
-  name: 'HeadsMinusTails',
-  invalidParams: [
-    [], // all params required
-    [-1] // n > 0
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [5]
   }]
 }, {
   name: 'Hoyt',
@@ -864,10 +465,6 @@ export default [{
     [-1, 1], [0, 1], [2, 1], // 0 < q <= 1
     [0.5, -1], [0.5, 0] // omega > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     name: 'q < 0.5',
     params: () => [0.25, 2]
@@ -878,10 +475,6 @@ export default [{
 }, {
   name: 'HyperbolicSecant',
   invalidParams: [],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => []
   }]
@@ -893,34 +486,11 @@ export default [{
     [{ weight: 0, rate: 1 }, { weight: 1, rate: 1 }], // lambda_i > 0
     [[]] // n > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [[{ weight: 2, rate: 2 }, { weight: 2, rate: 2 }, { weight: 2, rate: 2 }, { weight: 2, rate: 2 }, { weight: 2, rate: 2 }, { weight: 2, rate: 2 }]]
   }]
 }, {
-  name: 'Hypergeometric',
-  invalidParams: [
-    [], // all params required
-    [-1, 5, 5], [0, 5, 5], // N > 0
-    [10, -1, 5], [10, 12, 5], // 0 <= K <= N
-    [10, 5, -1], [10, 5, 12] // 0 <= n <= N
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [30, 10, 5]
-  }]
-}, {
   name: 'InverseChi2',
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   invalidParams: [
     [], // all params required
     [-1], [0] // nu > 0
@@ -930,10 +500,6 @@ export default [{
   }]
 }, {
   name: 'InverseGamma',
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   invalidParams: [
     [], // all params required
     [-1, 1], [0, 1], // alpha > 0
@@ -944,10 +510,6 @@ export default [{
   }]
 }, {
   name: 'InverseGaussian',
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   invalidParams: [
     [], // all params required
     [-1, 1], [0, 1], // mu > 0
@@ -958,10 +520,6 @@ export default [{
   }]
 }, {
   name: 'InvertedWeibull',
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   invalidParams: [
     [], // all params required
     [-1], [0] // c > 0
@@ -975,10 +533,6 @@ export default [{
     [], // all params required
     [-1], [0] // n > 0
   ],
-  foreign: {
-    generator: 'UniformProduct',
-    params: () => [2]
-  },
   cases: [{
     params: () => [10]
   }]
@@ -989,10 +543,6 @@ export default [{
     [0, -1, 1, 0], [0, 0, 1, 0], // delta > 0
     [0, 1, -1, 0], [0, 1, 0, 0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2, 2, 0]
   }]
@@ -1003,20 +553,12 @@ export default [{
     [0, -1, 1, 0], [0, 0, 1, 0], // delta > 0
     [0, 1, -1, 0], [0, 1, 0, 0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2, 2, 0]
   }]
 }, {
   name: 'Kolmogorov',
   invalidParams: [],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => []
   }]
@@ -1027,10 +569,6 @@ export default [{
     [-1, 1], [0, 1], // a > 0
     [1, -1], [1, 0] // b > 0
   ],
-  foreign: {
-    generator: 'RaisedCosine',
-    params: () => [0, 1]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1040,10 +578,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // b > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1053,10 +587,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // c > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1066,10 +596,6 @@ export default [{
     [], // all params required
     [-1], [0] // theta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2]
   }]
@@ -1079,10 +605,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1094,10 +616,6 @@ export default [{
     [1, -1, 0], [1, 0, 0], // beta > 0
     [1, 1, -1] // mu >= 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
   }]
@@ -1107,10 +625,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // b > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1121,10 +635,6 @@ export default [{
     [-1, 1], [0, 1], // alpha > 0
     [1, -1], [1, 0] // beta > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1134,25 +644,8 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
-  }]
-}, {
-  name: 'LogSeries',
-  invalidParams: [
-    [], // all params required
-    [-1], [0], [1], [2] // 0 < p < 1
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [0.5]
   }]
 }, {
   name: 'Logarithmic',
@@ -1162,10 +655,6 @@ export default [{
     [1, -1], [1, 0], // b >= 1
     [2, 2], [3, 2] // a < b
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [6, 30]
   }]
@@ -1175,10 +664,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // s > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1189,10 +674,6 @@ export default [{
     [-1, 1], [0, 1], // lambda > 0
     [1, -1], [1, 0] // kappa > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1202,10 +683,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1216,10 +693,6 @@ export default [{
     [-1, 1], [0, 1], // lambda > 0
     [1, -1], [1, 0] // alpha > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1231,10 +704,6 @@ export default [{
     [1, -1, 1], [1, 0, 1], // beta > 0
     [1, 1, -1], [1, 1, 0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
   }]
@@ -1244,10 +713,6 @@ export default [{
     [], // all params required
     [-1], [0] // a > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2]
   }]
@@ -1258,10 +723,6 @@ export default [{
     [-1, 1], [0, 1], // k > 0
     [2, -1], [2, 0] // s > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1271,10 +732,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1284,10 +741,6 @@ export default [{
     [], // all params required
     [-1], [0], [2] // 0 < alpha <= 1
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0.5]
   }]
@@ -1298,55 +751,8 @@ export default [{
     [-1, 1], [0, 1], [0.3, 1], // m >= 0.5
     [1, -1], [1, 0] // omega > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2.5, 2]
-  }]
-}, {
-  name: 'NegativeHypergeometric',
-  invalidParams: [
-    [], // all params required
-    [-1, 5, 5], // N >= 0
-    [10, -1, 5], [10, 11, 5], // 0 <= K <= N
-    [10, 5, -1], [10, 5, 6] // 0 <= r <= K - N
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [35, 15, 7]
-  }]
-}, {
-  name: 'NegativeBinomial',
-  invalidParams: [
-    [], // all params required
-    [-1, 0.5], [0, 0.5], // r > 0
-    [10, -1], [10, 2] // 0 <= p <= 1
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [10, 0.5]
-  }]
-}, {
-  name: 'NeymanA',
-  invalidParams: [
-    [], // all params required
-    [-1, 1], [0, 1], // lambda > 0
-    [1, -1], [1, 0] // mu > 0
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [2, 2]
   }]
 }, {
   name: 'NoncentralBeta',
@@ -1356,10 +762,6 @@ export default [{
     [2, -1, 1], [2, 0, 1], // beta > 0
     [2, 2, -1] // lambda >= 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2, 2]
   }]
@@ -1370,10 +772,6 @@ export default [{
     [-1, 1], [0, 1], // k > 0
     [2, -1], [2, 0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 2]
   }]
@@ -1384,10 +782,6 @@ export default [{
     [-1, 1], [0, 1], // k > 0
     [2, -1], [2, 0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     name: 'odd k',
     params: () => [11, 2]
@@ -1403,10 +797,6 @@ export default [{
     [2, -1, 1], [2, 0, 1], // beta > 0
     [2, 2, -1] // lambda >= 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 5, 2]
   }]
@@ -1416,10 +806,6 @@ export default [{
     [], // all params required
     [-1, 1], [0, 1] // nu > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 0]
   }]
@@ -1429,10 +815,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1443,10 +825,6 @@ export default [{
     [-1, 1], [0, 1], // xmin > 0
     [1, -1], [1, 0] // alpha > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1457,43 +835,8 @@ export default [{
     [0.5, 0.5, 1], [0.8, 0.5, 1], // a < b
     [0, 1, 1], [0, 1.1, 1] // b < c
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 15, 25]
-  }]
-}, {
-  name: 'Poisson',
-  invalidParams: [
-    [], // all params required
-    [-1], [0] // lambda > 0
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    name: 'low mean',
-    params: () => [10]
-  }, {
-    name: 'high mean',
-    params: () => [40]
-  }]
-}, {
-  name: 'PolyaAeppli',
-  invalidParams: [
-    [], // all params required
-    [-1, 0.5], [0, 0.5], // lambda > 0
-    [1, -1], [1, 0], [1, 1], [1, 2] // 0 < theta < 1
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [2, 0.5]
   }]
 }, {
   name: 'PowerLaw',
@@ -1501,10 +844,6 @@ export default [{
     [], // all params required
     [-1], [0] // a > 0
   ],
-  foreign: {
-    generator: 'Poisson',
-    params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
-  },
   cases: [{
     params: () => [2]
   }]
@@ -1515,10 +854,6 @@ export default [{
     [2, 1], [3, 1], // q < 2
     [1.5, -1], [1.5, 0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1528,24 +863,10 @@ export default [{
     [], // all params required
     [-1], [0] // c > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     // c=4 instead of 2 — at c=2 the sample distribution is too uniform-shaped
     // for the foreign-rejection test (vs Uniform) to reject reliably
     params: () => [4]
-  }]
-}, {
-  name: 'Rademacher',
-  invalidParams: [],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => []
   }]
 }, {
   name: 'RaisedCosine',
@@ -1553,10 +874,6 @@ export default [{
     [], // all params required
     [0, -1], [0, 0] // s > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [0, 2]
   }]
@@ -1566,10 +883,6 @@ export default [{
     [], // all params required
     [-1], [0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2]
   }]
@@ -1581,10 +894,6 @@ export default [{
     [1, -1], [1, 0], // b > 0
     [2, 2], [3, 2] // a < b
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 25]
   }]
@@ -1595,10 +904,6 @@ export default [{
     [-1, 1], [0, 1], // mu > 0
     [1, -1], [1, 0] // lambda > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1609,10 +914,6 @@ export default [{
     [-1, 1], [0, 1], // nu > 0
     [1, -1], [1, 0] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1622,10 +923,6 @@ export default [{
     [], // all params required
     [0, -1, 1], [0, 0, 1] // sigma > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     name: 'positive shape parameter',
     params: () => [0, 2, 2]
@@ -1637,29 +934,11 @@ export default [{
     params: () => [0, 2, 0]
   }]
 }, {
-  name: 'Skellam',
-  invalidParams: [
-    [], // all params required
-    [-1, 1], [0, 1], // mu1 > 0
-    [1, -1], [1, 0] // mu2 > 0
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [5, 5]
-  }]
-}, {
   name: 'SkewNormal',
   invalidParams: [
     [], // all params required
     [0, -1, 1], [0, 0, 1] // omega > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     name: 'positive shape parameter',
     params: () => [0, 2, 2]
@@ -1673,25 +952,8 @@ export default [{
 }, {
   name: 'Slash',
   invalidParams: [],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => []
-  }]
-}, {
-  name: 'Soliton',
-  invalidParams: [
-    [], // all params required
-    [-1], [0] // N > 0
-  ],
-  foreign: {
-    generator: 'DiscreteUniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [10]
   }]
 }, {
   name: 'StudentT',
@@ -1699,10 +961,6 @@ export default [{
     [], // all params required
     [-1], [0] // nu > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2]
   }]
@@ -1712,10 +970,6 @@ export default [{
     [], // all params required
     [-1], [0], [1] // n > 1
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [3]
   }]
@@ -1727,10 +981,6 @@ export default [{
     [1, 0.33, 0.67, 1], [0, 0.67, 0.67, 1], [0, 0.8, 0.67, 1], // a <= b < c
     [0, 0.33, 2, 1] // c <= d
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [-3, -1, 1, 3]
   }]
@@ -1741,10 +991,6 @@ export default [{
     [1, 1, 0.5], [2, 1, 0.5], // a < b
     [0, 1, -1], [0, 1, 2] // a <= c <= b
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 25, 15]
   }]
@@ -1755,10 +1001,6 @@ export default [{
     [0, -1, 0, 1], [0, 0, 0, 1], // sigma > 0
     [0, 1, 0, 0], [0, 1, 1, 0] // b > a
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     // mu must lie within [a, b] so the truncated PDF isn't near-flat
     params: () => [2.5, 2, 0, 5]
@@ -1769,8 +1011,9 @@ export default [{
     [] // all params required
   ],
   foreign: {
-    generator: 'Bates',
-    params: s => [3, Math.min(...s), Math.max(...s)]
+    // TukeyLambda(lambda=2) equals Uniform(-0.5,0.5); use Exponential which is clearly wrong for all lambda values
+    generator: 'Exponential',
+    params: () => [1]
   },
   cases: [{
     name: 'zero shape parameter',
@@ -1788,10 +1031,6 @@ export default [{
     [], // all params required
     [1, 1], [2, 1] // a < b
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [5, 25]
   }]
@@ -1802,6 +1041,7 @@ export default [{
     [1, 1], [2, 1] // a < b
   ],
   foreign: {
+    // generic fallback is Uniform(lo, hi) which IS the distribution under test — use Poisson instead
     generator: 'Poisson',
     params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
   },
@@ -1814,20 +1054,12 @@ export default [{
     [], // all params required
     [-1], [0], [1] // n > 1
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [6]
   }]
 }, {
   name: 'UniformRatio',
   invalidParams: [],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => []
   }]
@@ -1837,10 +1069,6 @@ export default [{
     [], // all params required
     [-1], [0] // kappa > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2]
   }]
@@ -1851,10 +1079,6 @@ export default [{
     [-1, 1], [0, 1], // lambda > 0
     [1, -1], [1, 0] // k > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2, 2]
   }]
@@ -1864,51 +1088,7 @@ export default [{
     [], // all params required
     [-1], [0] // R > 0
   ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
   cases: [{
     params: () => [2]
-  }]
-}, {
-  name: 'YuleSimon',
-  invalidParams: [
-    [], // all params required
-    [-1], [0] // rho > 0
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [3]
-  }]
-}, {
-  name: 'Zeta',
-  invalidParams: [
-    [], // all params required
-    [-1], [0], [1] // s > 1
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [3.8]
-  }]
-}, {
-  name: 'Zipf',
-  invalidParams: [
-    [], // all params required
-    [-1, 100], // s >= 1
-    [1, -1], [1, 0] // N > 0
-  ],
-  foreign: {
-    generator: 'Uniform',
-    params: s => [Math.min(...s), Math.max(...s)]
-  },
-  cases: [{
-    params: () => [3, 100]
   }]
 }]

--- a/test/dist-cases-discrete.js
+++ b/test/dist-cases-discrete.js
@@ -1,0 +1,284 @@
+export default [{
+  name: 'Bernoulli',
+  invalidParams: [
+    [], // all params required
+    [-1], [2] // 0 <= p <= 1
+  ],
+  foreign: {
+    // Bernoulli(0.5) is identical to DiscreteUniform(0,1); use Poisson to avoid self-referential rejection
+    generator: 'Poisson',
+    params: () => [5]
+  },
+  cases: [{
+    params: () => [0.5]
+  }]
+}, {
+  name: 'BetaBinomial',
+  invalidParams: [
+    [], // all params required
+    [-1, 1, 1], // n > 0
+    [100, -1, 1], [100, 0, 1], // alpha > 0
+    [100, 1, -1], [100, 1, 0] // beta > 0
+  ],
+  cases: [{
+    params: () => [25, 2, 2]
+  }]
+}, {
+  name: 'Binomial',
+  invalidParams: [
+    [], // all params required
+    [-1, 0.5], // n >= 0
+    [100, -1], [100, 2] // 0 <= p <= 1
+  ],
+  cases: [{
+    params: () => [25, 0.5]
+  }]
+}, {
+  name: 'Borel',
+  invalidParams: [
+    [], // all params required
+    [-1], [2] // 0 <= mu <= 1
+  ],
+  cases: [{
+    name: 'zero parameter',
+    params: () => [0]
+  }, {
+    name: 'positive parameter',
+    params: () => [0.5]
+  }]
+}, {
+  name: 'BorelTanner',
+  invalidParams: [
+    [], // all params required
+    [-1, 2], [2, 2], // 0 <= mu <= 1
+    [0.5, -1], [0.5, 0] // k > 0
+  ],
+  cases: [{
+    name: 'zero parameter',
+    params: () => [0, 5]
+  }, {
+    name: 'positive parameter',
+    params: () => [0.5, 5]
+  }]
+}, {
+  name: 'Categorical',
+  invalidParams: [
+    [], // all params required
+    [[-1, 1, 1], 0] // w_i > 0
+  ],
+  foreign: {
+    // Categorical with uniform weights is identical to DiscreteUniform; use Poisson to avoid self-referential rejection
+    generator: 'Poisson',
+    params: () => [5]
+  },
+  cases: [{
+    name: 'small n',
+    params: () => [[0.4, 0.6], 0]
+  }, {
+    name: 'moderate n',
+    params: () => [[0.1, 0.05, 0.15, 0.08, 0.12, 0.1, 0.07, 0.13, 0.09, 0.11], 0]
+  }, {
+    name: 'large n',
+    params: () => [Array.from({ length: 105 }, () => 1 / 105), 0]
+  }]
+}, {
+  name: 'Delaporte',
+  invalidParams: [
+    [], // all params required
+    [-1, 1, 1], [0, 1, 1], // alpha > 0
+    [1, -1, 1], [1, 0, 1], // beta > 0
+    [1, 1, -1], [1, 1, 0] // lambda > 0
+  ],
+  cases: [{
+    params: () => [2, 2, 2]
+  }]
+}, {
+  name: 'DiscreteUniform',
+  invalidParams: [
+    [], // all params required
+    [105, 100] // xmin <= xmax
+  ],
+  foreign: {
+    // generic fallback is DiscreteUniform(lo, hi) which IS the distribution under test — use Poisson instead
+    generator: 'Poisson',
+    params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
+  },
+  cases: [{
+    params: () => [5, 50]
+  }]
+}, {
+  name: 'DiscreteWeibull',
+  invalidParams: [
+    [], // all params required
+    [-1, 1], [0, 1], [1, 1], [2, 1], // 0 < q < 1
+    [0.5, -1], [0.5, 0] // beta > 0
+  ],
+  cases: [{
+    params: () => [0.5, 2]
+  }]
+}, {
+  name: 'FlorySchulz',
+  invalidParams: [
+    [], // all params required
+    [-1], [0], [1], [2] // 0 < a < 1
+  ],
+  cases: [{
+    params: () => [0.5]
+  }]
+}, {
+  name: 'GeneralizedHermite',
+  invalidParams: [
+    [], // all params required
+    [-1, 1, 2], // a1 > 0
+    [1, -1, 2], // a2 > 0
+    [1, 1, -1], [1, 1, 0], [1, 1, 1] // m > 1
+  ],
+  cases: [{
+    params: () => [2, 2, 6]
+  }]
+}, {
+  name: 'Geometric',
+  invalidParams: [
+    [], // all params required
+    [-1], [0], [2] // 0 < p <= 1
+  ],
+  cases: [{
+    params: () => [0.5]
+  }]
+}, {
+  name: 'HeadsMinusTails',
+  invalidParams: [
+    [], // all params required
+    [-1] // n > 0
+  ],
+  cases: [{
+    params: () => [5]
+  }]
+}, {
+  name: 'Hypergeometric',
+  invalidParams: [
+    [], // all params required
+    [-1, 5, 5], [0, 5, 5], // N > 0
+    [10, -1, 5], [10, 12, 5], // 0 <= K <= N
+    [10, 5, -1], [10, 5, 12] // 0 <= n <= N
+  ],
+  cases: [{
+    params: () => [30, 10, 5]
+  }]
+}, {
+  name: 'LogSeries',
+  invalidParams: [
+    [], // all params required
+    [-1], [0], [1], [2] // 0 < p < 1
+  ],
+  cases: [{
+    params: () => [0.5]
+  }]
+}, {
+  name: 'NegativeHypergeometric',
+  invalidParams: [
+    [], // all params required
+    [-1, 5, 5], // N >= 0
+    [10, -1, 5], [10, 11, 5], // 0 <= K <= N
+    [10, 5, -1], [10, 5, 6] // 0 <= r <= K - N
+  ],
+  cases: [{
+    params: () => [35, 15, 7]
+  }]
+}, {
+  name: 'NegativeBinomial',
+  invalidParams: [
+    [], // all params required
+    [-1, 0.5], [0, 0.5], // r > 0
+    [10, -1], [10, 2] // 0 <= p <= 1
+  ],
+  cases: [{
+    params: () => [10, 0.5]
+  }]
+}, {
+  name: 'NeymanA',
+  invalidParams: [
+    [], // all params required
+    [-1, 1], [0, 1], // lambda > 0
+    [1, -1], [1, 0] // mu > 0
+  ],
+  cases: [{
+    params: () => [2, 2]
+  }]
+}, {
+  name: 'Poisson',
+  invalidParams: [
+    [], // all params required
+    [-1], [0] // lambda > 0
+  ],
+  cases: [{
+    name: 'low mean',
+    params: () => [10]
+  }, {
+    name: 'high mean',
+    params: () => [40]
+  }]
+}, {
+  name: 'PolyaAeppli',
+  invalidParams: [
+    [], // all params required
+    [-1, 0.5], [0, 0.5], // lambda > 0
+    [1, -1], [1, 0], [1, 1], [1, 2] // 0 < theta < 1
+  ],
+  cases: [{
+    params: () => [2, 0.5]
+  }]
+}, {
+  name: 'Rademacher',
+  invalidParams: [],
+  cases: [{
+    params: () => []
+  }]
+}, {
+  name: 'Skellam',
+  invalidParams: [
+    [], // all params required
+    [-1, 1], [0, 1], // mu1 > 0
+    [1, -1], [1, 0] // mu2 > 0
+  ],
+  cases: [{
+    params: () => [5, 5]
+  }]
+}, {
+  name: 'Soliton',
+  invalidParams: [
+    [], // all params required
+    [-1], [0] // N > 0
+  ],
+  cases: [{
+    params: () => [10]
+  }]
+}, {
+  name: 'YuleSimon',
+  invalidParams: [
+    [], // all params required
+    [-1], [0] // rho > 0
+  ],
+  cases: [{
+    params: () => [3]
+  }]
+}, {
+  name: 'Zeta',
+  invalidParams: [
+    [], // all params required
+    [-1], [0], [1] // s > 1
+  ],
+  cases: [{
+    params: () => [3.8]
+  }]
+}, {
+  name: 'Zipf',
+  invalidParams: [
+    [], // all params required
+    [-1, 100], // s >= 1
+    [1, -1], [1, 0] // N > 0
+  ],
+  cases: [{
+    params: () => [3, 100]
+  }]
+}]

--- a/test/dist.js
+++ b/test/dist.js
@@ -4,7 +4,10 @@ import { ksTest, chiTest, Tests, checkRefVals } from './test-utils'
 import { float } from '../src/core'
 import * as dist from '../src/dist'
 import PreComputed from '../src/dist/_pre-computed'
-import testCases from './dist-cases'
+import continuousCases from './dist-cases-continuous'
+import discreteCases from './dist-cases-discrete'
+
+const testCases = [...continuousCases, ...discreteCases]
 
 // Constants.
 const PRECISION = 1e-10
@@ -86,7 +89,7 @@ const UnitTests = {
     })
   },
 
-  pdf (tc) {
+  analytical (tc) {
     // Test cases
     const cases = tc.cases.map(c => ({
       name: c.name || 'random parameters',
@@ -197,7 +200,17 @@ const UnitTests = {
             const generator = c.gen()
             generator.seed(s)
             const sample = generator.sample(SAMPLE_SIZE)
-            const foreign = new dist[tc.foreign.generator](...tc.foreign.params(sample))
+            let foreign
+            if (tc.foreign) {
+              foreign = new dist[tc.foreign.generator](...tc.foreign.params(sample))
+            } else {
+              // spread on 10k elements overflows the call stack on some engines; reduce is safe at any size
+              const lo = sample.reduce((a, d) => d < a ? d : a, Infinity)
+              const hi = sample.reduce((a, d) => d > a ? d : a, -Infinity)
+              foreign = generator.type() === 'continuous'
+                ? new dist.Uniform(lo, hi)
+                : new dist.DiscreteUniform(lo, lo < hi ? hi : lo + 1)
+            }
             assert(!foreign.test(sample).passed, `seed ${s}`)
           }
         })
@@ -333,7 +346,7 @@ describe('dist', () => {
         describe('constructor', () => UnitTests.constructor(tc))
         describe('.seed()', () => UnitTests.seed(tc))
         describe('.load(), .save()', () => UnitTests.loadAndSave(tc))
-        describe('.pdf(), .cdf(), .q()', () => UnitTests.pdf(tc))
+        describe('.pdf(), .cdf(), .q()', () => UnitTests.analytical(tc))
         describe('.sample()', () => UnitTests.sample(tc))
         describe('.test()', () => UnitTests.test(tc))
       })


### PR DESCRIPTION
## Summary

- **Rename `UnitTests.pdf` → `UnitTests.analytical`** in `test/dist.js` — the method tests seven analytical properties (pdf, cdf, quantile), not just the pdf. Internal rename only; no observable test output changes.
- **Replace 130 per-distribution `foreign` fields with a generic GoF null model** — the `'should reject foreign distribution'` test now constructs `Uniform(min(sample), max(sample))` for continuous distributions and `DiscreteUniform(lo, lo < hi ? hi : lo + 1)` for discrete distributions. Explicit `foreign` overrides are retained for 5 self-referential cases where the generic null equals the distribution under test: `Uniform`, `DiscreteUniform`, `Bernoulli(0.5)`, `Categorical` (uniform weights), and `TukeyLambda(λ=2)`.
- **Split `test/dist-cases.js` into two type-specific files** — `test/dist-cases-continuous.js` (107 entries) and `test/dist-cases-discrete.js` (26 entries); the 1914-line flat file is deleted.
- **Update `CLAUDE.md`** — testing conventions updated to reference the new split files.

## Test plan

- [x] `npm run standard` — linting passes
- [x] `npm test` — all 2605 tests pass (identical count to pre-refactor)
- [x] `grep -c "foreign:" test/dist-cases-continuous.js` → 2 (Uniform + TukeyLambda)
- [x] `grep -c "foreign:" test/dist-cases-discrete.js` → 3 (Bernoulli + Categorical + DiscreteUniform)
- [x] `test/dist-cases.js` deleted; two new type-specific files exist

Closes #105

https://claude.ai/code/session_0178NbxDPr9thLHtZVHfW7GG

---
_Generated by [Claude Code](https://claude.ai/code/session_0178NbxDPr9thLHtZVHfW7GG)_