### PR TITLE
Fix _qEstimateWalk infinite loop at p=0 and p=1 boundary

### DIFF
--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -188,7 +188,8 @@ class Distribution {
   // See solutions/algorithm/2026-05-20-0647-q-estimate-walk-infinite-support-discrete.md
   /**
    * Estimates the quantile function using a deterministic linear walk from a caller-supplied start.
-   * Walks toward the infimum quantile until cdf(k) >= p and cdf(k-1) < p.
+   * When p=0 returns the lower support bound; when p=1 returns the upper support bound.
+   * For 0 < p < 1, walks toward the infimum quantile until cdf(k) >= p and cdf(k-1) < p.
    *
    * @method _qEstimateWalk
    * @memberof ran.dist.Distribution
@@ -199,6 +200,12 @@ class Distribution {
    * @ignore
    */
   _qEstimateWalk (p, start) {
+    if (p === 0) {
+      return this.s[0].value
+    }
+    if (p === 1) {
+      return this.s[1].value
+    }
     let k = start
     if (this.cdf(k) >= p) {
       while (this.cdf(k - 1) >= p) {

--- a/test/dist.js
+++ b/test/dist.js
@@ -429,6 +429,14 @@ describe('dist', () => {
     it('should walk up from a negative start', () => {
       assert.strictEqual(d._qEstimateWalk(0.5, -10), 5)
     })
+
+    it('should return lower support boundary when p=0', () => {
+      assert.strictEqual(d._qEstimateWalk(0, 5), 0)
+    })
+
+    it('should return upper support boundary when p=1', () => {
+      assert.strictEqual(d._qEstimateWalk(1, 5), Infinity)
+    })
   })
 
   // Degenerate distribution.


### PR DESCRIPTION
Closes #285

## Summary
- `_qEstimateWalk` had no guard against boundary probabilities: calling it with `p=0` on a closed-lower-support distribution, or `p=1` on an infinite-upper-support distribution, caused an infinite loop that hung the process.
- Fixed by adding two early-return guards at the top of the method: `p === 0` returns `this.s[0].value`, `p === 1` returns `this.s[1].value`.

## Non-trivial changes
- **`src/dist/_distribution.js`**: Behavioral change — `_qEstimateWalk` now returns the support boundary immediately for `p=0`/`p=1` instead of entering a non-terminating walk. The public `q()` method already guards these boundary values before dispatching, so this fix is defensive but closes a latent hang for any direct caller.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/_distribution.js`**: JSDoc updated to document the p=0/p=1 boundary returns.
- **`test/dist.js`**: Two new tests for the boundary cases added to the existing `_qEstimateWalk` describe block.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfc76VeEqCFbAADJii4aiK)_