### PR TITLE
Add besselI odd-symmetry regression tests for n ≥ 3; tighten pipeline continuation rules

### DIFF
--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -78,9 +78,11 @@ git diff main --name-only | grep '\.js$'
 
 ### 7. Ship (fully autonomous)
 
+Invoke all three sub-skills in sequence **without any pause or output between them**. As soon as one returns, invoke the next immediately. Do not generate any text between steps — no confirmation prompts, no interim status messages. Proceed directly to step 8 only after all three have completed.
+
 a. **Commit** — invoke `/commit`
-b. **Push** — invoke `/push`
-c. **Pull Request** — invoke `/pull-request`
+b. **Push** — invoke `/push` immediately after `/commit` returns
+c. **Pull Request** — invoke `/pull-request` immediately after `/push` returns
 
 ### 8. Report
 

--- a/.claude/skills/hotfix/SKILL.md
+++ b/.claude/skills/hotfix/SKILL.md
@@ -82,9 +82,11 @@ Invoke `/review` via the Skill tool.
 
 ### 7. Ship (fully autonomous)
 
+Invoke all three sub-skills in sequence **without any pause or output between them**. As soon as one returns, invoke the next immediately. Do not generate any text between steps — no "committing now", no "pushing...", no confirmation prompts. Proceed directly to step 8 only after all three have completed.
+
 a. **Commit** — invoke `/commit`
-b. **Push** — invoke `/push`
-c. **Pull Request** — invoke `/pull-request`
+b. **Push** — invoke `/push` immediately after `/commit` returns
+c. **Pull Request** — invoke `/pull-request` immediately after `/push` returns
 
 ### 8. Report
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ The skill pushes `v{version}` which triggers `.github/workflows/release.yml` (li
 - When editing multiple files, make all independent edits in parallel.
 - When performing multi-step tasks, show a progress list with checkboxes (e.g., `- [x]` done, `- [ ]` pending) and update it as you go.
 - **Always use selectable options** (via the `AskUserQuestion` tool) when asking the user to make a choice or design decision during planning or implementation. Never ask the user to type their choice as free text. Always include a final option labeled "Other" or "Type something" so the user can provide a custom answer if none of the options fit.
-- **Never stop mid-pipeline.** When a sub-skill (`/commit`, `/push`, `/pull-request`, etc.) is invoked from within a parent skill (`/hotfix`, `/build`, `/implement`, etc.), continue executing the parent workflow immediately after the sub-skill returns. Do not pause for user input between steps unless the parent skill explicitly requires it.
+- **Never stop mid-pipeline.** When a sub-skill (`/commit`, `/push`, `/pull-request`, etc.) is invoked from within a parent skill (`/hotfix`, `/build`, `/implement`, etc.), continue executing the parent workflow immediately after the sub-skill returns. Do not pause for user input between steps unless the parent skill explicitly requires it. Do not output text that implies completion (e.g. "Done!", "Committed!") between steps — save all status reporting for the parent skill's final report.
 
 ## Code Style
 

--- a/test/special.js
+++ b/test/special.js
@@ -65,6 +65,17 @@ describe('special', () => {
       })
     })
 
+    it('In(-x) should be equal to -In(x) for odd n >= 3', () => {
+      // Regression for the backward-recurrence sign bug fixed in #255: abs(x) with no sign
+      // correction caused I_n(-x) != -I_n(x) for odd n >= 3
+      repeat(() => {
+        const x = 1 + 10 * Math.random()
+        assert(equal(special.besselI(3, -x), -special.besselI(3, x)))
+        assert(equal(special.besselI(5, -x), -special.besselI(5, x)))
+        assert(equal(special.besselI(7, -x), -special.besselI(7, x)))
+      })
+    })
+
     it('I1(x) should match scipy reference values', () => {
       // scipy.stats cross-validation; these were the values broken by the old _I1 polynomial
       assert(equal(special.besselI(1, 2), 1.590636854637329))


### PR DESCRIPTION
Closes #297

## Summary
- Adds a regression test asserting `I_n(-x) = -I_n(x)` for odd n ∈ {3, 5, 7} over random positive x, guarding against reintroduction of the backward-recurrence sign bug fixed in #255
- Strengthens the "never stop mid-pipeline" rule in `CLAUDE.md` and the Ship steps in `hotfix` and `fix` skills to explicitly prohibit interim output between sub-skills
- No production code changes

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/special.js`**: regression test for `besselI` odd-symmetry identity, n ∈ {3, 5, 7}
- **`CLAUDE.md`**: extended pipeline-continuation rule to prohibit interim status text between sub-skill steps
- **`.claude/skills/hotfix/SKILL.md`**: Step 7 now requires invoking all three ship sub-skills without pause or output between them
- **`.claude/skills/fix/SKILL.md`**: same treatment as hotfix

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*