### PR TITLE
Fix NaN at x=0 in NoncentralBeta.{pdf,cdf}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `NoncentralBeta._pdf(0)` and `._cdf(0)` now return `0` instead of `NaN` at the closed-support lower boundary. The series in `recursiveSum` hits a 0/0 indeterminate form at exact `x = 0`, but the mathematical limit is `0` for `alpha > 1`. Added boundary guard and `{ x: 0, pdf: 0, cdf: 0 }` to `NoncentralBeta` refVals. Closes #230.
 - `FisherZ` constructor now passes `(d1, d2)` to the F base class instead of `(d1/2, d2/2)`. Previously, `new FisherZ(d1, d2)` silently produced Fisher's z with degrees of freedom `(round(d1/2), round(d2/2))` (e.g. `FisherZ(5, 5)` was internally F(3, 3)). Internal-consistency tests passed because all distributional self-checks used the same wrong d.o.f. The bug was surfaced by adding scipy-independent reference values per #130. Closes #130.
 - `MaxwellBoltzmann` constructor now passes rate = 1/(2a²) to the Gamma base class (was incorrectly 2a²). The distribution was previously self-consistent but produced values from the wrong density; the correct PDF is f(x;a) = sqrt(2/π) x² exp(−x²/2a²) / a³. Closes #126.
 - `erf` and `erfc` in `src/special/error.js` now use a hybrid Taylor series (|x| ≤ 2) / Laplace continued fraction (|x| > 2) instead of delegating to `gammaLowerIncomplete`/`gammaUpperIncomplete`. This fixes relative precision loss in the tails (5σ+) and resolves the `// TODO Replace with continued fraction` comments. Adds far-tail `Normal(0, 2)` reference values at x = ±10 and ±14 to the test suite. Closes #211.

--- a/src/dist/noncentral-beta.js
+++ b/src/dist/noncentral-beta.js
@@ -62,6 +62,10 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
+    // recursiveSum produces 0/0 = NaN at the closed-support boundary; limit is 0 for alpha > 1.
+    // For alpha <= 1 the PDF is non-zero or divergent at 0 — out of scope, leave as NaN until fixed.
+    if (x === 0 && this.p.alpha > 1) return 0
+
     // Speed-up variables.
     const l2 = this.p.lambda / 2
     const i0 = Math.round(l2)
@@ -116,6 +120,9 @@ export default class extends Distribution {
   }
 
   _cdf (x) {
+    // regularizedBetaIncomplete + series produce NaN at exact x = 0; CDF is 0 at the closed lower support
+    if (x === 0) return 0
+
     // Speed-up variables
     const l2 = this.p.lambda / 2
     const i0 = Math.round(l2)

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -1276,9 +1276,8 @@ export default [{
     params: () => [2, 2, 2]
   }],
   // Reference values from R: dbeta(x, 2, 2, ncp=2), pbeta(x, 2, 2, ncp=2)
-  // x = 0 omitted: ranjs NoncentralBeta.{pdf,cdf}(0) return NaN even though the support is
-  // closed at 0 — separate pre-existing bug, see follow-up issue.
   refVals: [
+    { x: 0, pdf: 0, cdf: 0 },
     { x: 0.1, pdf: 2.41868290579682427e-01, cdf: 1.17498631239324781e-02 },
     { x: 0.3, pdf: 8.22792189851986433e-01, cdf: 1.16647887413446061e-01 },
     { x: 0.5, pdf: 1.40260215058546489e+00, cdf: 3.41173495906274826e-01 },


### PR DESCRIPTION
Closes #230

## Summary
- `NoncentralBeta._pdf(0)` and `._cdf(0)` returned `NaN` because the `recursiveSum` series hits 0/0 at the closed-support lower boundary. Added boundary guards so the mathematical limit (0 for α > 1) is returned directly.
- Added `{ x: 0, pdf: 0, cdf: 0 }` to the `NoncentralBeta` refVals (R: `dbeta(0, 2, 2, ncp=2) = 0`, `pbeta(0, 2, 2, ncp=2) = 0`); removed the obsolete inline comment that flagged the omission.
- CHANGELOG entry added under `[Unreleased] → Fixed`.

## Non-trivial changes
- **`src/dist/noncentral-beta.js`**: `_pdf` guard is gated on `alpha > 1` (where the limit really is 0). For `alpha ≤ 1` the PDF is non-zero or divergent — out of scope for this hotfix, so the function falls through to its prior NaN behaviour rather than silently returning a wrong value. The `_cdf` guard is unconditional because `CDF(0) = P(X ≤ 0) = 0` for every valid α.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Added one refVals entry; removed the obsolete "x = 0 omitted" comment.
- **`CHANGELOG.md`**: One bullet under `[Unreleased] → Fixed`.

</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_01WdpGA2L7awBfnFAnUdxYoW)_