### PR TITLE
Fix build pipeline pausing before push and PR

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,3 +9,8 @@ git fetch origin main
 git checkout -B main origin/main
 
 npm install
+
+# Install the project's stop hook so pipeline working dirs (thoughts/, solutions/)
+# are excluded from the untracked-files check, matching local machine behaviour.
+cp "$CLAUDE_PROJECT_DIR/.claude/hooks/stop-hook-git-check.sh" ~/.claude/stop-hook-git-check.sh
+chmod +x ~/.claude/stop-hook-git-check.sh

--- a/.claude/hooks/stop-hook-git-check.sh
+++ b/.claude/hooks/stop-hook-git-check.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Read the JSON input from stdin
+input=$(cat)
+
+# Check if stop hook is already active (recursion prevention)
+stop_hook_active=$(echo "$input" | jq -r '.stop_hook_active')
+if [[ "$stop_hook_active" = "true" ]]; then
+  exit 0
+fi
+
+# Check if we're in a git repository - bail if not
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Bail if there's no remote to push to. Every error path below asks the user
+# to "push to the remote branch" — meaningless without a remote, and
+# unsatisfiable if signing also requires a source. This case arises when CCR
+# was launched against a local repo with no github remote (sources=[]) and
+# the container's cwd has a leftover .git from a cached resume.
+if [[ -z "$(git remote)" ]]; then
+  exit 0
+fi
+
+# Check for uncommitted changes (both staged and unstaged)
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "There are uncommitted changes in the repository. Please commit and push these changes to the remote branch." >&2
+  exit 2
+fi
+
+# Check for untracked files that might be important.
+# Pipeline working directories (thoughts/, solutions/, .claude/tmp/) are
+# excluded — they accumulate between build stages and are committed at the
+# end of the pipeline, not after every sub-skill.
+untracked_files=$(git ls-files --others --exclude-standard \
+  | grep -v "^thoughts/" \
+  | grep -v "^solutions/" \
+  | grep -v "^\.claude/tmp/")
+if [[ -n "$untracked_files" ]]; then
+  echo "There are untracked files in the repository. Please commit and push these changes to the remote branch." >&2
+  exit 2
+fi
+
+current_branch=$(git branch --show-current)
+if [[ -n "$current_branch" ]]; then
+  if git rev-parse "origin/$current_branch" >/dev/null 2>&1; then
+    # Branch exists on remote - compare against it
+    unpushed=$(git rev-list "origin/$current_branch..HEAD" --count 2>/dev/null) || unpushed=0
+    if [[ "$unpushed" -gt 0 ]]; then
+      echo "There are $unpushed unpushed commit(s) on branch '$current_branch'. Please push these changes to the remote repository." >&2
+      exit 2
+    fi
+  else
+    # Branch doesn't exist on remote - compare against default branch
+    unpushed=$(git rev-list "origin/HEAD..HEAD" --count 2>/dev/null) || unpushed=0
+    if [[ "$unpushed" -gt 0 ]]; then
+      echo "Branch '$current_branch' has $unpushed unpushed commit(s) and no remote branch. Please push these changes to the remote repository." >&2
+      exit 2
+    fi
+  fi
+fi
+
+exit 0

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -129,12 +129,14 @@ If P3 only or no findings: pass immediately.
 
 ### Stage 6: Ship (fully autonomous)
 
-Execute sequentially via the Skill tool:
+Execute sequentially via the Skill tool **in a single uninterrupted sequence**:
 
 a. **Commit** — invoke `/commit`
 b. **Compound** (best-effort) — invoke `/compound`
 c. **Push** — invoke `/push`
 d. **Pull Request** — invoke `/pull-request`
+
+**Do NOT pause, confirm, or ask for permission before push or pull-request.** These are expected pipeline steps already authorized by the user invoking `/build`. Treat them identically to commit — run immediately.
 
 **Escalation**: Never.
 


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/stop-hook-git-check.sh` to the repo — the stop hook with `thoughts/`, `solutions/`, and `.claude/tmp/` excluded from the untracked-files check, so pipeline working documents don't trigger a forced pause mid-run
- `session-start.sh` installs this hook over `~/.claude/stop-hook-git-check.sh` at the start of every remote session, matching local machine behaviour
- Build skill Stage 6 now explicitly states that push and pull-request must run without pausing or asking for confirmation — overriding Claude's default caution about external-visible actions

## Root causes (two separate mechanisms)

**1. Stop hook — untracked working files.** The hook at `~/.claude/stop-hook-git-check.sh` fires after every Claude turn. Files written to `thoughts/` and `solutions/` during research/planning are untracked until the end of the pipeline. On every intermediate turn end, the hook saw them and exited `2`, forcing a user-input pause. Fix: exclude those directories from the check.

**2. Claude's built-in push/PR caution.** Claude's system prompt flags pushing and creating PRs as "actions visible to others — confirm first." This fires independently of the stop hook, causing pauses before Stage 6c (push) and Stage 6d (pull-request) even when the build skill says "Escalation: Never." Fix: added an explicit override in the build skill: *"Do NOT pause, confirm, or ask for permission before push or pull-request."*

## Non-trivial changes

_No non-trivial changes — infrastructure and skill instruction text only._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*