### PR TITLE
Deprecate Hoyt as misnamed Nakagami alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Skellam._q` applied `Math.floor` to the result of `_qEstimateRoot`, which finds a continuous root of `CDF(x) − p`. For a step function the root lands just below the integer boundary, causing `Math.floor` to undershoot by 1. Added a one-step correction: `if (this.cdf(k) < p) k++`. Closes #212.
 - `Skellam._q` could silently return `NaN` in the extreme tails: `_qEstimateRoot` uses a random bracket initialisation and returns `undefined` when its 100-iteration cap is exhausted, and `Math.floor(undefined)` is `NaN`. Replaced with `_qEstimateWalk(p, Math.floor(μ₁ − μ₂))`, anchored at the distribution mean; the walk is fully deterministic and always returns a valid integer. Closes #283.
 
+### Deprecated
+
+- `ran.dist.Hoyt` is deprecated. It was implementing the Nakagami-m distribution under the wrong name; `ran.dist.Nakagami` is the canonical, correctly-named class. `new Hoyt(q, omega)` now emits a `console.warn` and delegates entirely to `Nakagami(q, omega)`. The parameter constraint changes from `0 < q ≤ 1` to `q ≥ 0.5` (the Nakagami-m domain); computed values are identical for all previously valid `q ∈ [0.5, 1]`. `Hoyt` will be removed in a future major release. Closes #226.
+
 ### Added
 
 - `Distribution._qEstimateWalk(p, start)` protected helper: deterministic linear walk from a caller-supplied integer start toward the infimum discrete quantile. Exits when `cdf(k) >= p` and `cdf(k-1) < p`. Provides a non-random alternative to `_qEstimateRoot` for infinite-support discrete distributions with analytically-known parameters. Closes #284.

--- a/dist/ranjs.d.ts
+++ b/dist/ranjs.d.ts
@@ -103,6 +103,7 @@ declare module 'ranjs' {
     class HalfLogistic extends Distribution { constructor() }
     class HalfNormal extends Distribution { constructor(sigma: number) }
     class HeadsMinusTails extends Distribution { constructor(n: number) }
+    /** @deprecated Use `ran.dist.Nakagami` instead. */
     class Hoyt extends Distribution { constructor(q: number, omega: number) }
     class HyperbolicSecant extends Distribution { constructor() }
     class Hyperexponential extends Distribution { constructor(parameters: Array<{ weight: number; rate: number }>) }

--- a/docs/index.js
+++ b/docs/index.js
@@ -59,7 +59,8 @@ function parseEntry (entry) {
     examples: entry.examples.length > 0
       ? hljs.highlight(entry.examples[0].description, { language: 'javascript' }).value
       : undefined,
-    sees: entry.sees.length > 0 ? entry.sees.map(SeesParser) : undefined
+    sees: entry.sees.length > 0 ? entry.sees.map(SeesParser) : undefined,
+    deprecated: entry.deprecated ? DescParser({ description: entry.deprecated }) : undefined
   }
 }
 

--- a/docs/styles/card.scss
+++ b/docs/styles/card.scss
@@ -19,6 +19,32 @@
     }
   }
 
+  &.deprecated .title {
+    border-left-color: darkorange;
+  }
+
+  .deprecated-banner {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 8px 0;
+    margin-top: 10px;
+
+    .deprecated-label {
+      font-weight: bold;
+      color: darkorange;
+      font-family: 'Courier', monospace;
+      font-size: 0.85em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    .deprecated-message {
+      color: #666;
+      font-size: 0.9em;
+    }
+  }
+
   .desc {
     margin-top: 10px;
     margin-bottom: 20px;

--- a/docs/templates/index.pug
+++ b/docs/templates/index.pug
@@ -36,7 +36,11 @@ block content
 
     h1 documentation
     each entry in api
-        .card
+        .card(class=entry.deprecated ? 'deprecated' : '')
+            if entry.deprecated
+                .deprecated-banner.margined
+                    span.deprecated-label Deprecated
+                    span.deprecated-message !{entry.deprecated}
             pre.title(id="" + entry.index) #{entry.signature}
             .desc.margined !{entry.desc}
             if entry.params

--- a/src/dist/hoyt.js
+++ b/src/dist/hoyt.js
@@ -1,65 +1,27 @@
-import { gammaLowerIncomplete, logGamma } from '../special'
-import gamma from './_gamma'
-import Distribution from './_distribution'
+import Nakagami from './nakagami'
 
 /**
- * Generator for the [Hoyt distribution]{@link https://en.wikipedia.org/wiki/Nakagami_distribution} (also known as
- * Nakagami-q distribution):
+ * @deprecated `ran.dist.Hoyt` is a misnamed alias for the Nakagami distribution. Use
+ * `ran.dist.Nakagami` instead. This class will be removed in a future major release.
  *
- * $$f(x; q, \omega) = \frac{2q^q}{\Gamma(q) \omega^q} x^{2q - 1} e^{-\frac{q}{\omega} x^2},$$
+ * Generator for the [Nakagami distribution]{@link https://en.wikipedia.org/wiki/Nakagami_distribution}
+ * (previously mis-labelled as the Hoyt distribution):
  *
- * where $q \in (0, 1]$ and $\omega > 0$. Support: $x > 0$.
+ * $$f(x; m, \omega) = \frac{2m^m}{\Gamma(m) \omega^m} x^{2m - 1} e^{-\frac{m}{\omega} x^2},$$
+ *
+ * where $m \ge 0.5$ and $\omega > 0$. Support: $x > 0$.
  *
  * @class Hoyt
  * @memberof ran.dist
- * @param {number=} q Shape parameter. Default value is 0.5.
+ * @param {number=} q Shape parameter (same as m in Nakagami). Default value is 0.5.
  * @param {number=} omega Spread parameter. Default value is 1.
- * @see https://en.wikipedia.org/wiki/Nakagami_distribution
+ * @see ran.dist.Nakagami
  * @constructor
  */
-export default class extends Distribution {
+export default class Hoyt extends Nakagami {
   constructor (q, omega) {
-    super('continuous', arguments.length)
-
-    // Validate parameters
-    this.p = { q, omega }
-    Distribution.validate({ q, omega }, [
-      'q > 0', 'q <= 1',
-      'omega > 0'
-    ])
-
-    // Set support
-    this.s = [{
-      value: 0,
-      closed: true
-    }, {
-      value: Infinity,
-      closed: false
-    }]
-
-    // Speed-up constants
-    this.c = [
-      2 * Math.pow(this.p.q, this.p.q) / Math.pow(this.p.omega, this.p.q)
-    ]
-  }
-
-  _generator () {
-    // Direct sampling from gamma
-    return Math.sqrt(gamma(this.r, this.p.q, this.p.q / this.p.omega))
-  }
-
-  _pdf (x) {
-    const z = Math.pow(x, 2 * this.p.q - 1)
-
-    // Handle q < 0.5 and x << 0 case
-    if (!Number.isFinite(z)) {
-      return 0
-    } else {
-      return 2 * Math.exp(this.p.q * Math.log(this.p.q) - this.p.q * x * x / this.p.omega - logGamma(this.p.q) - this.p.q * Math.log(this.p.omega)) * z
-    }
-  }
-
-  _cdf (x) {
-    return gammaLowerIncomplete(this.p.q, this.p.q * x * x / this.p.omega)
+    // Hoyt was implementing Nakagami-m under the wrong name; warn before full removal
+    console.warn('ran.dist.Hoyt is deprecated and will be removed in a future major release; use ran.dist.Nakagami instead.')
+    super(q, omega)
   }
 }

--- a/src/dist/hoyt.js
+++ b/src/dist/hoyt.js
@@ -1,9 +1,6 @@
 import Nakagami from './nakagami'
 
 /**
- * @deprecated `ran.dist.Hoyt` is a misnamed alias for the Nakagami distribution. Use
- * `ran.dist.Nakagami` instead. This class will be removed in a future major release.
- *
  * Generator for the [Nakagami distribution]{@link https://en.wikipedia.org/wiki/Nakagami_distribution}
  * (previously mis-labelled as the Hoyt distribution):
  *
@@ -15,6 +12,7 @@ import Nakagami from './nakagami'
  * @memberof ran.dist
  * @param {number=} q Shape parameter (same as m in Nakagami). Default value is 0.5.
  * @param {number=} omega Spread parameter. Default value is 1.
+ * @deprecated Use [ran.dist.Nakagami]{@link ran.dist.Nakagami} instead. This class will be removed in a future major release.
  * @see ran.dist.Nakagami
  * @constructor
  */

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -992,26 +992,26 @@ export default [{
   name: 'Hoyt',
   invalidParams: [
     [], // all params required
-    [-1, 1], [0, 1], [2, 1], // 0 < q <= 1
+    [-1, 1], [0, 1], [0.25, 1], // q >= 0.5 (delegates to Nakagami)
     [0.5, -1], [0.5, 0] // omega > 0
   ],
   cases: [{
-    name: 'q < 0.5',
-    params: () => [0.25, 2]
-  }, {
-    name: 'normal q',
+    name: 'q at boundary',
     params: () => [0.5, 2]
+  }, {
+    name: 'q > 1 (previously invalid)',
+    params: () => [2, 1]
   }],
-  // any interior q exercises the same Gamma-variate sampler (sqrt(Gamma(q, q/omega))); no q-value branch exists in _generator
-  sampleParams: [{ name: 'normal q', params: () => [0.5, 2] }],
-  // ranjs's Hoyt impl is Nakagami-m with m=q (class is misnamed); refs via scipy.stats.nakagami
+  // delegates to Nakagami; sampler is sqrt(Gamma(q, q/omega))
+  sampleParams: [{ name: 'q at boundary', params: () => [0.5, 2] }],
+  // deprecated alias for Nakagami; case 1: scipy.stats.nakagami(nu=0.5, loc=0, scale=sqrt(2)); case 2: scipy.stats.nakagami(nu=2, loc=0, scale=1/sqrt(2))
   refVals: [
-    { x: 0.1, pdf: 1.0359375032184368, cdf: 0.2073948032927819 },
-    { x: 0.5, pdf: 0.4495931846212488, cdf: 0.460990635130189 },
-    { x: 1, pdf: 0.2894607037402299, cdf: 0.6401572060830842 },
-    { x: 1.5, pdf: 0.20215545797877604, cdf: 0.7615574091542903 },
-    { x: 2, pdf: 0.14067411288159118, cdf: 0.8464864041916776 },
-    { x: 4, pdf: 0.022195118312496324, cdf: 0.9827139881404833 }
+    { x: 0.1, pdf: 0.5627808712129855, cdf: 0.056371977797014215 },
+    { x: 0.5, pdf: 0.5300070646880344, cdf: 0.276326390168225 },
+    { x: 1, pdf: 0.4393912894677035, cdf: 0.5204998778130242 },
+    { x: 1.5, pdf: 0.32146553459758986, cdf: 0.7111556336534848 },
+    { x: 2, pdf: 0.20755374871028842, cdf: 0.8427007929496787 },
+    { x: 4, pdf: 0.010333492677045582, cdf: 0.9953222650189529 }
   ]
 }, {
   name: 'HyperbolicSecant',

--- a/todo.md
+++ b/todo.md
@@ -177,6 +177,14 @@ Continuous distribution on [0, 1] whose PDF involves the Gauss hypergeometric fu
 - **Dependency:** `hypergeometric.js` must implement ₂F₁ accurately for |z| < 1
 - Refs: [scipy `gausshyper`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gausshyper.html)
 
+#### Hoyt (Nakagami-q)
+The classical Hoyt distribution — not to be confused with `ran.dist.Hoyt`, which was a misnamed alias for the Nakagami-m distribution and has been deprecated (see #226). The true Hoyt (Nakagami-q) PDF contains a modified Bessel function I₀ and is a distinct family used in fading-channel modelling.
+- **PDF:** f(x; q, ω) = 2(1+q²)x / (qω) · exp(−(1+q²)²x²/(4q²ω)) · I₀((1−q⁴)x²/(4q²ω)),  q ∈ (0, 1], ω > 0, x ≥ 0
+- **CDF:** no elementary closed form; expressible via the Marcum Q-function: F(x) = 1 − Q₁(a·x, b·x) where a and b are functions of q and ω
+- **Sampling:** rejection sampling against a Rayleigh envelope, or inversion via Brent root-finding on the Marcum Q CDF
+- **Dependency:** `bessel.js` (I₀ — already present); `marcum-q.js` (marcumQ — already present)
+- Refs: [Wikipedia — Hoyt distribution](https://en.wikipedia.org/wiki/Hoyt_distribution); Simon, M.K. (2002) "A new twist on the Marcum Q-function and its application", *IEEE Commun. Lett.* 2(2):39–41
+
 #### Wrapped Cauchy
 Heavy-tailed circular distribution on [−π, π); the stereographic projection of a Cauchy distribution onto the circle. Used in wind direction modelling, paleomagnetism, and neuroscience (head direction cells). The only other circular distribution in the library is `VonMises`.
 - **PDF:** f(θ; μ, ρ) = (1/(2π)) · (1−ρ²) / (1 + ρ² − 2ρ·cos(θ−μ)),  ρ ∈ (0,1)


### PR DESCRIPTION
Closes #226

> **⚠ Missing ADR**: This PR contains a behavioral API change (parameter constraint and deprecation) but no Architecture Decision Record was found. Consider adding one at `decisions/` to document the rationale for the deprecation strategy. See `decisions/0000-template.md` for the format.

## Summary
- `hoyt.js` was implementing the Nakagami-m distribution under the wrong name; `nakagami.js` already exists as the correctly-named class
- `Hoyt` now extends `Nakagami` and emits a `console.warn` on every instantiation, giving users one release cycle of notice before removal
- Parameter constraint relaxed from `0 < q ≤ 1` to `q ≥ 0.5` (the true Nakagami-m domain); computed values are identical for all previously valid `q ∈ [0.5, 1]`

## Non-trivial changes
- **`src/dist/hoyt.js`**: Rewritten from a standalone Nakagami-m implementation to a deprecated delegation shim extending `Nakagami`. Emits `console.warn` in constructor. The upper-bound constraint `q ≤ 1` is removed (was artificial — Nakagami-m is defined for all `m ≥ 0.5`); the lower-bound constraint `q > 0` is tightened to `q ≥ 0.5` (now enforced by `Nakagami`'s validation).
- **`test/dist-cases-continuous.js`**: `invalidParams` updated to reflect new constraints (`[2, 1]` removed — no longer invalid; `[0.25, 1]` added — now invalid). A second `cases` entry (`q=2, omega=1`) added to prove `q > 1` is accepted. `refVals` corrected from the `q=0.25` parameterisation (was the first case) to `q=0.5` (now the first and reference case).

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`dist/ranjs.d.ts`**: `/** @deprecated */` JSDoc comment added above the `Hoyt` class declaration
- **`CHANGELOG.md`**: `### Deprecated` section added with full description of the constraint change and removal timeline

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCgAwdPn7rZcfBx8MBCix9)_