### PR TITLE
Replace sadists vignette links with primary references in doubly non-central distributions

### DIFF
--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -6,11 +6,12 @@ import noncentralChi2 from './_noncentral-chi2'
 import Distribution from './_distribution'
 
 /**
- * Generator for the [doubly non-central beta distribution]{@link https://rdrr.io/cran/sadists/f/inst/doc/sadists.pdf}:
+ * Generator for the [doubly non-central beta distribution]{@link https://arxiv.org/abs/1706.08557}:
  *
  * $$f(x; \alpha, \beta, \lambda_1, \lambda_2) = e^{-\frac{\lambda_1 + \lambda_2}{2}} \sum\_{k = 0}^\infty \sum\_{l = 0}^\infty \frac{\big(\frac{\lambda_1}{2}\big)^k}{k!} \frac{\big(\frac{\lambda_2}{2}\big)^l}{l!} \frac{x^{\alpha + k - 1} (1 - x)^{\beta + l - 1}}{\mathrm{B}\big(\alpha + k, \beta + l\big)},$$
  *
  * where $\alpha, \beta > 0$ and $\lambda_1, \lambda_2 \ge 0$. Support: $x \in (0, 1)$.
+ * Formula from C. Orsi. New insights into non-central beta distributions. arXiv:1706.08557, 2017, Eq. (21).
  *
  * @class DoublyNoncentralBeta
  * @memberof ran.dist
@@ -18,7 +19,7 @@ import Distribution from './_distribution'
  * @param {number=} beta Second shape parameter. Default value is 1.
  * @param {number=} lambda1 First non-centrality parameter. Default value is 1.
  * @param {number=} lambda2 Second non-centrality parameter. Default value is 1.
- * @see https://rdrr.io/cran/sadists/f/inst/doc/sadists.pdf
+ * @see https://arxiv.org/abs/1706.08557
  * @constructor
  */
 export default class extends Distribution {

--- a/src/dist/doubly-noncentral-chi2.js
+++ b/src/dist/doubly-noncentral-chi2.js
@@ -3,11 +3,12 @@ import noncentralChi2 from './_noncentral-chi2'
 import Distribution from './_distribution'
 
 /**
- * Generator for the [doubly non-central $\chi^2$ distribution]{@link https://rdrr.io/cran/sadists/f/inst/doc/sadists.pdf}:
+ * Generator for the [doubly non-central $\chi^2$ distribution]{@link https://doi.org/10.1093/biomet/36.1-2.202}:
  *
  * $$f(x; k_1, k_2, \lambda_1, \lambda_2) = e^{-\frac{\lambda_1 + \lambda_2}{2}} \sum\_{j = 0}^\infty \sum\_{l = 0}^\infty \frac{\big(\frac{\lambda_1}{2}\big)^j}{j!} \frac{\big(\frac{\lambda_2}{2}\big)^l}{l!} f_{\chi^2}\big(x; k_1 + k_2 + 2j + 2l\big),$$
  *
  * where $f_{\chi^2}(x; \nu)$ is the central $\chi^2$ density with $\nu$ degrees of freedom, $k_1, k_2 \in \mathbb{N}^+$ and $\lambda_1, \lambda_2 \ge 0$. Support: $x \in [0, \infty)$.
+ * Formula follows from the Poisson-mixture representation of the non-central χ² in P. B. Patnaik. The non-central χ²- and F-distributions and their applications. *Biometrika*, 36(1–2):202–232, 1949.
  *
  * @class DoublyNoncentralChi2
  * @memberof ran.dist
@@ -15,7 +16,7 @@ import Distribution from './_distribution'
  * @param {number=} k2 Second degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 1.
  * @param {number=} lambda1 First non-centrality parameter. Default value is 1.
  * @param {number=} lambda2 Second non-centrality parameter. Default value is 1.
- * @see https://rdrr.io/cran/sadists/f/inst/doc/sadists.pdf
+ * @see https://doi.org/10.1093/biomet/36.1-2.202
  * @constructor
  */
 export default class extends Distribution {

--- a/src/dist/doubly-noncentral-f.js
+++ b/src/dist/doubly-noncentral-f.js
@@ -1,11 +1,12 @@
 import DoublyNoncentralBeta from './doubly-noncentral-beta'
 
 /**
- * Generator for the [doubly non-central F distribution]{@link https://rdrr.io/cran/sadists/f/inst/doc/sadists.pdf}:
+ * Generator for the [doubly non-central F distribution]{@link https://doi.org/10.1111/j.1467-842X.1965.tb00036.x}:
  *
  * $$f(x; d_1, d_2, \lambda_1, \lambda_2) = \frac{d_1}{d_2} e^{-\frac{\lambda_1 + \lambda_2}{2}} \sum\_{k = 0}^\infty \sum\_{l = 0}^\infty \frac{\big(\frac{\lambda_1}{2}\big)^k}{k!} \frac{\big(\frac{\lambda_2}{2}\big)^l}{l!} \frac{\big(\frac{d_1 x}{d_2}\big)^{\frac{d_1}{2} + k - 1}}{\big(1 + \frac{d_1 x}{d_2}\big)^{\frac{d_1 + d_2}{2} + k + l}} \frac{1}{\mathrm{B}\big(\frac{d_1}{2} + k, \frac{d_2}{2} + l\big)},$$
  *
  * where $d_1, d_2 \in \mathbb{N}^+$ and $\lambda_1, \lambda_2 \ge 0$. Support: $x > 0$.
+ * Formula from M. L. Tiku. Series expansions for the doubly non-central F-distribution. *Australian Journal of Statistics*, 7(2):78–89, 1965.
  *
  * @class DoublyNoncentralF
  * @memberof ran.dist
@@ -13,7 +14,7 @@ import DoublyNoncentralBeta from './doubly-noncentral-beta'
  * @param {number=} d2 Second degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
  * @param {number=} lambda1 First non-centrality parameter. Default value is 1.
  * @param {number=} lambda2 Second non-centrality parameter. Default value is 1.
- * @see https://rdrr.io/cran/sadists/f/inst/doc/sadists.pdf
+ * @see https://doi.org/10.1111/j.1467-842X.1965.tb00036.x
  * @constructor
  */
 export default class extends DoublyNoncentralBeta {

--- a/src/dist/doubly-noncentral-t.js
+++ b/src/dist/doubly-noncentral-t.js
@@ -7,7 +7,7 @@ import { acceleratedSum, recursiveSum } from '../algorithms'
 import NoncentralT from './noncentral-t'
 
 /**
- * Generator for the [doubly non-central t distribution]{@link https://cran.r-project.org/web/packages/sadists/sadists.pdf}:
+ * Generator for the [doubly non-central t distribution]{@link https://www.wiley.com/en-us/Intermediate+Probability%3A+A+Computational+Approach-p-9780470026373}:
  *
  * $$f(x; \nu, \mu, \theta) = \frac{e^{-\frac{\theta + \mu^2}{2}}}{\sqrt{\pi \nu}} \sum_{j = 0}^\infty \frac{1}{j!} \frac{(x \mu \sqrt{2 / \nu})^j}{(1 + x^2 / \nu)^{\frac{\nu + j + 1}{2}}} \frac{\Gamma\big(\frac{\nu + j + 1}{2}\big)}{\Gamma\big(\frac{\nu}{2}\big)} {}_1F_1\bigg(\frac{\nu + j + 1}{2}, \frac{\nu}{2}; \frac{\theta}{2 (1 + x^2 / \nu)}\bigg),$$
  *
@@ -19,7 +19,7 @@ import NoncentralT from './noncentral-t'
  * @param {number} nu Degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 1.
  * @param {number} mu Location parameter. Default value is 1.
  * @param {number} theta Shape parameter. Default value is 1.
- * @see https://cran.r-project.org/web/packages/sadists/sadists.pdf
+ * @see https://www.wiley.com/en-us/Intermediate+Probability%3A+A+Computational+Approach-p-9780470026373
  * @constructor
  */
 export default class extends Distribution {


### PR DESCRIPTION
## Summary
- The four doubly non-central distribution JSDoc blocks (`DoublyNoncentralBeta`, `DoublyNoncentralChi2`, `DoublyNoncentralF`, `DoublyNoncentralT`) previously linked to the sadists R package vignette as their formula reference. That vignette lists formulas without derivation and is not a primary source.
- Each `@link` and `@see` URL is now replaced with the actual primary reference for the stated formula, and a prose citation line is added to the description.

## Design decisions

_No ADRs — this is a documentation-only change._

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

| Distribution | New reference |
|---|---|
| `DoublyNoncentralChi2` | Patnaik (1949), *Biometrika* 36(1–2):202–232. [doi:10.1093/biomet/36.1-2.202](https://doi.org/10.1093/biomet/36.1-2.202) |
| `DoublyNoncentralBeta` | Orsi (2017), arXiv:1706.08557, Eq. (21). |
| `DoublyNoncentralF` | Tiku (1965), *Australian Journal of Statistics* 7(2):78–89. [doi:10.1111/j.1467-842X.1965.tb00036.x](https://doi.org/10.1111/j.1467-842X.1965.tb00036.x) |
| `DoublyNoncentralT` | Paolella (2007), *Intermediate Probability*, §10.4.1.2 (already cited in prose; link updated to Wiley page). |

<details>
<summary>Trivial changes</summary>

- **`src/dist/doubly-noncentral-chi2.js`**: `@link`/`@see` replaced with Patnaik (1949) DOI; prose citation added.
- **`src/dist/doubly-noncentral-beta.js`**: `@link`/`@see` replaced with Orsi (2017) arXiv URL; prose citation added.
- **`src/dist/doubly-noncentral-f.js`**: `@link`/`@see` replaced with Tiku (1965) DOI; prose citation added.
- **`src/dist/doubly-noncentral-t.js`**: `@link`/`@see` replaced with Paolella (2007) Wiley page.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_014BKzG2oMjssuUEw2jPiQLD)_