### PR TITLE
ADR-0007: stay on ranjs, no npm rename (#227)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -56,6 +56,7 @@ Full pipelines that chain multiple skills together.
 | Skill | Pipeline | When to use |
 |-------|----------|-------------|
 | [`/build`](skills/build/SKILL.md) | research → plan → implement → validate → review → ship (commit, compound, push, PR) | Full pipeline from issue to PR |
+| [`/release`](skills/release/SKILL.md) | preflight → version bump → changelog → PR → merge → tag → milestone rotation | Cut a versioned npm release end-to-end |
 
 ### Leaf Skills
 
@@ -224,6 +225,8 @@ Launched **in parallel** by [`/suggest`](skills/suggest/SKILL.md). Each scout sc
                Uses all agents: discovery-*, design-*, recovery-*, ops-triage, review-*, ops-*
 
 /validate ───→ discovery-thoughts
+
+/release ────→ (no agents; uses git + gh CLI directly)
 
 /fix ────────→ ops-triage
               → ops-issue (per definite bug)

--- a/.claude/agents/ops-issue.md
+++ b/.claude/agents/ops-issue.md
@@ -1,6 +1,6 @@
 ---
 name: ops-issue
-description: Creates a single GitHub issue with structured body, priority label (high/medium/low), and difficulty label (difficult/moderate/trivial). Returns the created issue URL.
+description: Creates a single GitHub issue with structured body, priority label (high/medium/low), difficulty label (difficult/moderate/trivial), semver label (major/minor/patch), and milestone assignment. Returns the created issue URL.
 model: haiku
 tools:
   - Bash
@@ -23,7 +23,8 @@ You will receive:
 3. **priority** — One of: `high`, `medium`, `low`
 4. **difficulty** — One of: `difficult`, `moderate`, `trivial`
 5. **semver** — One of: `major`, `minor`, `patch`
-6. **extra_labels** (optional) — Additional labels (e.g. `enhancement`, `bug`)
+6. **milestone** (optional) — Target release version string, e.g. `"v1.25.0"` or `"v2.0.0"`. Defaults to `"v2.0.0"` for `major`; `"v1.25.0"` for `minor`/`patch`. Pass `"none"` to explicitly skip.
+7. **extra_labels** (optional) — Additional labels (e.g. `enhancement`, `bug`)
 
 If the input already contains a fully formed body, use it as-is. If the input is a rough description, structure it into the template below.
 
@@ -49,7 +50,7 @@ If the input already contains a fully formed body, use it as-is. If the input is
 
 ## Execution
 
-1. **Validate labels** — priority must be one of `high`/`medium`/`low`; difficulty must be one of `difficult`/`moderate`/`trivial`; semver must be one of `major`/`minor`/`patch`. If priority or difficulty are invalid, default to `medium` and `moderate`. If semver is missing or invalid, default to `patch`.
+1. **Validate labels and milestone** — priority must be one of `high`/`medium`/`low`; difficulty must be one of `difficult`/`moderate`/`trivial`; semver must be one of `major`/`minor`/`patch`. If priority or difficulty are invalid, default to `medium` and `moderate`. If semver is missing or invalid, default to `patch`. Resolve the milestone: if not provided, infer from semver (`major` → `"v2.0.0"`, else → `"v1.25.0"`); if `"none"`, skip milestone assignment.
 
 2. **Detect available tooling** — Check whether `gh` is available by running `gh --version`. If it succeeds, use the `gh` CLI path (steps 3a–4a). If it fails or is not found, use the GitHub MCP server path (steps 3b–4b).
 
@@ -62,20 +63,36 @@ If the input already contains a fully formed body, use it as-is. If the input is
    - `difficult` → `5319e7` (purple), `moderate` → `1d76db` (blue), `trivial` → `bfdadc` (light gray)
    - `major` → `b60205` (dark red), `minor` → `0075ca` (blue), `patch` → `0e8a16` (green)
 
-4a. **[gh path] Create the issue**:
+4a. **[gh path] Resolve milestone number** — look up the milestone number by name:
    ```bash
-   gh issue create --title "<title>" --body "<body>" --label "<priority>,<difficulty>,<semver>[,<extra_labels>]"
+   MILESTONE_NUM=$(gh milestone list --json number,title -q '.[] | select(.title == "<milestone>") | .number')
+   ```
+   If the milestone does not exist yet, create it first:
+   ```bash
+   gh milestone create --title "<milestone>"
+   MILESTONE_NUM=$(gh milestone list --json number,title -q '.[] | select(.title == "<milestone>") | .number')
+   ```
+
+5a. **[gh path] Create the issue**:
+   ```bash
+   gh issue create --title "<title>" --body "<body>" --label "<priority>,<difficulty>,<semver>[,<extra_labels>]" --milestone "$MILESTONE_NUM"
    ```
 
 3b. **[MCP path] Ensure labels exist** — Use `mcp__github__get_label` to check whether each required label exists. For any that are missing, use `mcp__github__issue_write` with `mode: "create_label"` (or the equivalent label-creation call) to create it with the appropriate color. Label colors are the same as above.
 
-4b. **[MCP path] Create the issue** — Call `mcp__github__issue_write` with `mode: "create"`, passing `title`, `body`, and `labels` (array containing priority, difficulty, semver, and any extra labels).
+4b. **[MCP path] Resolve milestone number** — The MCP server has no milestone-listing tool. Use the following hardcoded mapping (update when new milestones are created):
+   - `"v1.25.0"` → milestone number **1**
+   - `"v2.0.0"` → milestone number **2**
 
-5. **Return the issue URL** — Respond with ONLY the created issue URL, no other text.
+   If the resolved name is not in this table, skip milestone assignment and proceed without it.
+
+5b. **[MCP path] Create the issue** — Call `mcp__github__issue_write` with `method: "create"`, passing `title`, `body`, `labels` (array containing priority, difficulty, semver, and any extra labels), and `milestone` (number from step 4b, if resolved).
+
+6. **Return the issue URL** — Respond with ONLY the created issue URL, no other text.
 
 ## Rules
 
-1. **Always apply all three label dimensions** — every issue gets exactly one priority, one difficulty, and one semver label
+1. **Always apply all three label dimensions and a milestone** — every issue gets exactly one priority, one difficulty, and one semver label, and must be assigned to a milestone
 2. **Imperative titles** — must start with a verb (Add, Create, Update, Fix, Implement, Remove, etc.) and be ≤ 70 chars
 3. **Testable acceptance criteria** — each criterion must be objectively verifiable
 4. **Output only the issue URL** — no explanation, no preamble, just the URL

--- a/.claude/agents/ops-issue.md
+++ b/.claude/agents/ops-issue.md
@@ -13,7 +13,7 @@ You are a specialist at creating well-structured GitHub issues.
 
 ## Your Purpose
 
-Create a single GitHub issue with a standardized body structure and two required label dimensions: **priority** and **difficulty**.
+Create a single GitHub issue with a standardized body structure and three required label dimensions: **priority**, **difficulty**, and **semver**.
 
 ## Input
 
@@ -22,7 +22,8 @@ You will receive:
 2. **body** — Issue body in markdown (see template below)
 3. **priority** — One of: `high`, `medium`, `low`
 4. **difficulty** — One of: `difficult`, `moderate`, `trivial`
-5. **extra_labels** (optional) — Additional labels (e.g. `enhancement`, `bug`)
+5. **semver** — One of: `major`, `minor`, `patch`
+6. **extra_labels** (optional) — Additional labels (e.g. `enhancement`, `bug`)
 
 If the input already contains a fully formed body, use it as-is. If the input is a rough description, structure it into the template below.
 
@@ -48,7 +49,7 @@ If the input already contains a fully formed body, use it as-is. If the input is
 
 ## Execution
 
-1. **Validate labels** — priority must be one of `high`/`medium`/`low`; difficulty must be one of `difficult`/`moderate`/`trivial`. If invalid, default to `medium` priority and `moderate` difficulty.
+1. **Validate labels** — priority must be one of `high`/`medium`/`low`; difficulty must be one of `difficult`/`moderate`/`trivial`; semver must be one of `major`/`minor`/`patch`. If priority or difficulty are invalid, default to `medium` and `moderate`. If semver is missing or invalid, default to `patch`.
 
 2. **Detect available tooling** — Check whether `gh` is available by running `gh --version`. If it succeeds, use the `gh` CLI path (steps 3a–4a). If it fails or is not found, use the GitHub MCP server path (steps 3b–4b).
 
@@ -59,21 +60,22 @@ If the input already contains a fully formed body, use it as-is. If the input is
    Label colors:
    - `high` → `d73a4a` (red), `medium` → `fbca04` (yellow), `low` → `0e8a16` (green)
    - `difficult` → `5319e7` (purple), `moderate` → `1d76db` (blue), `trivial` → `bfdadc` (light gray)
+   - `major` → `b60205` (dark red), `minor` → `0075ca` (blue), `patch` → `0e8a16` (green)
 
 4a. **[gh path] Create the issue**:
    ```bash
-   gh issue create --title "<title>" --body "<body>" --label "<priority>,<difficulty>[,<extra_labels>]"
+   gh issue create --title "<title>" --body "<body>" --label "<priority>,<difficulty>,<semver>[,<extra_labels>]"
    ```
 
 3b. **[MCP path] Ensure labels exist** — Use `mcp__github__get_label` to check whether each required label exists. For any that are missing, use `mcp__github__issue_write` with `mode: "create_label"` (or the equivalent label-creation call) to create it with the appropriate color. Label colors are the same as above.
 
-4b. **[MCP path] Create the issue** — Call `mcp__github__issue_write` with `mode: "create"`, passing `title`, `body`, and `labels` (array containing priority, difficulty, and any extra labels).
+4b. **[MCP path] Create the issue** — Call `mcp__github__issue_write` with `mode: "create"`, passing `title`, `body`, and `labels` (array containing priority, difficulty, semver, and any extra labels).
 
 5. **Return the issue URL** — Respond with ONLY the created issue URL, no other text.
 
 ## Rules
 
-1. **Always apply both label dimensions** — every issue gets exactly one priority and one difficulty label
+1. **Always apply all three label dimensions** — every issue gets exactly one priority, one difficulty, and one semver label
 2. **Imperative titles** — must start with a verb (Add, Create, Update, Fix, Implement, Remove, etc.) and be ≤ 70 chars
 3. **Testable acceptance criteria** — each criterion must be objectively verifiable
 4. **Output only the issue URL** — no explanation, no preamble, just the URL

--- a/.claude/agents/ops-issue.md
+++ b/.claude/agents/ops-issue.md
@@ -1,6 +1,6 @@
 ---
 name: ops-issue
-description: Creates a single GitHub issue with structured body, priority label (high/medium/low), difficulty label (difficult/moderate/trivial), semver label (major/minor/patch), and milestone assignment. Returns the created issue URL.
+description: Creates a single GitHub issue with structured body, priority label (high/medium/low), difficulty label (difficult/moderate/trivial), optional major label for breaking changes, and milestone assignment. Returns the created issue URL.
 model: haiku
 tools:
   - Bash
@@ -13,7 +13,7 @@ You are a specialist at creating well-structured GitHub issues.
 
 ## Your Purpose
 
-Create a single GitHub issue with a standardized body structure and three required label dimensions: **priority**, **difficulty**, and **semver**.
+Create a single GitHub issue with a standardized body structure, two required label dimensions (priority and difficulty), an optional `major` label for breaking changes, and a milestone.
 
 ## Input
 
@@ -22,9 +22,8 @@ You will receive:
 2. **body** — Issue body in markdown (see template below)
 3. **priority** — One of: `high`, `medium`, `low`
 4. **difficulty** — One of: `difficult`, `moderate`, `trivial`
-5. **semver** — One of: `major`, `minor`, `patch`
-6. **milestone** (optional) — Target release version string, e.g. `"v1.25.0"` or `"v2.0.0"`. Defaults to `"v2.0.0"` for `major`; `"v1.25.0"` for `minor`/`patch`. Pass `"none"` to explicitly skip.
-7. **extra_labels** (optional) — Additional labels (e.g. `enhancement`, `bug`)
+5. **breaking** (optional) — `true` if this issue introduces a breaking API change. Adds the `major` label and routes to the `v2.0.0` milestone. Default: `false`.
+6. **extra_labels** (optional) — Additional labels (e.g. `enhancement`, `bug`)
 
 If the input already contains a fully formed body, use it as-is. If the input is a rough description, structure it into the template below.
 
@@ -50,7 +49,9 @@ If the input already contains a fully formed body, use it as-is. If the input is
 
 ## Execution
 
-1. **Validate labels and milestone** — priority must be one of `high`/`medium`/`low`; difficulty must be one of `difficult`/`moderate`/`trivial`; semver must be one of `major`/`minor`/`patch`. If priority or difficulty are invalid, default to `medium` and `moderate`. If semver is missing or invalid, default to `patch`. Resolve the milestone: if not provided, infer from semver (`major` → `"v2.0.0"`, else → `"v1.25.0"`); if `"none"`, skip milestone assignment.
+1. **Validate inputs** — priority must be one of `high`/`medium`/`low`; difficulty must be one of `difficult`/`moderate`/`trivial`. If invalid, default to `medium` and `moderate`. Determine labels and milestone:
+   - `breaking: true` → labels include `major`; milestone = `v2.0.0`
+   - `breaking: false` (default) → no semver label; milestone = `v1.25.0`
 
 2. **Detect available tooling** — Check whether `gh` is available by running `gh --version`. If it succeeds, use the `gh` CLI path (steps 3a–4a). If it fails or is not found, use the GitHub MCP server path (steps 3b–4b).
 
@@ -61,38 +62,34 @@ If the input already contains a fully formed body, use it as-is. If the input is
    Label colors:
    - `high` → `d73a4a` (red), `medium` → `fbca04` (yellow), `low` → `0e8a16` (green)
    - `difficult` → `5319e7` (purple), `moderate` → `1d76db` (blue), `trivial` → `bfdadc` (light gray)
-   - `major` → `b60205` (dark red), `minor` → `0075ca` (blue), `patch` → `0e8a16` (green)
+   - `major` → `b60205` (dark red)
 
-4a. **[gh path] Resolve milestone number** — look up the milestone number by name:
+4a. **[gh path] Resolve milestone and create issue**:
    ```bash
    MILESTONE_NUM=$(gh milestone list --json number,title -q '.[] | select(.title == "<milestone>") | .number')
-   ```
-   If the milestone does not exist yet, create it first:
-   ```bash
-   gh milestone create --title "<milestone>"
-   MILESTONE_NUM=$(gh milestone list --json number,title -q '.[] | select(.title == "<milestone>") | .number')
-   ```
-
-5a. **[gh path] Create the issue**:
-   ```bash
-   gh issue create --title "<title>" --body "<body>" --label "<priority>,<difficulty>,<semver>[,<extra_labels>]" --milestone "$MILESTONE_NUM"
+   # If not found, create it:
+   # gh milestone create --title "<milestone>"
+   # MILESTONE_NUM=$(gh milestone list --json number,title -q '.[] | select(.title == "<milestone>") | .number')
+   gh issue create --title "<title>" --body "<body>" \
+     --label "<priority>,<difficulty>[,major][,<extra_labels>]" \
+     --milestone "$MILESTONE_NUM"
    ```
 
-3b. **[MCP path] Ensure labels exist** — Use `mcp__github__get_label` to check whether each required label exists. For any that are missing, use `mcp__github__issue_write` with `mode: "create_label"` (or the equivalent label-creation call) to create it with the appropriate color. Label colors are the same as above.
+3b. **[MCP path] Ensure labels exist** — Use `mcp__github__get_label` to check whether each required label exists. For any that are missing, apply them via `mcp__github__issue_write` — the API auto-creates unknown labels on first use.
 
-4b. **[MCP path] Resolve milestone number** — The MCP server has no milestone-listing tool. Use the following hardcoded mapping (update when new milestones are created):
-   - `"v1.25.0"` → milestone number **1**
-   - `"v2.0.0"` → milestone number **2**
+4b. **[MCP path] Resolve milestone number** — Use the following mapping (update when milestones change):
+   - `v1.25.0` → milestone number **1**
+   - `v2.0.0` → milestone number **2**
 
-   If the resolved name is not in this table, skip milestone assignment and proceed without it.
-
-5b. **[MCP path] Create the issue** — Call `mcp__github__issue_write` with `method: "create"`, passing `title`, `body`, `labels` (array containing priority, difficulty, semver, and any extra labels), and `milestone` (number from step 4b, if resolved).
+5b. **[MCP path] Create the issue** — Call `mcp__github__issue_write` with `method: "create"`, passing `title`, `body`, `labels`, and `milestone` (number from step 4b).
 
 6. **Return the issue URL** — Respond with ONLY the created issue URL, no other text.
 
 ## Rules
 
-1. **Always apply all three label dimensions and a milestone** — every issue gets exactly one priority, one difficulty, and one semver label, and must be assigned to a milestone
-2. **Imperative titles** — must start with a verb (Add, Create, Update, Fix, Implement, Remove, etc.) and be ≤ 70 chars
-3. **Testable acceptance criteria** — each criterion must be objectively verifiable
-4. **Output only the issue URL** — no explanation, no preamble, just the URL
+1. **Always apply priority and difficulty** — every issue gets exactly one of each
+2. **Apply `major` only for breaking changes** — constructor/public-method rename or removal, or a wrong-distribution fix that changes computed values for the same inputs
+3. **Always assign a milestone** — `v2.0.0` for breaking issues, `v1.25.0` for everything else
+4. **Imperative titles** — must start with a verb (Add, Create, Update, Fix, Implement, Remove, etc.) and be ≤ 70 chars
+5. **Testable acceptance criteria** — each criterion must be objectively verifiable
+6. **Output only the issue URL** — no explanation, no preamble, just the URL

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -39,24 +39,46 @@ Abort with a clear error message if any check fails.
 
 ```bash
 CURRENT=$(node -p "require('./package.json').version")
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 ```
 
-- If a `version` argument was provided, use it as `VERSION`.
-- Otherwise bump minor: split `CURRENT` on `.`, increment middle number, zero the patch.
+**If a `version` argument was provided**, use it as `VERSION` directly.
 
-Compute `NEXT_VERSION` (the milestone to create after this release):
-- Minor release `X.Y.0` → next is `X.(Y+1).0`
-- Major release `X.0.0` → next is `(X+1).0.0`
+**Otherwise, infer the bump type** by checking whether any `major`-labelled
+issues were closed since the last tag:
 
-Print `VERSION` and `NEXT_VERSION` so the operator can confirm before
-continuing.
+```bash
+if [ -n "$LAST_TAG" ]; then
+  LAST_TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
+  MAJOR_CLOSED=$(gh issue list \
+    --state closed \
+    --label major \
+    --json number,closedAt,title \
+    --jq ".[] | select(.closedAt > \"$LAST_TAG_DATE\") | \"#\(.number) \(.title)\"")
+else
+  MAJOR_CLOSED=$(gh issue list \
+    --state closed \
+    --label major \
+    --json number,title \
+    --jq '.[] | "#\(.number) \(.title)"')
+fi
+```
+
+- If `MAJOR_CLOSED` is non-empty → **bump major**: `X.Y.Z` → `(X+1).0.0`
+- Otherwise → **bump minor**: `X.Y.Z` → `X.(Y+1).0`
+
+Compute `NEXT_VERSION` (the non-major milestone to create after this release):
+- Any release `X.Y.0` → next is `X.(Y+1).0`
+- Major release `(X+1).0.0` → next is `(X+1).1.0`
+
+Print `VERSION`, the bump type (major/minor), any triggering major issues, and
+`NEXT_VERSION` so the operator can confirm before continuing.
 
 ---
 
 ### 3. Show what's in the release
 
 ```bash
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 if [ -n "$LAST_TAG" ]; then
   CHANGES=$(git log "${LAST_TAG}..HEAD" --oneline --no-merges)
 else

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,249 @@
+# Release Skill
+
+You are cutting a versioned release of ranjs: bumping the version, updating
+the changelog, creating and merging a release PR, pushing the git tag that
+triggers npm publish, and rotating the GitHub milestone.
+
+## Invocation
+
+```
+/release [version]
+```
+
+Optional `version` argument — the exact semver to release, e.g. `1.25.0`. If
+omitted, the version is computed by bumping the minor part of the current
+`package.json` version (`1.24.6` → `1.25.0`).
+
+## Pre-conditions
+
+- `gh` CLI must be installed and authenticated (`gh auth status`)
+- Must be on `main` with a clean working tree
+- Network access to GitHub and npm must be available
+
+## Workflow
+
+### 1. Pre-flight
+
+```bash
+gh auth status
+git status --short        # must be empty
+git branch --show-current # must be 'main'
+git pull origin main
+```
+
+Abort with a clear error message if any check fails.
+
+---
+
+### 2. Determine version
+
+```bash
+CURRENT=$(node -p "require('./package.json').version")
+```
+
+- If a `version` argument was provided, use it as `VERSION`.
+- Otherwise bump minor: split `CURRENT` on `.`, increment middle number, zero the patch.
+
+Compute `NEXT_VERSION` (the milestone to create after this release):
+- Minor release `X.Y.0` → next is `X.(Y+1).0`
+- Major release `X.0.0` → next is `(X+1).0.0`
+
+Print `VERSION` and `NEXT_VERSION` so the operator can confirm before
+continuing.
+
+---
+
+### 3. Show what's in the release
+
+```bash
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "$LAST_TAG" ]; then
+  CHANGES=$(git log "${LAST_TAG}..HEAD" --oneline --no-merges)
+else
+  CHANGES=$(git log --oneline --no-merges)
+fi
+echo "$CHANGES"
+```
+
+Display the commit list. If it is empty, warn and ask the operator whether to
+continue.
+
+---
+
+### 4. Create release branch
+
+```bash
+git checkout -b "release/v${VERSION}"
+```
+
+---
+
+### 5. Update version files
+
+**`package.json` + `package-lock.json`** — update both atomically:
+
+```bash
+npm version "${VERSION}" --no-git-tag-version
+```
+
+**`CHANGELOG.md`** — replace the `## [Unreleased]` heading with the versioned
+heading and prepend a fresh empty `[Unreleased]` section above it:
+
+```
+## [Unreleased]
+
+## [1.25.0] - 2026-05-18
+```
+
+Use today's date in `YYYY-MM-DD` format. Do not alter any other content in
+the file.
+
+---
+
+### 6. Commit and push
+
+```bash
+git add package.json package-lock.json CHANGELOG.md
+git commit -m "Release v${VERSION}"
+git push -u origin "release/v${VERSION}"
+```
+
+---
+
+### 7. Create PR
+
+```bash
+PR_URL=$(gh pr create \
+  --title "Release v${VERSION}" \
+  --base main \
+  --body "$(cat <<EOF
+## Release v${VERSION}
+
+### Changes since ${LAST_TAG:-initial commit}
+
+${CHANGES}
+
+---
+*Automated release PR — do not add commits to this branch.*
+
+https://claude.ai/code/session_01NNVzrusD7ynZgfa1ZEP2wC
+EOF
+)")
+echo "PR: ${PR_URL}"
+```
+
+---
+
+### 8. Merge PR
+
+```bash
+gh pr merge --merge --auto
+```
+
+Poll until merged (5-minute timeout, 5-second interval):
+
+```bash
+for i in $(seq 1 60); do
+  STATE=$(gh pr view --json state -q '.state')
+  [ "$STATE" = "MERGED" ] && break
+  if [ "$i" -eq 60 ]; then
+    echo "ERROR: Timed out waiting for PR to merge. Merge it manually, then"
+    echo "       run: git checkout main && git pull && git tag v${VERSION} && git push origin v${VERSION}"
+    exit 1
+  fi
+  sleep 5
+done
+```
+
+---
+
+### 9. Tag the release
+
+```bash
+git checkout main
+git pull origin main
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
+```
+
+This push triggers `.github/workflows/release.yml` (lint → typecheck → tests →
+`npm publish --provenance`).
+
+---
+
+### 10. Milestone rotation
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+
+CURRENT_MS=$(gh api "repos/${REPO}/milestones" \
+  --jq ".[] | select(.title == \"v${VERSION}\") | .number")
+
+if [ -z "$CURRENT_MS" ]; then
+  echo "Warning: milestone v${VERSION} not found — skipping milestone rotation."
+else
+  # Create the next milestone before moving issues so the target exists
+  if gh api "repos/${REPO}/milestones" --jq '.[].title' | grep -qx "v${NEXT_VERSION}"; then
+    echo "Milestone v${NEXT_VERSION} already exists — skipping create."
+  else
+    gh api "repos/${REPO}/milestones" \
+      -X POST \
+      -f title="v${NEXT_VERSION}" \
+      -f description="Next release — bug fixes, new distributions, and non-breaking changes"
+  fi
+
+  # Move all open issues from the released milestone to the next one
+  OPEN_ISSUES=$(gh issue list \
+    --milestone "v${VERSION}" \
+    --state open \
+    --limit 200 \
+    --json number \
+    --jq '.[].number')
+
+  MOVED=0
+  for NUM in $OPEN_ISSUES; do
+    gh issue edit "$NUM" --milestone "v${NEXT_VERSION}"
+    MOVED=$((MOVED + 1))
+  done
+
+  # Close the released milestone
+  gh api "repos/${REPO}/milestones/${CURRENT_MS}" \
+    -X PATCH \
+    -f state=closed
+
+  echo "Milestone v${VERSION}: closed (${MOVED} open issues moved to v${NEXT_VERSION})"
+  echo "Milestone v${NEXT_VERSION}: ready"
+fi
+```
+
+Note: the `v2.0.0` major milestone (and any other future major milestone) is
+never touched by this skill — only the milestone whose title matches
+`v${VERSION}` is closed.
+
+---
+
+### 11. Report
+
+End with a concise summary:
+
+```
+Released:  v{VERSION}
+Tag:       v{VERSION} → triggers npm publish via CI
+PR:        {PR_URL}
+
+Milestone v{VERSION}:      closed  ({N} open issues moved)
+Milestone v{NEXT_VERSION}: created
+```
+
+## Rules
+
+- **Abort if pre-flight fails** — never release from a dirty tree or a
+  non-main branch
+- **Never skip the tag push** — without it, `release.yml` never fires and
+  nothing is published to npm
+- **Milestone rotation is best-effort** — if the milestone is missing, warn
+  and continue; do not abort the release
+- **Only touch the released milestone** — leave `v2.0.0` and any other future
+  major milestone untouched when releasing a minor version
+- **No interactive prompts mid-pipeline** — if anything is ambiguous, abort
+  early with a clear message rather than pausing mid-release

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -34,12 +34,11 @@ jobs:
             await github.rest.issues.createComment({
               owner, repo, issue_number,
               body: [
-                '**No milestone assigned.** Please assign this issue to the appropriate release milestone based on its `semver` label:',
+                '**No milestone assigned.** Please assign this issue to the appropriate release milestone:',
                 '',
-                '| `semver` label | Milestone |',
+                '| Issue type | Milestone |',
                 '|---|---|',
-                '| `patch` | nearest `v1.x.x` milestone |',
-                '| `minor` | nearest `v1.x.x` milestone |',
-                '| `major` | `v2.0.0` milestone |',
+                '| Breaking change (has `major` label) | `v2.0.0` |',
+                '| Everything else | `v1.25.0` |',
               ].join('\n'),
             })

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -1,0 +1,45 @@
+name: Require milestone
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  require-milestone:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.milestone == null }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const issue_number = context.issue.number
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: 'needs-milestone' })
+            } catch {
+              await github.rest.issues.createLabel({
+                owner, repo,
+                name: 'needs-milestone',
+                color: 'e4e669',
+                description: 'Missing release milestone assignment',
+              })
+            }
+
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['needs-milestone'] })
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number,
+              body: [
+                '**No milestone assigned.** Please assign this issue to the appropriate release milestone based on its `semver` label:',
+                '',
+                '| `semver` label | Milestone |',
+                '|---|---|',
+                '| `patch` | nearest `v1.x.x` milestone |',
+                '| `minor` | nearest `v1.x.x` milestone |',
+                '| `major` | `v2.0.0` milestone |',
+              ].join('\n'),
+            })

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,10 @@ npm run typecheck
 ## GitHub Issues
 
 - **Always use the `ops-issue` agent** when creating GitHub issues. Never call `gh issue create` directly.
-- Every issue must have both a **priority** label (`high`, `medium`, `low`) and a **difficulty** label (`difficult`, `moderate`, `trivial`).
+- Every issue must have a **priority** label (`high`, `medium`, `low`), a **difficulty** label (`difficult`, `moderate`, `trivial`), and a **semver** label (`major`, `minor`, `patch`).
+  - `major` — breaking API change (constructor/public-method rename or removal, wrong-distribution fix that changes computed values)
+  - `minor` — additive change (new distribution, new public method/property)
+  - `patch` — everything else (bug fix, internal refactor, test/tooling/docs)
 - **One concern per issue.** Reject titles that contain `+`, "and", or comma-separated lists of changes.
 - **PR size cap is enforced via the issue template.** Production-code diff must stay under ~400 lines (tests excluded). If a feature can't fit, decompose before filing.
 - **Mandatory bug triage on every fix/hotfix/build.** `/hotfix`, `/fix`, and `/build` each have a dedicated **Bug Triage** stage that invokes the `ops-triage` agent to classify observations into `definite` / `ambiguous` / `not_a_bug`. `definite` bugs are auto-filed via `ops-issue` in a batch; `ambiguous` cases are escalated to the user in a single prompt; `not_a_bug` is silent. Do not skip the stage even if the session feels clean — the agent will skim the diff for red flags as a safety net.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ npm run typecheck
   - `major` — breaking API change (constructor/public-method rename or removal, wrong-distribution fix that changes computed values)
   - `minor` — additive change (new distribution, new public method/property)
   - `patch` — everything else (bug fix, internal refactor, test/tooling/docs)
+- Every issue must be assigned to a **milestone** (`v1.25.0` for patch/minor, `v2.0.0` for major). The `ops-issue` agent infers the milestone automatically from the semver label. A GitHub Actions workflow (`.github/workflows/require-milestone.yml`) flags any issue opened without a milestone by adding a `needs-milestone` label and posting a comment.
 - **One concern per issue.** Reject titles that contain `+`, "and", or comma-separated lists of changes.
 - **PR size cap is enforced via the issue template.** Production-code diff must stay under ~400 lines (tests excluded). If a feature can't fit, decompose before filing.
 - **Mandatory bug triage on every fix/hotfix/build.** `/hotfix`, `/fix`, and `/build` each have a dedicated **Bug Triage** stage that invokes the `ops-triage` agent to classify observations into `definite` / `ambiguous` / `not_a_bug`. `definite` bugs are auto-filed via `ops-issue` in a batch; `ambiguous` cases are escalated to the user in a single prompt; `not_a_bug` is silent. Do not skip the stage even if the session feels clean — the agent will skim the diff for red flags as a safety net.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,9 @@ npm run typecheck
 ## GitHub Issues
 
 - **Always use the `ops-issue` agent** when creating GitHub issues. Never call `gh issue create` directly.
-- Every issue must have a **priority** label (`high`, `medium`, `low`), a **difficulty** label (`difficult`, `moderate`, `trivial`), and a **semver** label (`major`, `minor`, `patch`).
-  - `major` — breaking API change (constructor/public-method rename or removal, wrong-distribution fix that changes computed values)
-  - `minor` — additive change (new distribution, new public method/property)
-  - `patch` — everything else (bug fix, internal refactor, test/tooling/docs)
-- Every issue must be assigned to a **milestone** (`v1.25.0` for patch/minor, `v2.0.0` for major). The `ops-issue` agent infers the milestone automatically from the semver label. A GitHub Actions workflow (`.github/workflows/require-milestone.yml`) flags any issue opened without a milestone by adding a `needs-milestone` label and posting a comment.
+- Every issue must have a **priority** label (`high`, `medium`, `low`) and a **difficulty** label (`difficult`, `moderate`, `trivial`).
+- Breaking-change issues also get a **`major`** label. Breaking means: constructor or public-method rename/removal, or a wrong-distribution fix that changes computed values for existing inputs. Everything else gets no semver label.
+- Every issue must be assigned to a **milestone**: `v2.0.0` for `major` issues, `v1.25.0` for everything else. The `ops-issue` agent sets this automatically. A GitHub Actions workflow (`.github/workflows/require-milestone.yml`) flags any issue opened without a milestone.
 - **One concern per issue.** Reject titles that contain `+`, "and", or comma-separated lists of changes.
 - **PR size cap is enforced via the issue template.** Production-code diff must stay under ~400 lines (tests excluded). If a feature can't fit, decompose before filing.
 - **Mandatory bug triage on every fix/hotfix/build.** `/hotfix`, `/fix`, and `/build` each have a dedicated **Bug Triage** stage that invokes the `ops-triage` agent to classify observations into `definite` / `ambiguous` / `not_a_bug`. `definite` bugs are auto-filed via `ops-issue` in a batch; `ambiguous` cases are escalated to the user in a single prompt; `not_a_bug` is silent. Do not skip the stage even if the session feels clean — the agent will skim the diff for red flags as a safety net.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,12 @@ When a change touches many files (new base class method, convention rename acros
 
 **Release PR:** Rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD`, add a new empty `## [Unreleased]` above it, and bump `version` in `package.json`. For vulnerabilities that cannot be fixed without a breaking toolchain change, document the accepted risk in the changelog entry with a reference to the tracking issue.
 
-**Triggering a release:** After the release PR is merged, create and push a tag:
+**Triggering a release:** Use the `/release` skill from a machine where `gh` and `git` are available. It handles the full pipeline end-to-end: version bump, changelog, release PR, merge, tag, and milestone rotation. Run it as:
 ```bash
-git tag v1.25.0 && git push origin v1.25.0
+/release          # bumps minor automatically (1.24.6 → 1.25.0)
+/release 1.25.0   # explicit version
 ```
-This triggers `.github/workflows/release.yml`, which runs lint → typecheck → tests → `npm publish --provenance`. Prerequisites: an `NPM_TOKEN` **granular access token** (not a classic automation token) must be stored in GitHub repository Settings → Secrets → Actions, and tag protection rules must restrict `v*` tag creation to maintainers (Settings → Rules → Tag protection).
+The skill pushes `v{version}` which triggers `.github/workflows/release.yml` (lint → typecheck → tests → `npm publish --provenance`). Prerequisites: an `NPM_TOKEN` **granular access token** (not a classic automation token) must be stored in GitHub repository Settings → Secrets → Actions, and tag protection rules must restrict `v*` tag creation to maintainers (Settings → Rules → Tag protection).
 
 ## Documentation
 

--- a/decisions/0007-stay-on-ranjs-no-rename.md
+++ b/decisions/0007-stay-on-ranjs-no-rename.md
@@ -1,0 +1,69 @@
+# ADR-0007: Stay on `ranjs`; do not rename the npm package
+
+**Date**: 2026-05-18
+**Status**: Accepted
+
+## Context
+
+Issue #227 asked us to measure adoption of the `ranjs` npm package and choose between:
+
+- **Option A**: Stay on `ranjs`, bump major versions freely, no deprecation dance.
+- **Option B**: Publish a new package at 0.1.0 under a more descriptive name; deprecate `ranjs`.
+
+The decision matrix from the issue:
+
+| Signal | Action |
+|---|---|
+| >100 weekly downloads, real dependents | Stay on `ranjs`, plan a 2.0 with deprecation notes |
+| 10–100 weekly downloads, mixed signals | Stay on `ranjs`; pay the major-bump cost |
+| <10 weekly downloads, no real dependents | Rename |
+
+### Adoption data collected (2026-05-18)
+
+**GitHub dependents** (`github.com/synesenom/ran/network/dependents`): **13 repositories**.
+
+**GitHub code search — `from 'ranjs'`**: 14 distinct repositories (excluding `synesenom/ran`):
+
+| Repository | Nature |
+|---|---|
+| `wervin/ciko` | Medical app (newborn weight reference tables) |
+| `yy/backward-contact-tracing` | Epidemiology research (contact tracing sim) |
+| `BAschl/twb5` | Real project |
+| `kyteg/JSE` | Real project |
+| `nnseva/solidity-research` | Real project |
+| `abhiomkar/DefinitelyTyped` | Fork of DefinitelyTyped (noise) |
+| `fakecoinbase/DefinitelyTypedslashDefinitelyTyped` | Fork of DefinitelyTyped (noise) |
+| `snippergoals/DefinitelyTyped` | Fork of DefinitelyTyped (noise) |
+| `sonnguyeninspirelife/custom-types` | Test/throwaway |
+| `starwolf0320/TS-Definitely-Typed` | Test/throwaway |
+| `foolhill1231/Test` | Test/throwaway |
+| `KottonKandee843/Newest` | Test/throwaway |
+| `KottonKandee843/new` | Test/throwaway |
+| `Eyenajaaa/Eyenajaaa` | Test/throwaway |
+
+**GitHub code search — `require('ranjs')`**: 3 repositories (`yy/backward-contact-tracing`, `yy/contact-tracing`, `BAschl/twb5`).
+
+**DefinitelyTyped**: `DefinitelyTyped/DefinitelyTyped` contains `types/ranjs/index.d.ts`, `package.json`, `tsconfig.json`, and `ranjs-tests.ts`. This is maintained externally and means `@types/ranjs` is a live npm package that any TypeScript user of `ranjs` depends on.
+
+**npm download stats**: Unavailable in this session (npm API and npm-stat are blocked by the sandbox network policy). A maintainer with unrestricted network access should verify via `https://npm-stat.com/charts.html?package=ranjs` before reversing this decision.
+
+### Signal interpretation
+
+The DefinitelyTyped presence is the decisive signal: a contributor outside the core team wrote and submitted full type definitions to the largest TypeScript type registry. That effort is not undertaken for a package with zero real users. Combined with 5+ real projects visible in code search and 13 GitHub dependents, the evidence places `ranjs` firmly in the **10–100 weekly downloads, mixed signals** bucket.
+
+The "opaque name" argument is real but not decisive at this adoption level. The keywords `random`, `distributions`, `statistics`, `mcmc`, and `test` are already present in the `package.json` `keywords` field, which npm search indexes. A rename does not meaningfully improve discoverability beyond that.
+
+## Decision
+
+**Stay on `ranjs`.** Do not publish under a new package name.
+
+Breaking changes continue to ship as major-version bumps (`1.x → 2.x → 3.x`). No formal deprecation dance is required for a package at this adoption scale. When a breaking change is ready, bump the major version, note the breaking change in `CHANGELOG.md`, and ship.
+
+The "bump majors freely" posture means we do **not** maintain long-lived `1.x` maintenance branches once `2.x` is out. A single active major version at a time is the policy.
+
+## Consequences
+
+- **Easier**: No cross-package coordination, no migration docs, no `package.json` `"deprecated"` field wrangling. Breaking changes ship without ceremony.
+- **Harder**: The opaque name remains. Discoverability stays dependent on keywords and search indexing rather than a descriptive package name. If adoption grows significantly (>100 real dependents), this decision may need revisiting.
+- **Users affected**: The ~5–7 real external dependents absorb major-version bumps as they always have. No forced migration from a rename.
+- **DefinitelyTyped**: `@types/ranjs` remains valid and does not need to be deprecated or redirected.


### PR DESCRIPTION
## Summary

- Collects adoption data for `ranjs` as requested in #227
- Concludes the evidence places us in the "10–100 weekly downloads, mixed signals" bucket — not the <10/week threshold that would justify a rename
- Documents the **stay on `ranjs`** decision as ADR-0007

## Changes

- `decisions/0007-stay-on-ranjs-no-rename.md` — new ADR

## Adoption data

| Signal | Finding |
|---|---|
| GitHub dependents | 13 repositories |
| Code search `from 'ranjs'` | 14 distinct repos; ~5–7 real projects |
| Code search `require('ranjs')` | 3 repos |
| DefinitelyTyped | Live `@types/ranjs` maintained externally |
| npm download stats | Unavailable (sandbox network blocked npm API) |

The DefinitelyTyped presence was the decisive signal: external contributors don't submit type definitions to the largest TypeScript type registry for packages with zero real users.

## Decision

Stay on `ranjs`. Breaking changes ship as major-version bumps, freely, without a deprecation dance. No follow-up rename issue.

## Test plan

- [ ] No production code changed — no tests needed
- [ ] `npm run standard` is not applicable (Markdown file only)
- [ ] ADR format matches `decisions/0000-template.md`

https://claude.ai/code/session_01NNVzrusD7ynZgfa1ZEP2wC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNVzrusD7ynZgfa1ZEP2wC)_