### PR TITLE
Add GoF sampling tests for BenktanderII b=1 and b≈1 branches

### DIFF
--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -133,8 +133,13 @@ export default [{
     name: 'normal shape parameter',
     params: () => [2, 0.5]
   }],
-  // b=1 (log branch in _q) and b≈1 near-boundary excluded — b=0.5 covers the Lambert W path; b=1 correctness verified by the analytical suite
-  sampleParams: [{ name: 'normal shape parameter', params: () => [2, 0.5] }],
+  sampleParams: [
+    { name: 'normal shape parameter', params: () => [2, 0.5] },
+    // b=0.9995 exercises the near-boundary asymptotic approximation branch in _q
+    { name: 'high shape parameter', params: () => [2, 0.9995] },
+    // b=1 exercises the log branch (1 - Math.log(1-p)/a) in _q
+    { name: 'unit shape parameter', params: () => [2, 1] }
+  ],
   // mpmath: BenktanderII PDF/CDF formula with a=2, b=0.9995 @ 50 dps
   refVals: [
     { x: 1.001, pdf: 1.996500505574631, cdf: 0.001998499585372714 },


### PR DESCRIPTION
Closes #269

## Summary
- Extends `BenktanderII.sampleParams` with `b=0.9995` and `b=1` so the Anderson-Darling GoF test covers all three quantile branches in `_q`: the Lambert W path (`b=0.5`), the near-boundary asymptotic approximation (`b=0.9995`), and the log branch (`b=1`)

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Added `{ name: 'high shape parameter', params: () => [2, 0.9995] }` and `{ name: 'unit shape parameter', params: () => [2, 1] }` to `BenktanderII.sampleParams`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y82hC5mBQ1CQB2jAm752sb)_