### PR TITLE
Allow edits to .claude/tmp without approval prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "permissions": {
+    "allow": [
+      "Edit(.claude/tmp*)",
+      "Write(.claude/tmp*)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

- Adds `Edit(.claude/tmp*)` and `Write(.claude/tmp*)` to the `permissions.allow` list in `.claude/settings.json`
- Prevents approval prompts when the pipeline writes scratch files to `.claude/tmp` during review/build/implement workflows

## Test plan

- [ ] Run any pipeline that writes to `.claude/tmp` (e.g. `/review`, `/implement`) and confirm no approval prompt appears for `.claude/tmp` edits

https://claude.ai/code/session_01BFdf3HZC88DeSjBsLTJWyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFdf3HZC88DeSjBsLTJWyb)_