### PR TITLE
Add lambda=0 regression tests for DoublyNoncentralF

### DIFF
--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -526,6 +526,19 @@ export default [{
   ],
   cases: [{
     params: () => [5, 5, 2, 2]
+  }, {
+    // Regression: lambda1=0 previously produced NaN (inherited from DoublyNoncentralBeta, fixed in #304).
+    // Reduces to singly-noncentral F(n1, n2, lambda2).
+    name: 'lambda1 = 0',
+    params: () => [5, 5, 0, 2]
+  }, {
+    // Symmetric case: lambda2=0 reduces to singly-noncentral F(n1, n2, lambda1).
+    name: 'lambda2 = 0',
+    params: () => [5, 5, 2, 0]
+  }, {
+    // Both zero collapses to central F(n1, n2).
+    name: 'both lambdas = 0',
+    params: () => [5, 5, 0, 0]
   }],
   // Reference via DNCF = (d1/d2) DNCB(d1 x / (d2 + d1 x); d1/2, d2/2, l1, l2) / (1 + d1 x / d2)^2
   // with DNCB computed as a double Poisson mixture of central Beta (scipy.stats.beta).


### PR DESCRIPTION
Closes #307

## Summary
- Adds three regression test cases to `DoublyNoncentralF` covering `lambda1=0`, `lambda2=0`, and both lambdas zero — the boundary conditions that previously produced `NaN` before the `DoublyNoncentralBeta` fix in #304.
- No production code changes; the fix propagates through inheritance from `DoublyNoncentralBeta`.
- Each new case exercises pdf, cdf, sampling (Anderson-Darling GoF), and the full quantile round-trip.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Three `cases` entries added to `DoublyNoncentralF` — `lambda1=0` (reduces to singly-noncentral F with `lambda2`), `lambda2=0` (symmetric), and both zero (collapses to central F). Mirrors the pattern established for `DoublyNoncentralBeta` in #304.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_012Pjdr7R6xfeBBAoAmuVMUE)_