### PR TITLE
Remove checkout-main reset from session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,9 +5,6 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-git fetch origin main
-git checkout -B main origin/main
-
 npm install
 
 # Install the project's stop hook so pipeline working dirs (thoughts/, solutions/)


### PR DESCRIPTION
Removes the two lines that were forcing `git checkout -B main origin/main` on every remote session start:

```bash
-git fetch origin main
-git checkout -B main origin/main
```

This reset was switching back to `main` at the start of every web session, silently discarding any feature branch the session was meant to continue on and making branch-based workflows unreliable.

The hook now only runs `npm install` and installs the stop hook, which is all it needs to do.

https://claude.ai/code/session_01UCcPiqQFCNE1BRUPT9Wnyp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCcPiqQFCNE1BRUPT9Wnyp)_