### PR TITLE
Add _qEstimateWalk to Distribution base class for discrete quantile estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Distribution._qEstimateWalk(p, start)` protected helper: deterministic linear walk from a caller-supplied integer start toward the infimum discrete quantile. Exits when `cdf(k) >= p` and `cdf(k-1) < p`. Provides a non-random alternative to `_qEstimateRoot` for infinite-support discrete distributions with analytically-known parameters. Closes #284.
 - Property tests for all distributions: `cdfMonotonicity` now asserts `cdf(x₂) >= cdf(x₁)` across a deterministic grid (it was previously a no-op that only asserted scalar arithmetic ordering). A new `Tests.quantileRoundtrip` helper asserts `|cdf(q(p)) − p| < 1e-6` for continuous distributions and the two-sided infimum definition for discrete distributions across the fixed probability grid `{0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95}`. Closes #212.
 
 - `R` distribution generator, PDF, and CDF now produce a symmetric distribution matching the documented formula `f(x; c) = (1 - x²)^(c/2-1) / B(1/2, c/2)` on `[-1, 1]`. The previous implementation configured `Beta(0.5, c/2)` (the squared-variable parent) but then applied the affine substitution `y = (x+1)/2` and squared it, breaking `x → −x` symmetry. For `c=4`, `pdf(-0.95)` returned `~0.7495` instead of the correct `~0.0731`. Reduced to the affine `U = (X+1)/2 ~ Beta(c/2, c/2)`, which is one-to-one and avoids the `0·∞` corner at `x=0` for `c<2`. `refVals` for `R(4)` (previously deferred) added to the test suite. Closes #261.

--- a/solutions/algorithm/2026-05-20-0647-q-estimate-walk-infinite-support-discrete.md
+++ b/solutions/algorithm/2026-05-20-0647-q-estimate-walk-infinite-support-discrete.md
@@ -1,0 +1,54 @@
+---
+date: 2026-05-20T06:47:38Z
+category: "algorithm"
+problem: "_qEstimateTable silently broken for discrete distributions with negative-integer support; _qEstimateRoot non-deterministic and can return NaN"
+status: complete
+related_issue: "#284"
+related_plan: "thoughts/plans/2026-05-20-0626-issue-284-q-estimate-walk.md"
+tags: [quantile, discrete, infinite-support, walk, skellam, deterministic, _qEstimateWalk, _qEstimateTable, _qEstimateRoot]
+---
+
+# Solution: Deterministic linear walk for infinite-support discrete quantile estimation
+
+**Date**: 2026-05-20T06:47:38Z
+**Category**: algorithm
+**Related Issue**: #284
+
+## Problem
+
+Discrete distributions with support that includes negative integers (e.g. Skellam, whose support is `(-∞, ∞)`) had a fragile and non-deterministic quantile path. `_qEstimateTable` always starts its expansion bracket at `k=0` and walks only upward, silently producing wrong quantiles for any `p` that maps to a negative integer. As a workaround, `Skellam._q` called `_qEstimateRoot` (the continuous Brent root-finder), applied `Math.floor` to snap the result to an integer, and added a one-step correction. Because `_qEstimateRoot` initialises its bracket with `Math.random()`, it can exhaust its 100-iteration cap without finding a sign change when `p` is near 0 or 1, returning `undefined`; `Math.floor(undefined)` is `NaN`, so `Skellam.q(p)` silently returned `NaN` in the extreme tails.
+
+## Root Cause
+
+The `Distribution` base class had no discrete quantile helper that accepted an externally-supplied starting point. The two available helpers were both wrong for the infinite-support discrete case:
+
+- `_qEstimateTable` — hardwired expansion from `k=0` upward; incorrect for negative support.
+- `_qEstimateRoot` — designed for continuous distributions with random bracket initialisation; can return `undefined` on infinite-support inputs.
+
+The missing primitive was a deterministic integer walk anchored at a caller-known point such as the distribution mean.
+
+## Fix
+
+Added `_qEstimateWalk(p, start)` to `src/dist/_distribution.js` (between `_qEstimateTable` and `_qEstimateRoot`). The method takes an integer `start` supplied by the caller and walks toward the infimum quantile:
+
+- If `cdf(start) >= p`: steps down while `cdf(k-1) >= p`.
+- If `cdf(start) < p`: steps up while `cdf(k) < p`.
+
+The exit condition (`cdf(k) >= p && cdf(k-1) < p`) directly encodes the discrete infimum quantile definition — no `ceil`/`floor` correction needed. The method is not wired into the `q()` dispatch; subclasses with a good analytic starting point call it explicitly from their `_q` override (e.g. Skellam can use `floor(μ₁ − μ₂)` as `start`).
+
+## Prevention Strategy
+
+When implementing `_q` for a new discrete distribution with support that includes negative integers or is not anchored at 0:
+
+1. **Do not use `_qEstimateTable`** — it hard-codes its expansion start at `k=0` and is silently wrong for negative support.
+2. **Do not use `_qEstimateRoot`** — it is designed for continuous distributions; its random bracket initialization can fail and return `undefined`, which becomes `NaN` after `Math.floor`.
+3. **Use `_qEstimateWalk(p, floor(mean))`** where `floor(mean)` (or another analytically-known central parameter) is passed as `start`. The walk is O(|start − true_quantile|) steps; a good starting point like the mean keeps it O(σ).
+4. **Guard `p=0` and `p=1` before calling `_qEstimateWalk`** — the public `q()` method already does this, but any `_q` override that calls `_qEstimateWalk` directly should not pass boundary probabilities, as they cause infinite loops (filed as #285).
+
+## Related Solutions
+
+- [`solutions/testing/2026-05-20-0459-discrete-quantile-ceil-minus-one-pattern.md`](../testing/2026-05-20-0459-discrete-quantile-ceil-minus-one-pattern.md) — Documents the `ceil(x)-1` fix for algebraic inverse quantiles and the `_qEstimateRoot` + floor + correction workaround that `_qEstimateWalk` supersedes. Issue #212.
+
+## Key Insight
+
+`_qEstimateTable` is silently broken for any discrete distribution with negative-integer support because it hard-codes its expansion start at `k=0`; use `_qEstimateWalk(p, floor(mean))` instead — it is always deterministic and correct so long as the caller supplies any finite integer near the answer.

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -185,6 +185,32 @@ class Distribution {
   }
 
   /**
+   * Estimates the quantile function using a deterministic linear walk from a caller-supplied start.
+   * Walks toward the infimum quantile until cdf(k) >= p and cdf(k-1) < p.
+   *
+   * @method _qEstimateWalk
+   * @memberof ran.dist.Distribution
+   * @param {number} p Probability to find value for.
+   * @param {number} start Integer to start the walk from.
+   * @returns {number} The smallest integer k such that F(k) >= p and F(k-1) < p.
+   * @protected
+   * @ignore
+   */
+  _qEstimateWalk (p, start) {
+    let k = start
+    if (this.cdf(k) >= p) {
+      while (this.cdf(k - 1) >= p) {
+        k--
+      }
+    } else {
+      while (this.cdf(k) < p) {
+        k++
+      }
+    }
+    return k
+  }
+
+  /**
    * Estimates the quantile function by solving F(x) = p using Brent's method.
    *
    * @method _qEstimateRoot

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -184,6 +184,8 @@ class Distribution {
     }
   }
 
+  // _qEstimateTable is broken for negative-integer support (hardwired start at k=0); use this instead.
+  // See solutions/algorithm/2026-05-20-0647-q-estimate-walk-infinite-support-discrete.md
   /**
    * Estimates the quantile function using a deterministic linear walk from a caller-supplied start.
    * Walks toward the infimum quantile until cdf(k) >= p and cdf(k-1) < p.

--- a/test/dist.js
+++ b/test/dist.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai'
-import { describe, it } from 'mocha'
+import { before, describe, it } from 'mocha'
 import { adTest, chiTest, Tests, checkRefVals, checkQuantileVals } from './test-utils'
 import { float } from '../src/core'
 import * as dist from '../src/dist'
@@ -402,6 +402,32 @@ describe('dist', () => {
       it('should return 1 at the open lower boundary x = 0', () => {
         assert.equal(k.survival(0), 1)
       })
+    })
+  })
+
+  // Base class helper: _qEstimateWalk.
+  describe('Distribution._qEstimateWalk', () => {
+    // Poisson(5) reference values:
+    //   ppf(0.1) = 2   cdf(2)=0.12465  cdf(1)=0.04043
+    //   ppf(0.5) = 5   cdf(5)=0.61596  cdf(4)=0.44049
+    //   ppf(0.9) = 8   cdf(8)=0.93191  cdf(7)=0.86663
+    let d
+    before(() => { d = new dist.Poisson(5) })
+
+    it('should walk up from a start below the quantile', () => {
+      assert.strictEqual(d._qEstimateWalk(0.9, 0), 8)
+    })
+
+    it('should walk down from a start above the quantile', () => {
+      assert.strictEqual(d._qEstimateWalk(0.1, 20), 2)
+    })
+
+    it('should return immediately when start already satisfies the invariant', () => {
+      assert.strictEqual(d._qEstimateWalk(0.5, 5), 5)
+    })
+
+    it('should walk up from a negative start', () => {
+      assert.strictEqual(d._qEstimateWalk(0.5, -10), 5)
     })
   })
 


### PR DESCRIPTION
Closes #284

## Summary
- Adds `_qEstimateWalk(p, start)` protected helper to the `Distribution` base class, positioned between `_qEstimateTable` and `_qEstimateRoot`.
- The walk is deterministic: starting from a caller-supplied integer `start`, it steps down while `cdf(k-1) >= p` or steps up while `cdf(k) < p`, exiting when the infimum invariant `cdf(k) >= p && cdf(k-1) < p` holds exactly — no `floor`/`ceil` correction needed.
- Needed because `_qEstimateTable` hard-codes its expansion start at `k=0` (silently wrong for negative-integer support) and `_qEstimateRoot` uses random bracket initialisation (can return `undefined`/`NaN` for extreme probabilities on infinite-support distributions like Skellam).

## Design decisions

No ADR — `_qEstimateWalk` is `@protected @ignore`, not part of the public API. The algorithm is fully specified by the issue acceptance criteria.

## Non-trivial changes

- **`src/dist/_distribution.js:187–213`**: New `_qEstimateWalk(p, start)` method. Key correctness property: the method calls `this.cdf()` (not `this._cdf()`) so out-of-support inputs are clamped correctly during the walk, and the loop terminates naturally when `k` descends past the closed lower bound (where `cdf` returns 0). Not wired into `q()` dispatch — must be called explicitly from subclass `_q` overrides.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: 4 unit tests for `_qEstimateWalk` (walk-up, walk-down, at-boundary, negative-start) using Poisson(5) reference values; `before` added to mocha imports.
- **`CHANGELOG.md`**: Added entry under `[Unreleased] → Added`.
- **`solutions/algorithm/2026-05-20-0647-q-estimate-walk-infinite-support-discrete.md`**: Solution document capturing the root cause and prevention strategy for future sessions.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_016CCAxidbTKaxXoS93wRGrC)_