### PR TITLE
Fix NegativeHypergeometric PMF: Ki → k in logBinomial weight loop

### DIFF
--- a/src/dist/negative-hypergeometric.js
+++ b/src/dist/negative-hypergeometric.js
@@ -32,7 +32,7 @@ export default class extends Categorical {
     // Build weights
     const weights = []
     for (let k = 0; k <= Ki; k++) {
-      weights.push(Math.exp(logBinomial(Ki + ri - 1, k) + logBinomial(Ni - ri - k, Ki - k) - logBinomial(Ni, Ki)))
+      weights.push(Math.exp(logBinomial(k + ri - 1, k) + logBinomial(Ni - ri - k, Ki - k) - logBinomial(Ni, Ki)))
     }
     super(weights, 0)
   }

--- a/test/dist-cases-discrete.js
+++ b/test/dist-cases-discrete.js
@@ -338,14 +338,20 @@ export default [{
     [], // all params required
     [-1, 5, 5], // N >= 0
     [10, -1, 5], [10, 11, 5], // 0 <= K <= N
-    [10, 5, -1], [10, 5, 6] // 0 <= r <= K - N
+    [10, 5, -1], [10, 5, 6] // 0 < r <= N - K
   ],
   cases: [{
     params: () => [35, 15, 7]
-  }]
-  // refVals deferred: ranjs._pdf uses logBinomial(K+r-1, k) where the documented
-  // formula and scipy.stats.nhypergeom use C(k+r-1, k). pmf(0;35,15,7) is 0.000297
-  // in ranjs vs 0.0115 in scipy. Filed as separate bug.
+  }],
+  // scipy.stats.nhypergeom(M=35, n=15, r=7)
+  refVals: [
+    { x: 0, pmf: 0.0115279603600311, cdf: 0.0115279603600311 },
+    { x: 2, pmf: 0.08966191391124509, cdf: 0.1444197256213678 },
+    { x: 5, pmf: 0.16273637374860703, cdf: 0.603040415276796 },
+    { x: 8, pmf: 0.07167384049897532, cdf: 0.9237349067403976 },
+    { x: 12, pmf: 0.0032007456682079717, cdf: 0.998939093503107 },
+    { x: 15, pmf: 0.000016707188927434303, cdf: 1 }
+  ]
 }, {
   name: 'NegativeBinomial',
   invalidParams: [


### PR DESCRIPTION
Closes #262

## Summary
- Corrects a one-character typo in `src/dist/negative-hypergeometric.js`: the first `logBinomial` argument used the constant `Ki` (parameter K) instead of the loop variable `k`, making the first binomial coefficient identical for every k and producing a completely wrong distribution shape.
- Adds scipy-verified `refVals` for `NegativeHypergeometric(35, 15, 7)` so the corrected formula is pinned against an independent reference; `pmf(0)` now matches `scipy.stats.nhypergeom(M=35, n=15, r=7).pmf(0) ≈ 0.01153`.
- Fixes an inverted constraint comment in `invalidParams` (`K - N` → `N - K`).

## Non-trivial changes
- **`src/dist/negative-hypergeometric.js:35`**: `logBinomial(Ki + ri - 1, k)` → `logBinomial(k + ri - 1, k)`. This restores the correct PMF formula `C(k+r-1, k) · C(N-r-k, K-k) / C(N, K)` as documented in the JSDoc and on Wikipedia. The old code produced a unimodal distribution with mode near K instead of the correct monotonically-decreasing (for small r) shape.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-discrete.js`**: Added `refVals` from `scipy.stats.nhypergeom(M=35, n=15, r=7)` covering 6 points across the support. Removed the now-obsolete deferred-bug comment. Fixed inverted constraint comment `0 <= r <= K - N` → `0 < r <= N - K`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7TqAd7NsScUiLfBVRwzpD)_