### PR TITLE
Fix DoublyNoncentralBeta NaN when lambda1 or lambda2 is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DoublyNoncentralBeta._pdf` and `._cdf` returned `NaN` when `lambda1` or `lambda2` was 0, because the outward-summation Poisson-weight initialisation evaluated `0 * Math.log(0) = NaN` (IEEE 754). Added early-return guards: when `lambda1 = 0` the double sum collapses to `NoncentralBeta(beta, alpha, lambda2)` at `(1-x)`; when `lambda2 = 0` it collapses to `NoncentralBeta(alpha, beta, lambda1)` at `x`. `DoublyNoncentralF` (which inherits both methods) is fixed implicitly. Closes #304.
+
 - `NoncentralBeta._pdf` and `._cdf` returned `NaN` for `lambda = 0` because the Poisson weight computation evaluated `0 * Math.log(0) = NaN` (IEEE 754). Added a guard: when `lambda / 2 === 0`, the weight for the sole k=0 term is 1. Closes #267.
 
 - `besselI(n=1, x)` had only ~8 significant digits of accuracy due to a polynomial approximation (`_I1`, from Numerical Recipes) with limited-precision coefficients. Replaced with Miller's backward recurrence — the same algorithm used for n≥2 — and extended the loop upper-bound by `⌈2|x|⌉` to ensure the recurrence contracts the K_n component before reaching n=1 (required when |x| > n). Added odd-function sign correction for negative arguments. Fixes ~3.7e-10 CDF error in `VonMises` at intermediate x; expands VonMises refVals from 3 to 11 reference points. Closes #255.

--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -3,6 +3,7 @@ import { recursiveSum } from '../algorithms'
 import { EPS, MAX_ITER } from '../core/constants'
 import { regularizedBetaIncomplete, beta as fnBeta, logGamma } from '../special'
 import noncentralChi2 from './_noncentral-chi2'
+import NoncentralBeta from './noncentral-beta'
 import Distribution from './_distribution'
 
 /**
@@ -59,6 +60,16 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
+    // Poisson weight init r0 * log(l1) = 0 * -Inf = NaN when lambda1 or lambda2 is 0.
+    // When lambda1=0 the double sum collapses to NoncentralBeta(beta, alpha, lambda2) at (1-x).
+    if (this.p.lambda1 === 0) {
+      return new NoncentralBeta(this.p.beta, this.p.alpha, this.p.lambda2)._pdf(1 - x)
+    }
+    // When lambda2=0 the double sum collapses to NoncentralBeta(alpha, beta, lambda1) at x.
+    if (this.p.lambda2 === 0) {
+      return new NoncentralBeta(this.p.alpha, this.p.beta, this.p.lambda1)._pdf(x)
+    }
+
     // Using outward summation
     const y = x / (1 - x)
     const ab = this.p.alpha + this.p.beta
@@ -200,6 +211,15 @@ export default class extends Distribution {
   }
 
   _cdf (x) {
+    // Poisson weight init 0 * log(0) = NaN — same guard as _pdf.
+    // F_DNB(x; a, b, 0, l2) = 1 - F_NB(1-x; b, a, l2) by symmetry of the Beta integral.
+    if (this.p.lambda1 === 0) {
+      return 1 - new NoncentralBeta(this.p.beta, this.p.alpha, this.p.lambda2)._cdf(1 - x)
+    }
+    if (this.p.lambda2 === 0) {
+      return new NoncentralBeta(this.p.alpha, this.p.beta, this.p.lambda1)._cdf(x)
+    }
+
     // Using outward summation
     const r0 = Math.round(this.p.lambda1 / 2)
     const s0 = Math.round(this.p.lambda2 / 2)

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -457,6 +457,19 @@ export default [{
   ],
   cases: [{
     params: () => [2, 2, 2, 2]
+  }, {
+    // Regression: lambda1=0 previously produced NaN via 0*log(0) in Poisson-weight init.
+    // Reduces to NoncentralBeta(beta, alpha, lambda2) at (1-x).
+    name: 'lambda1 = 0',
+    params: () => [2, 2, 0, 2]
+  }, {
+    // Symmetric case: lambda2=0 reduces to NoncentralBeta(alpha, beta, lambda1) at x.
+    name: 'lambda2 = 0',
+    params: () => [2, 2, 2, 0]
+  }, {
+    // Both zero collapses to central Beta(alpha, beta).
+    name: 'both lambdas = 0',
+    params: () => [2, 2, 0, 0]
   }],
   // mpmath: DNCBeta double-Poisson mixture of central Beta @ 50 dps
   refVals: [


### PR DESCRIPTION
Closes #304

## Summary
- `DoublyNoncentralBeta._pdf` and `._cdf` produced `NaN` for valid inputs when `lambda1 = 0` or `lambda2 = 0`, because the outward-summation initialises a Poisson weight via `r0 * Math.log(l1)` — which evaluates to `0 * -Infinity = NaN` (IEEE 754) when the half-parameter `l1 = 0`.
- Added early-return guards in both methods: when `lambda1 = 0` the double sum collapses mathematically to `NoncentralBeta(beta, alpha, lambda2)` evaluated at `(1-x)`; when `lambda2 = 0` it collapses to `NoncentralBeta(alpha, beta, lambda1)` at `x`. Both identities follow from the Beta integral symmetry `B(a,b) = B(b,a)`.
- `DoublyNoncentralF` (which inherits both methods) is fixed implicitly. Three regression test cases added to `DoublyNoncentralBeta` covering `lambda1=0`, `lambda2=0`, and `both=0`.

## Non-trivial changes
- **`src/dist/doubly-noncentral-beta.js`**: Early-return guards in `_pdf` and `_cdf` that delegate degenerate-lambda cases to `NoncentralBeta`. The mathematical reduction is: when one Poisson series has all mass at index 0, the double sum factors into a single sum identical to the singly-noncentral formula — with parameters and argument reflected appropriately for the lambda2=0 direction.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Bug-fix entry added to `[Unreleased]`.
- **`test/dist-cases-continuous.js`**: Three new `DoublyNoncentralBeta` cases (`lambda1=0`, `lambda2=0`, `both=0`) added — these receive all structural property tests (pdf≥0, cdf∈[0,1], monotonicity, quantile round-trip, GoF sampling).

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHJR5KBWp2BHXqpCLMtee2)_