### PR TITLE
Fix one-sided KS statistic to two-sided D in ksTest and kolmogorovSmirnov

### DIFF
--- a/src/dist/_tests.js
+++ b/src/dist/_tests.js
@@ -113,7 +113,8 @@ export function kolmogorovSmirnov (values, cdf) {
   // Calculate D value
   let D = 0
   for (let i = 0; i < values.length; i++) {
-    D = Math.max(D, Math.abs((i + 1) / values.length - cdf(values[i])))
+    const F = cdf(values[i])
+    D = Math.max(D, Math.abs((i + 1) / values.length - F), Math.abs(F - i / values.length))
   }
 
   // Return comparison results

--- a/test/ad.js
+++ b/test/ad.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { adTest, _adinf, _adStatistic } from './test-utils'
+import { adTest, ksTest, _adinf, _adStatistic } from './test-utils'
 import { float, seed } from '../src/core'
 
 // Hand-computed A² for the symmetric reference sample u = [0.1, 0.3, 0.5, 0.7, 0.9].
@@ -25,6 +25,22 @@ describe('test-utils', () => {
       const left = _adinf(2 - 1e-6)
       const right = _adinf(2 + 1e-6)
       assert(Math.abs(left - right) < 1e-5, `discontinuity at z=2: left=${left}, right=${right}`)
+    })
+  })
+
+  describe('ksTest', () => {
+    it('should accept a sample that matches the model CDF', () => {
+      seed(12345)
+      const sample = Array.from({ length: 1000 }, () => float())
+      assert(ksTest(sample, x => x))
+    })
+
+    it('should reject a left-shifted sample at α = 0.01', () => {
+      seed(12345)
+      // Compressing to [0, 0.7) means the EDF saturates at 1 by x=0.7 while the
+      // Uniform[0,1) model CDF is only 0.7 there, giving D ≈ 0.3 >> threshold ≈ 0.051.
+      const sample = Array.from({ length: 1000 }, () => float() * 0.7)
+      assert(!ksTest(sample, x => x))
     })
   })
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -129,7 +129,8 @@ export function ksTest (values, model) {
   let D = 0
   values.sort((a, b) => a - b)
   for (let i = 0; i < values.length; i++) {
-    D = Math.max(D, Math.abs((i + 1) / values.length - model(values[i])))
+    const F = model(values[i])
+    D = Math.max(D, Math.abs((i + 1) / values.length - F), Math.abs(F - i / values.length))
     // console.log(values[i], (i + 1) / values.length, model(values[i]))
   }
   // console.log(D, 1.628 / Math.sqrt(values.length))


### PR DESCRIPTION
Closes #266

## Summary
- Both `ksTest` (test utility) and `kolmogorovSmirnov` (production, backs `Distribution.test()`) were computing only the upper one-sided EDF statistic `|(i+1)/N − F(x_i)|` while comparing against the two-sided critical value `1.628/√N`, making the test blind to samplers that systematically under-produce left-tail probability.
- `D` is now `max(|(i+1)/N − F|, |F − i/N|)` — the correct two-sided Kolmogorov-Smirnov supremum.
- A targeted regression test verifies that a sample compressed to `[0, 0.7)` (EDF saturates at 1 by x=0.7 while the Uniform[0,1) model CDF is only 0.7 there) is rejected at α = 0.01.

## Non-trivial changes
- **`src/dist/_tests.js:116-117`**: The `kolmogorovSmirnov` loop now caches `F = cdf(values[i])` and accumulates `Math.max(D, |(i+1)/N − F|, |F − i/N|)`. This changes the behavior of `Distribution.test()` for any distribution whose sampler has a left-tail deficit — such samples will now correctly fail.
- **`test/test-utils.js:130-132`**: Same two-sided fix applied to the test-helper `ksTest`, which is used by every distribution's goodness-of-fit assertion in the test suite.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/ad.js`**: Added two `ksTest` acceptance/rejection tests to the existing `describe('test-utils')` block; imports `ksTest` from `test-utils`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bmj8uFbdqN2c9ouBTQ8Csk)_