### PR TITLE
Fix discrete _q off-by-ones and add quantile roundtrip property tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Bernoulli._q` returned `0` for all `p > 0.5` because `this.p.p` is `undefined` after the `Categorical` parent constructor overwrites `this.p` with `{ n, weights, min }`. Fixed by using `this.p.weights[0]` (the CDF at k=0) as the threshold. Closes #212.
+- `DiscreteUniform._q`, `Geometric._q`, and `DiscreteWeibull._q` returned a quantile one too large when `p` landed exactly on a CDF step (e.g., `Geometric(0.5).q(0.5)` returned `1` instead of `0`). Each used `Math.floor` on the algebraic inverse `k+1`; changed to `Math.ceil(…) - 1` which is identical for non-integer arguments but correct at exact integers. Closes #212.
+- `Skellam._q` applied `Math.floor` to the result of `_qEstimateRoot`, which finds a continuous root of `CDF(x) − p`. For a step function the root lands just below the integer boundary, causing `Math.floor` to undershoot by 1. Added a one-step correction: `if (this.cdf(k) < p) k++`. Closes #212.
+
+### Added
+
+- Property tests for all distributions: `cdfMonotonicity` now asserts `cdf(x₂) >= cdf(x₁)` across a deterministic grid (it was previously a no-op that only asserted scalar arithmetic ordering). A new `Tests.quantileRoundtrip` helper asserts `|cdf(q(p)) − p| < 1e-6` for continuous distributions and the two-sided infimum definition for discrete distributions across the fixed probability grid `{0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95}`. Closes #212.
+
 - `R` distribution generator, PDF, and CDF now produce a symmetric distribution matching the documented formula `f(x; c) = (1 - x²)^(c/2-1) / B(1/2, c/2)` on `[-1, 1]`. The previous implementation configured `Beta(0.5, c/2)` (the squared-variable parent) but then applied the affine substitution `y = (x+1)/2` and squared it, breaking `x → −x` symmetry. For `c=4`, `pdf(-0.95)` returned `~0.7495` instead of the correct `~0.0731`. Reduced to the affine `U = (X+1)/2 ~ Beta(c/2, c/2)`, which is one-to-one and avoids the `0·∞` corner at `x=0` for `c<2`. `refVals` for `R(4)` (previously deferred) added to the test suite. Closes #261.
 - `Soliton` distribution support truncation fixed: the weight array was built with `length: N-2`, silently omitting `k=N` and causing the Categorical base class to renormalize the remaining weights upward. Changed to `length: N-1` so `pmf(1)` returns the correct `1/N` and `pmf(N)` returns `1/(N(N-1))`. Closes #263.
 - Catastrophic cancellation in `Rice._cdf` at small `x` fixed by computing the complementary Marcum Q (`marcumP`) directly instead of `1 - marcumQ(...)`. The same double subtraction-from-1 chain that affected `NoncentralChi2` (see #245) destroyed precision in the Rice lower tail. Boundary-region reference values at `x=1e-4` (CDF ≈ 7.58e-10) and `x=1e-2` (CDF ≈ 7.58e-6) added to the test suite. Closes #246.

--- a/solutions/testing/2026-05-20-0459-discrete-quantile-ceil-minus-one-pattern.md
+++ b/solutions/testing/2026-05-20-0459-discrete-quantile-ceil-minus-one-pattern.md
@@ -1,0 +1,69 @@
+---
+date: 2026-05-20T04:59:40Z
+category: "testing"
+problem: "Discrete _q off-by-one when p lands exactly on a CDF step; cdfMonotonicity no-op; no quantile roundtrip test"
+status: complete
+related_issue: "#212"
+related_plan: "thoughts/plans/2026-05-19-2048-property-tests-issue-212.md"
+tags: [quantile, discrete, floor-ceil, off-by-one, property-test, cdf-monotonicity, bernoulli, geometric, skellam]
+---
+
+# Solution: Discrete quantile `ceil(x)-1` pattern and property test infrastructure
+
+**Date**: 2026-05-20T04:59:40Z
+**Category**: testing / correctness
+**Related Issue**: #212
+
+## Problem
+
+Five discrete distribution quantile functions returned wrong values for specific inputs, yet the test suite gave no signal. `Geometric(0.5).q(0.5)` returned `1` instead of `0`. `Bernoulli(0.5).q(0.75)` always returned `0`. `Skellam(5,5).q(0.05)` returned a value whose CDF was 4% below the target probability.
+
+The failures were invisible because `Tests.cdfMonotonicity` was a silent no-op (it asserted `p2 > p1`, comparing two x-domain scalars by name, never calling `d.cdf()` at all), and no quantile roundtrip test existed.
+
+## Root Cause
+
+Three independent bugs across the five distributions, plus one test infrastructure bug:
+
+**1. `cdfMonotonicity` variable naming collision**: Local variables were named `p1`/`p2` but held x-domain coordinates, not probabilities. The assertion `assert(p2 > p1)` is always true by construction and never exercises the CDF.
+
+**2. Algebraic inverse quantile anti-pattern (`Math.floor` on k+1)**: For `DiscreteUniform`, `Geometric`, and `DiscreteWeibull`, the closed-form `_q` computed `Math.floor(algebraic_inverse_of_k_plus_1)`. When `p` exactly equals a CDF step value, the algebraic inverse is exactly the integer `k+1`, and `Math.floor(k+1) = k+1` instead of `k`. This is the correct quantile `Q(p)` only if `CDF(k) < p`, but when `CDF(k) = p` exactly, `k` is the correct infimum.
+
+**3. Parent constructor parameter shadowing (Bernoulli)**: `Bernoulli` extends `Categorical`, whose constructor overwrites `this.p` with `{ n, weights, min }`. `Bernoulli._q` referenced `this.p.p`, which is `undefined`. The condition `p > 1 - undefined` is `false` for all `p`, so `_q` always returned `0`.
+
+**4. Continuous root undershoots step boundary (Skellam)**: `_qEstimateRoot` applies Brent root-finding on the continuous interpretation of the Skellam CDF (a step function). The root of `CDF(x) - p = 0` for a step function lands at approximately `k - ε` (just left of the jump). `Math.floor(k - ε) = k - 1`, which has `CDF(k-1) < p`.
+
+## Fix
+
+**Test infrastructure:**
+- Renamed `p1`/`p2` → `x1`/`x2` in `cdfMonotonicity`; replaced the arithmetic assertion with `assert(d.cdf(x2) >= d.cdf(x1))`.
+- Added `Tests.quantileRoundtrip` with the correct two-sided discrete infimum check: `cdf(q(p)) >= p` AND (when `q(p) > support_min`) `cdf(q(p) - 1) < p`. Continuous: `|cdf(q(p)) - p| < 1e-6`. Fixed probability grid: `ROUNDTRIP_PROBS = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95]`.
+
+**Algebraic inverse fix (DiscreteUniform, Geometric, DiscreteWeibull):**
+Replace `Math.floor(expr)` with `Math.ceil(expr) - 1`. For non-integer arguments they are identical; at exact integers `ceil(n) - 1 = n - 1` (correct) vs `floor(n) = n` (wrong).
+
+**Geometric p=1 edge case:**
+`Math.ceil(log(1-p) / log(0)) - 1 = Math.ceil(0) - 1 = -1`. Added guard `if (this.p.p === 1) return 0`.
+
+**Bernoulli:** Use `this.p.weights[0]` (the weight stored by the Categorical parent for outcome 0) instead of the undefined `this.p.p`.
+
+**Skellam:** After `let k = Math.floor(_qEstimateRoot(p))`, add `if (this.cdf(k) < p) k++`.
+
+## Prevention Strategy
+
+1. **`ceil(expr) - 1` for discrete algebraic quantiles**: Whenever implementing `_q` with a closed-form algebraic inverse for a discrete distribution, use `Math.ceil(expr) - 1` instead of `Math.floor(expr)`. They agree for irrational results; `ceil - 1` is correct at exact integers, which occurs whenever `p` is a rational number whose denominator divides the distribution's period.
+
+2. **Variable names in property tests must match their domain**: A variable named `p` will be read as a probability. Use `x` for domain values. A monotonicity helper with variables named `p1`/`p2` will mislead maintainers into thinking the assertion compares probabilities.
+
+3. **Subclass `this.p` shadowing**: When a discrete distribution subclasses another, never access the original constructor parameter via `this.p.original_name` — the parent constructor may overwrite `this.p` entirely. Access the stored representation (e.g., `this.p.weights[0]`). Audit `_q`, `_pdf`, `_cdf`, and `_generator` for any `this.p.<param>` access in subclasses.
+
+4. **Continuous root-finder for discrete quantiles**: Any `_q` that calls `_qEstimateRoot` and floors the result must post-correct: `if (this.cdf(k) < p) k++`. The root of a step function in continuous space always undershoots the integer boundary by ε.
+
+5. **Add `quantileRoundtrip` to every new discrete distribution's test case**: The two-sided check (`cdf(q(p)) >= p AND cdf(q(p)-1) < p`) is the minimal spec for the infimum quantile. `qGalois` alone does not catch off-by-one errors — it checks sign consistency, not absolute roundtrip accuracy.
+
+## Related Solutions
+
+- [`solutions/testing/2026-05-16-0653-galois-inequality-ulp-guard.md`](../testing/2026-05-16-0653-galois-inequality-ulp-guard.md) — ULP-guard in `qGalois` to avoid false failures from floating-point noise at steep CDF boundaries; the quantile roundtrip check uses the same deterministic GOLDEN-offset grid convention.
+
+## Key Insight
+
+For discrete quantile functions derived from algebraic inverses, `Math.ceil(expr) - 1` must replace `Math.floor(expr)` — they agree for irrational results but `floor` erroneously returns `k + 1` when the argument is exactly the integer `k + 1`, which happens whenever the input probability `p` exactly coincides with a CDF step value.

--- a/src/dist/bernoulli.js
+++ b/src/dist/bernoulli.js
@@ -27,6 +27,7 @@ export default class extends Categorical {
   }
 
   _q (p) {
-    return p > 1 - this.p.p ? 1 : 0
+    // this.p.weights[0] is the CDF at k=0; this.p.p is shadowed by the Categorical constructor.
+    return p > this.p.weights[0] ? 1 : 0
   }
 }

--- a/src/dist/discrete-uniform.js
+++ b/src/dist/discrete-uniform.js
@@ -56,6 +56,8 @@ export default class extends Distribution {
   }
 
   _q (p) {
-    return Math.floor(p * this.c[0]) + this.p.xmin
+    // ceil(x)-1 equals floor(x) for non-integer x but gives x-1 when x is exactly an integer,
+    // which is needed when p*N is exact so CDF(k) = p and the correct quantile is k, not k+1.
+    return Math.ceil(p * this.c[0]) - 1 + this.p.xmin
   }
 }

--- a/src/dist/discrete-weibull.js
+++ b/src/dist/discrete-weibull.js
@@ -49,6 +49,8 @@ export default class extends Distribution {
   }
 
   _q (p) {
-    return Math.floor(Math.pow(Math.log(1 - p) / Math.log(this.p.q), 1 / this.p.beta))
+    // ceil(x)-1 equals floor(x) for non-integer x but gives x-1 when x is exact,
+    // preventing the off-by-one when CDF(k) = p exactly.
+    return Math.ceil(Math.pow(Math.log(1 - p) / Math.log(this.p.q), 1 / this.p.beta)) - 1
   }
 }

--- a/src/dist/geometric.js
+++ b/src/dist/geometric.js
@@ -52,6 +52,7 @@ export default class extends Distribution {
     if (this.p.p === 1) return 0
     // ceil(x)-1 equals floor(x) for non-integer x but gives x-1 when x is exact,
     // preventing the off-by-one when CDF(k) = p exactly.
+    // See solutions/testing/2026-05-20-0459-discrete-quantile-ceil-minus-one-pattern.md
     return Math.ceil(Math.log(1 - p) / Math.log(1 - this.p.p)) - 1
   }
 }

--- a/src/dist/geometric.js
+++ b/src/dist/geometric.js
@@ -48,6 +48,10 @@ export default class extends Distribution {
   }
 
   _q (p) {
-    return Math.floor(Math.log(1 - p) / Math.log(1 - this.p.p))
+    // p=1 gives log(0)=-Infinity in denominator; the distribution degenerates to always 0.
+    if (this.p.p === 1) return 0
+    // ceil(x)-1 equals floor(x) for non-integer x but gives x-1 when x is exact,
+    // preventing the off-by-one when CDF(k) = p exactly.
+    return Math.ceil(Math.log(1 - p) / Math.log(1 - this.p.p)) - 1
   }
 }

--- a/src/dist/skellam.js
+++ b/src/dist/skellam.js
@@ -65,6 +65,10 @@ export default class extends Distribution {
   }
 
   _q (p) {
-    return Math.floor(this._qEstimateRoot(p))
+    // _qEstimateRoot finds a continuous root of CDF(x)-p. For a step function the root lands
+    // just below the integer boundary, so floor undershoots by 1. Increment if needed.
+    let k = Math.floor(this._qEstimateRoot(p))
+    if (this.cdf(k) < p) k++
+    return k
   }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -135,6 +135,10 @@ const UnitTests = {
         it('quantile should satisfy Galois inequalities', () => {
           Tests.qGalois(c.generate())
         })
+
+        it('quantile should round-trip through cdf', () => {
+          Tests.quantileRoundtrip(c.generate())
+        })
       })
     })
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -8,6 +8,8 @@ const RANGE_STEPS = 10
 const GOLDEN = 0.6180339887
 // Fixed reference probabilities for qGalois: well-spread across (0,1), spanning both sides of any p.
 const GALOIS_PROBS = [0.1, 0.25, 0.5, 0.75, 0.9]
+// Fixed probabilities for quantile roundtrip: includes tails where root-finding is hardest.
+const ROUNDTRIP_PROBS = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95]
 
 // Critical values for P = 0.01
 // Source: https://www.medcalc.org/manual/chi-square-table.php
@@ -320,9 +322,11 @@ export const Tests = {
 
     // Run through x values and assert CDF(x - dx) <= CDF(x + dx).
     runX(dist, (d, x) => {
-      const p1 = discrete ? x : x - 1e-3
-      const p2 = discrete ? x + 1 : x + 1e-3
-      assert(p2 > p1, `cdf(${p1}; ${getParamList(d)}) > cdf(${p2}; ${getParamList(d)})`)
+      const x1 = discrete ? x : x - 1e-3
+      const x2 = discrete ? x + 1 : x + 1e-3
+      const c1 = d.cdf(x1)
+      const c2 = d.cdf(x2)
+      assert(c2 >= c1, `cdf(${x2}; ${getParamList(d)}) = ${c2} < cdf(${x1}; ${getParamList(d)}) = ${c1}`)
     })
   },
 
@@ -423,5 +427,27 @@ export const Tests = {
         assert(dx * dp >= 0, `cdf(${x}) = ${cdf} and q(${p}) = ${q}`)
       }
     })
+  },
+
+  quantileRoundtrip (dist) {
+    const discrete = dist.type() === 'discrete'
+    for (const p of ROUNDTRIP_PROBS) {
+      const x = dist.q(p)
+      assert(typeof x === 'number' && Number.isFinite(x),
+        `q(${p}; ${getParamList(dist)}) = ${x} is not finite`)
+      if (discrete) {
+        assert(dist.cdf(x) >= p,
+          `cdf(q(${p}); ${getParamList(dist)}) = ${dist.cdf(x)} < ${p}`)
+        // Skip lower-infimum check at the support boundary — cdf(min-1) = 0 < p trivially.
+        if (x > dist.support()[0].value) {
+          assert(dist.cdf(x - 1) < p,
+            `cdf(q(${p}) - 1; ${getParamList(dist)}) = ${dist.cdf(x - 1)} >= ${p}`)
+        }
+      } else {
+        const c = dist.cdf(x)
+        assert(Math.abs(c - p) < 1e-6,
+          `|cdf(q(${p}); ${getParamList(dist)}) - ${p}| = ${Math.abs(c - p)} >= 1e-6`)
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #212

## Summary
- Fixed `Tests.cdfMonotonicity` which was a silent no-op (asserting scalar arithmetic, never calling `cdf()`), and added `Tests.quantileRoundtrip` for the discrete infimum check and continuous roundtrip check
- The new `quantileRoundtrip` test exposed 5 pre-existing discrete quantile bugs; all fixed in the same PR (expanded scope authorized by maintainer)
- All 2891 tests pass; no new public API surface

## Non-trivial changes

- **`test/test-utils.js`**: `cdfMonotonicity` renamed `p1`/`p2` → `x1`/`x2` and now asserts `d.cdf(x2) >= d.cdf(x1)` instead of the always-true `x2 > x1`. Added `ROUNDTRIP_PROBS = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95]` and `Tests.quantileRoundtrip` with the two-sided discrete check (`cdf(q(p)) >= p` AND `cdf(q(p)-1) < p` when `q(p) > support_min`) and continuous roundtrip (`|cdf(q(p)) - p| < 1e-6`).

- **`src/dist/bernoulli.js`**: `_q` referenced `this.p.p` which is `undefined` — the `Categorical` parent constructor overwrites `this.p` with `{n, weights, min}`. Fixed to use `this.p.weights[0]` (the stored CDF at k=0).

- **`src/dist/discrete-uniform.js`**, **`src/dist/geometric.js`**, **`src/dist/discrete-weibull.js`**: `_q` used `Math.floor(algebraic_inverse)`. When the input probability `p` exactly equals a CDF step value, the algebraic inverse is exactly an integer `k+1`, and `floor(k+1) = k+1` (wrong) instead of `k` (correct). Fixed with `Math.ceil(expr) - 1` — identical to `floor` for non-integer results, correct at exact integers.

- **`src/dist/geometric.js`** (additional): `Geometric(p=1)` is degenerate (always returns 0). With the `ceil-1` fix, `Math.ceil(log(1-p)/log(0)) - 1 = Math.ceil(0) - 1 = -1`. Added `if (this.p.p === 1) return 0` guard.

- **`src/dist/skellam.js`**: `_q` calls `_qEstimateRoot` (Brent root-finding on continuous interpretation of a step CDF). The continuous root lands at `k - ε` (just below the step), so `Math.floor` returns `k-1` when the correct quantile is `k`. Fixed with post-floor correction: `if (this.cdf(k) < p) k++`.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Added one `it` block calling `Tests.quantileRoundtrip` after the existing `qGalois` block.
- **`CHANGELOG.md`**: Added entries under `### Fixed` and `### Added` for the five distribution fixes and the new property tests.
- **`solutions/testing/2026-05-20-0459-discrete-quantile-ceil-minus-one-pattern.md`**: Solution document capturing root cause and prevention strategy.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKuof5ScDUBfPJsxVibmCb)_