### PR TITLE
Fix catastrophic cancellation in BenktanderII._cdf near x=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `BenktanderII._cdf` lost precision near the lower support boundary (x ≈ 1) due to catastrophic cancellation in `1 − exp(arg)` and `1 − xᵇ⁻¹·exp(u)` when their arguments approach zero. Rewrote using `Math.expm1` for the b=1 branch and a split `(1−xᵇ⁻¹) − xᵇ⁻¹·expm1(u)` decomposition for the general branch, eliminating the cancellation. Closes #242.
 - `Bernoulli._q` returned `0` for all `p > 0.5` because `this.p.p` is `undefined` after the `Categorical` parent constructor overwrites `this.p` with `{ n, weights, min }`. Fixed by using `this.p.weights[0]` (the CDF at k=0) as the threshold. Closes #212.
 - `DiscreteUniform._q`, `Geometric._q`, and `DiscreteWeibull._q` returned a quantile one too large when `p` landed exactly on a CDF step (e.g., `Geometric(0.5).q(0.5)` returned `1` instead of `0`). Each used `Math.floor` on the algebraic inverse `k+1`; changed to `Math.ceil(…) - 1` which is identical for non-integer arguments but correct at exact integers. Closes #212.
 - `Skellam._q` applied `Math.floor` to the result of `_qEstimateRoot`, which finds a continuous root of `CDF(x) − p`. For a step function the root lands just below the integer boundary, causing `Math.floor` to undershoot by 1. Added a one-step correction: `if (this.cdf(k) < p) k++`. Closes #212.

--- a/src/dist/benktander-ii.js
+++ b/src/dist/benktander-ii.js
@@ -64,11 +64,20 @@ export default class extends Distribution {
   _cdf (x) {
     // b = 1
     if (this.c[4]) {
-      return 1 - Math.exp(this.p.a * (1 - x))
+      // expm1 avoids 1 - exp(arg) cancellation when arg → 0 near x = 1
+      return -Math.expm1(this.p.a * (1 - x))
     }
 
     // All other cases
-    return 1 - Math.pow(x, this.p.b - 1) * Math.exp(this.p.a * (1 - Math.pow(x, this.p.b)) / this.p.b)
+    // Split 1 - xbm1*exp(u) as (1 - xbm1) + xbm1*(1 - exp(u)) to avoid
+    // 1 - 1 cancellation when both factors approach 1 near x = 1;
+    // xbm1 = xb/x reuses the already-computed xb and avoids a second Math.pow;
+    // using the same xbm1 in both terms guarantees (1-xbm1)+xbm1 = 1 at large x
+    // where expm1(u) collapses to -1
+    const xb = Math.pow(x, this.p.b)
+    const u = this.p.a * (1 - xb) / this.p.b
+    const xbm1 = xb / x
+    return (1 - xbm1) - xbm1 * Math.expm1(u)
   }
 
   _q (p) {

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -141,7 +141,10 @@ export default [{
     { name: 'unit shape parameter', params: () => [2, 1] }
   ],
   // mpmath: BenktanderII PDF/CDF formula with a=2, b=0.9995 @ 50 dps
+  // Boundary values (x near 1): Python Decimal @ 60 dps, a=2, b=0.9995
   refVals: [
+    { x: 1.000001, pdf: 2.0004959965037585, cdf: 2.000497998251211222e-6 },
+    { x: 1.0001, pdf: 2.0000996900573424, cdf: 0.00020002998383485039863 },
     { x: 1.001, pdf: 1.996500505574631, cdf: 0.001998499585372714 },
     { x: 1.01, pdf: 1.960863182279961, cdf: 0.01980615448460798 },
     { x: 1.1, pdf: 1.6376855076637271, cdf: 0.18130429928524164 },


### PR DESCRIPTION
Closes #242

## Summary
- `BenktanderII._cdf` lost precision near x=1 due to `1 − exp(arg)` and `1 − xᵇ⁻¹·exp(u)` evaluating as `1 − 1` when their arguments approach zero.
- Fixed the b=1 branch with the identity `1 − eᵗ = −expm1(t)`; fixed the general branch by splitting into `(1−xbm1) − xbm1·expm1(u)`, which keeps both subtracted terms away from cancellation.
- Used `xbm1 = xb/x` (reuses the already-computed `xb`) instead of a second `Math.pow`, eliminating one transcendental call while preserving the algebraic guarantee `(1−xbm1)+xbm1 = 1` at large x where `expm1(u)` collapses to −1 exactly.

## Non-trivial changes
- **`src/dist/benktander-ii.js`**: Both `_cdf` branches rewritten to use `Math.expm1`. The general branch additionally replaces `Math.pow(x, b−1)` with `xb/x` and uses a consistent `xbm1` in both terms — this is required to prevent non-monotonicity at large x (tested and confirmed).

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Entry added under `[Unreleased] → Fixed`
- **`test/dist-cases-continuous.js`**: Two boundary refVal entries added at x=1+1e-6 and x=1+1e-4 (independently verified via Python Decimal @ 60 dps)

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_015DjiCHhgNyyCjZTPcVC6rU)_