### PR TITLE
Fix Lindley parameter count and add AIC/BIC regression tests

### DIFF
--- a/src/dist/lindley.js
+++ b/src/dist/lindley.js
@@ -16,7 +16,7 @@ import { lambertW1m } from '../special'
  */
 export default class extends Distribution {
   constructor (theta) {
-    super('continuous', arguments.length)
+    super('continuous', 1)
 
     // Validate parameters
     this.p = { theta }

--- a/test/dist.js
+++ b/test/dist.js
@@ -467,4 +467,29 @@ describe('dist', () => {
       })
     })
   })
+
+  // Lindley: AIC/BIC parameter-count regression — this.k must be 1 so the penalty is not silently dropped.
+  // Guard against reverting super('continuous', 1) back to super('continuous', arguments.length),
+  // which would set k=0 if a default were ever reintroduced to the constructor.
+  describe('Lindley', () => {
+    const sample = [0.1, 0.5, 1.0, 1.5, 2.0, 0.3, 0.8, 1.2, 2.5, 0.6]
+    const d = new dist.Lindley(1)
+
+    it('should throw when constructed without arguments', () => {
+      assert.throws(() => new dist.Lindley())
+    })
+
+    it('should have paramCount k=1', () => {
+      assert.strictEqual(d.k, 1)
+    })
+
+    it('aic() should include the parameter penalty (k=1)', () => {
+      // AIC = 2*(k - lnL); with k=1 the penalty is 2. k=0 would make aic() return a lower value.
+      assert.strictEqual(d.aic(sample), 2 * (1 - d.lnL(sample)))
+    })
+
+    it('bic() should include the parameter penalty (k=1)', () => {
+      assert.strictEqual(d.bic(sample), Math.log(sample.length) * 1 - 2 * d.lnL(sample))
+    })
+  })
 })


### PR DESCRIPTION
Closes #291

## Summary
- Hardcodes `super('continuous', 1)` in the Lindley constructor instead of `super('continuous', arguments.length)`, ensuring `this.k` is always 1 regardless of how the constructor is invoked
- Adds 4 targeted regression tests in `test/dist.js` to guard against future regression of the AIC/BIC parameter penalty

## Non-trivial changes
- **`src/dist/lindley.js`**: `arguments.length` returned 0 whenever a JS default parameter was in effect, silently setting `k=0` and dropping the parameter penalty from AIC and BIC. Hardcoding `1` (the true parameter count for this single-parameter distribution) makes this immune to future constructor signature changes.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Four regression assertions added for Lindley AIC/BIC parameter-count correctness

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01K99N8ueGcUPTrX8TYANAaB)_