### PR TITLE
ci: disable Coveralls coverage-decrease failure on main

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_threshold:
+  lower_limit: 0


### PR DESCRIPTION
fail-on-error: false only prevents the GHA step from erroring; the
Coveralls service still posts its own coverage/coveralls GitHub status
check as failure when coverage decreases. Setting lower_limit: 0
prevents that server-side check from ever posting failure.

https://claude.ai/code/session_011Sx5XBeRKE77NTHZ1nE1Vn