### PR TITLE
Fix sign error in Soliton JSDoc PMF formula

### DIFF
--- a/src/dist/soliton.js
+++ b/src/dist/soliton.js
@@ -4,7 +4,7 @@ import Distribution from './_distribution'
 /**
  * Generator for the (ideal) [soliton distribution]{@link https://en.wikipedia.org/wiki/Soliton_distribution}:
  *
- * $$f(k; N) = \begin{cases}\frac{1}{N} &\quad\text{if $k = 1$},\\\\ \frac{1}{k (1 - k)} &\quad\text{otherwise}\\\\ \end{cases},$$
+ * $$f(k; N) = \begin{cases}\frac{1}{N} &\quad\text{if $k = 1$},\\\\ \frac{1}{k (k - 1)} &\quad\text{otherwise}\\\\ \end{cases},$$
  *
  * with $N \in \mathbb{N}^+$. Support: $k \in \{1, 2, ..., N\}$.
  *


### PR DESCRIPTION
Closes #273

## Summary
- Corrects the LaTeX formula in the `Soliton` JSDoc from `\frac{1}{k(1-k)}` to `\frac{1}{k(k-1)}` — the old formula evaluated to a negative value for all k ≥ 2, which is impossible for a PMF.
- The implementation was already correct; only the documentation was wrong.

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/soliton.js:7`**: JSDoc LaTeX formula sign corrected — `k(1-k)` → `k(k-1)`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_017D8DnJchwh9oAb5HFo5eWA)_