### PR TITLE
Add MCP fallback to ops-issue agent and mandate bug issue filing

### DIFF
--- a/.claude/agents/ops-issue.md
+++ b/.claude/agents/ops-issue.md
@@ -4,6 +4,8 @@ description: Creates a single GitHub issue with structured body, priority label 
 model: haiku
 tools:
   - Bash
+  - mcp__github__issue_write
+  - mcp__github__get_label
 permissionMode: default
 ---
 
@@ -48,7 +50,9 @@ If the input already contains a fully formed body, use it as-is. If the input is
 
 1. **Validate labels** — priority must be one of `high`/`medium`/`low`; difficulty must be one of `difficult`/`moderate`/`trivial`. If invalid, default to `medium` priority and `moderate` difficulty.
 
-2. **Ensure labels exist** — Before creating the issue, create any missing labels:
+2. **Detect available tooling** — Check whether `gh` is available by running `gh --version`. If it succeeds, use the `gh` CLI path (steps 3a–4a). If it fails or is not found, use the GitHub MCP server path (steps 3b–4b).
+
+3a. **[gh path] Ensure labels exist** — Before creating the issue, create any missing labels:
    ```bash
    gh label create "<label>" --description "<description>" --color "<color>" --force
    ```
@@ -56,12 +60,16 @@ If the input already contains a fully formed body, use it as-is. If the input is
    - `high` → `d73a4a` (red), `medium` → `fbca04` (yellow), `low` → `0e8a16` (green)
    - `difficult` → `5319e7` (purple), `moderate` → `1d76db` (blue), `trivial` → `bfdadc` (light gray)
 
-3. **Create the issue**:
+4a. **[gh path] Create the issue**:
    ```bash
    gh issue create --title "<title>" --body "<body>" --label "<priority>,<difficulty>[,<extra_labels>]"
    ```
 
-4. **Return the issue URL** — Respond with ONLY the created issue URL, no other text.
+3b. **[MCP path] Ensure labels exist** — Use `mcp__github__get_label` to check whether each required label exists. For any that are missing, use `mcp__github__issue_write` with `mode: "create_label"` (or the equivalent label-creation call) to create it with the appropriate color. Label colors are the same as above.
+
+4b. **[MCP path] Create the issue** — Call `mcp__github__issue_write` with `mode: "create"`, passing `title`, `body`, and `labels` (array containing priority, difficulty, and any extra labels).
+
+5. **Return the issue URL** — Respond with ONLY the created issue URL, no other text.
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ npm run typecheck
 - Every issue must have both a **priority** label (`high`, `medium`, `low`) and a **difficulty** label (`difficult`, `moderate`, `trivial`).
 - **One concern per issue.** Reject titles that contain `+`, "and", or comma-separated lists of changes.
 - **PR size cap is enforced via the issue template.** Production-code diff must stay under ~400 lines (tests excluded). If a feature can't fit, decompose before filing.
+- **Mandatory bug issue on surfaced bugs.** If any bug is discovered during `/hotfix`, `/fix`, or `/build`, file a bugfix issue via the `ops-issue` agent immediately — before continuing with the fix. No bug may be silently patched without a corresponding issue on record.
 
 ## Decomposing Cross-Cutting Changes
 


### PR DESCRIPTION
## Summary
- `ops-issue` agent now detects `gh` availability at runtime and falls back to `mcp__github__issue_write` / `mcp__github__get_label` when `gh` is absent (remote/web sessions)
- `CLAUDE.md`: mandates filing a bugfix issue via `ops-issue` before patching any bug surfaced by `/hotfix`, `/fix`, or `/build`

## Non-trivial changes
- **`.claude/agents/ops-issue.md`**: Added `mcp__github__issue_write` and `mcp__github__get_label` to the agent's tools list. Execution section now has two paths — the existing `gh` CLI path (3a/4a) and a new MCP path (3b/4b) selected at runtime via `gh --version` detection. This ensures the agent works in remote/web environments where `gh` is not installed.

<details>
<summary>Trivial changes</summary>

- **`CLAUDE.md`**: Added one bullet to the `## GitHub Issues` section requiring a bug issue to be filed before any silent patch.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEfxgEVW69RtwAksVL789M)_