### PR TITLE
DoublyNoncentralChi2 extends NoncentralChi2, lambda=0 accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `DoublyNoncentralChi2` now extends `NoncentralChi2` instead of reimplementing its PDF and CDF. The `_pdf`, `_cdf`, and `_generator` are fully inherited. The model complexity used by `aic()` and `bic()` changes from 4 to 2, reflecting that the distribution has 2 identifiable parameters in its collapsed form `NoncentralChi2(k1+k2, λ1+λ2)`. `NoncentralChi2` now also accepts `lambda = 0` (was `lambda > 0`), degenerating correctly to a central chi-squared. Closes #316.
+
 ### Fixed
 
 - `romberg` returned the silent sentinel `0` when the 20-step budget was exhausted without convergence — indistinguishable from a genuine zero integral. It now returns the best Richardson extrapolate accumulated so far, consistent with how `trap` returns its last estimate on timeout. The stray `console.log` in `Davis._cdf` (which exposed this bug during development) has also been removed. Closes #312.

--- a/solutions/distribution/2026-05-21-1300-doubly-noncentral-chi2-inherit-noncentral-chi2.md
+++ b/solutions/distribution/2026-05-21-1300-doubly-noncentral-chi2-inherit-noncentral-chi2.md
@@ -1,0 +1,65 @@
+---
+date: 2026-05-21T13:00:00Z
+category: "distribution"
+problem: "DoublyNoncentralChi2 duplicated ~25 lines of NoncentralChi2 _pdf/_cdf instead of inheriting"
+status: complete
+related_issue: "#316"
+related_plan: "thoughts/plans/2026-05-21-1229-doubly-noncentral-chi2-inherit-noncentral-chi2.md"
+tags: [doubly-noncentral-chi2, noncentral-chi2, inheritance, constructor-only-subclass, reproductive-property, lambda-zero-guard, validator-relaxation, deferred-inheritance, parameter-collapse, erlang-pattern]
+---
+
+# Solution: DoublyNoncentralChi2 inherits NoncentralChi2
+
+**Date**: 2026-05-21T13:00:00Z
+**Category**: distribution
+**Related Issue**: #316
+
+## Problem
+
+`DoublyNoncentralChi2(k1, k2, λ1, λ2)` was implemented as a standalone class extending `Distribution`, duplicating the full `_pdf`, `_cdf`, and `_generator` implementations from `NoncentralChi2` (~25 lines). This was dead weight — the two distributions are mathematically identical via the reproductive property of noncentral chi-squared: `DNCχ²(k1, k2, λ1, λ2) ≡ NCχ²(k1+k2, λ1+λ2)`.
+
+## Root Cause
+
+`NoncentralChi2` originally validated `lambda > 0`, which excluded the `lambda = 0` case (central chi-squared degenerate). `DoublyNoncentralChi2` needed to handle `lambda1 = lambda2 = 0` (both non-centralities zero), so it could not inherit from a parent that rejected `lambda = 0`. Rather than fixing the parent first, the implementation duplicated the parent's logic and added the `lambda = 0` branch inline. The constraint relaxation was deferred indefinitely.
+
+## Fix
+
+Two coupled changes implemented together:
+
+1. **Relaxed `NoncentralChi2` validator** from `lambda > 0` to `lambda >= 0`, and added a `lambda === 0` guard in `_pdf` that falls back to the central chi-squared formula (since the Bessel form divides by `lambda` and is undefined at zero):
+   ```js
+   if (this.p.lambda === 0) {
+     if (this.p.k === 2 && x === 0) { return 0.5 }  // 0*log(0) = NaN without guard
+     return Math.exp(
+       (this.p.k / 2 - 1) * Math.log(x) - x / 2 -
+       (this.p.k / 2) * Math.LN2 - logGamma(this.p.k / 2)
+     )
+   }
+   ```
+
+2. **Rewrote `DoublyNoncentralChi2`** as a constructor-only subclass of `NoncentralChi2`, following the `Erlang extends Gamma` / `Gilbrat extends LogNormal` precedent:
+   ```js
+   export default class extends NoncentralChi2 {
+     constructor (k1, k2, lambda1, lambda2) {
+       const k1i = Math.round(k1); const k2i = Math.round(k2)
+       super(k1i + k2i, lambda1 + lambda2)           // collapse to equivalent NCχ²
+       this.p = Object.assign(this.p, { k1: k1i, k2: k2i, lambda1, lambda2 })
+       Distribution.validate({ k1: k1i, k2: k2i, lambda1, lambda2 }, [...])
+     }
+   }
+   ```
+   All `_pdf`, `_cdf`, `_generator` methods deleted — fully inherited.
+
+Net result: ~-50 lines of production code, with correctness guaranteed by the collapsed-parameter equivalence.
+
+## Prevention Strategy
+
+When a subclass stores collapsed parameters in `this.c` and then reimplements the parent's `_pdf`/`_cdf` verbatim, that is a sign of deferred subclassing. The pattern to check for: if `DistA(a, b)` is provably equivalent to `DistB(f(a,b), g(a,b))`, the correct design is a constructor-only subclass. When inheritance is blocked by a parent validator constraint that is *too strict*, fix the parent constraint first (as a prerequisite issue) rather than duplicating code in the child.
+
+## Related Solutions
+
+- [solutions/distribution/2026-05-20-1838-doubly-noncentral-chi2-additivity-collapse.md](../distribution/2026-05-20-1838-doubly-noncentral-chi2-additivity-collapse.md) — Mathematical proof that DNCχ² collapses to NCχ² via the Poisson mixture structure.
+
+## Key Insight
+
+When a distribution stores its parameters as a collapsed equivalent of a parent distribution and then reimplements the parent's `_pdf`/`_cdf` verbatim, that is a deferred subclassing decision waiting to be completed — fix the parent's over-restrictive constraint instead of duplicating code in the child.

--- a/src/dist/doubly-noncentral-chi2.js
+++ b/src/dist/doubly-noncentral-chi2.js
@@ -1,6 +1,5 @@
-import { besselI, besselISpherical, marcumP, logGamma } from '../special'
-import noncentralChi2 from './_noncentral-chi2'
 import Distribution from './_distribution'
+import NoncentralChi2 from './noncentral-chi2'
 
 /**
  * Generator for the [doubly non-central $\chi^2$ distribution]{@link https://doi.org/10.1093/biomet/36.1-2.202}:
@@ -19,74 +18,25 @@ import Distribution from './_distribution'
  * @see https://doi.org/10.1093/biomet/36.1-2.202
  * @constructor
  */
-export default class extends Distribution {
+export default class extends NoncentralChi2 {
   constructor (k1, k2, lambda1, lambda2) {
-    super('continuous', 4)
-
-    // Validate parameters
     const k1i = Math.round(k1)
     const k2i = Math.round(k2)
-    this.p = { k1: k1i, k2: k2i, lambda1, lambda2 }
+
+    // DNCχ²(k1, k2, λ1, λ2) ≡ ncχ²(k1 + k2, λ1 + λ2): χ² is additive in
+    // degrees of freedom and the Poisson noncentrality counts add.
+    // See solutions/distribution/2026-05-20-1838-doubly-noncentral-chi2-additivity-collapse.md
+    super(k1i + k2i, lambda1 + lambda2)
+
+    // Merge original params alongside the collapsed k/lambda set by super
+    this.p = Object.assign(this.p, { k1: k1i, k2: k2i, lambda1, lambda2 })
+
+    // Validate the four individual parameters (super already validated collapsed form)
     Distribution.validate({ k1: k1i, k2: k2i, lambda1, lambda2 }, [
       'k1 > 0',
       'k2 > 0',
       'lambda1 >= 0',
       'lambda2 >= 0'
     ])
-
-    // Set support
-    this.s = [{
-      value: 0,
-      closed: true
-    }, {
-      value: Infinity,
-      closed: false
-    }]
-
-    // The sum of two independent non-central chi-squares is itself a
-    // non-central chi-square: DNCχ²(k1, k2, λ1, λ2) ≡ ncχ²(k1 + k2, λ1 + λ2),
-    // since χ² is additive in degrees of freedom and the Poisson noncentrality
-    // counts add. The double series collapses to a single one by the binomial
-    // theorem.
-    // See solutions/distribution/2026-05-20-1838-doubly-noncentral-chi2-additivity-collapse.md
-    // Speed-up constants: [collapsed dof, collapsed noncentrality, dof is even]
-    this.c = [k1i + k2i, lambda1 + lambda2, (k1i + k2i) % 2 === 0]
-  }
-
-  _generator () {
-    // Direct sampling from the equivalent non-central chi-square
-    return noncentralChi2(this.r, this.c[0], this.c[1])
-  }
-
-  _pdf (x) {
-    const k = this.c[0]
-    const lambda = this.c[1]
-
-    if (lambda === 0) {
-      // λ1 = λ2 = 0 reduces to a central chi-square; the non-central Bessel
-      // form below divides by λ and cannot be evaluated here
-      if (k === 2 && x === 0) {
-        return 0.5
-      }
-      return Math.exp((k / 2 - 1) * Math.log(x) - x / 2 - (k / 2) * Math.LN2 - logGamma(k / 2))
-    }
-
-    if (this.c[2]) {
-      // k is even
-      if (k === 2 && x === 0) {
-        // k = 2, x -> 0, by differentiating F(x)
-        return 0.5 * Math.exp(-0.5 * lambda)
-      }
-      return 0.5 * Math.exp(-0.5 * (x + lambda) + (k / 4 - 0.5) * Math.log(x / lambda)) * besselI(Math.round(k / 2) - 1, Math.sqrt(lambda * x))
-    }
-
-    // k is odd; k = k1 + k2 >= 2, so the k = 1 limit of NoncentralChi2 never applies
-    return 0.5 * Math.exp(-0.5 * (x + lambda)) * Math.pow(x / lambda, k / 4 - 0.5) * besselISpherical(Math.floor((k - 3) / 2), Math.sqrt(lambda * x)) * Math.sqrt(2 * Math.sqrt(x * lambda) / Math.PI)
-  }
-
-  _cdf (x) {
-    // marcumP handles λ = 0 (it reduces to the central chi-square CDF), so no
-    // separate branch is needed here
-    return marcumP(this.c[0] / 2, this.c[1] / 2, x / 2)
   }
 }

--- a/src/dist/doubly-noncentral-chi2.js
+++ b/src/dist/doubly-noncentral-chi2.js
@@ -26,6 +26,7 @@ export default class extends NoncentralChi2 {
     // DNCχ²(k1, k2, λ1, λ2) ≡ ncχ²(k1 + k2, λ1 + λ2): χ² is additive in
     // degrees of freedom and the Poisson noncentrality counts add.
     // See solutions/distribution/2026-05-20-1838-doubly-noncentral-chi2-additivity-collapse.md
+    // See solutions/distribution/2026-05-21-1300-doubly-noncentral-chi2-inherit-noncentral-chi2.md
     super(k1i + k2i, lambda1 + lambda2)
 
     // Merge original params alongside the collapsed k/lambda set by super

--- a/src/dist/noncentral-chi2.js
+++ b/src/dist/noncentral-chi2.js
@@ -1,4 +1,4 @@
-import { besselI, besselISpherical, marcumP } from '../special'
+import { besselI, besselISpherical, marcumP, logGamma } from '../special'
 import noncentralChi2 from './_noncentral-chi2'
 import Distribution from './_distribution'
 
@@ -7,7 +7,7 @@ import Distribution from './_distribution'
  *
  * $$f(x; k; \lambda) = \frac{1}{2}e^{-\frac{x + \lambda}{2}} \bigg(\frac{x}{\lambda}\bigg)^{k/4 - 1/2} I_{k/2 - 1}\big(\sqrt{\lambda x}\big),$$
  *
- * with $k \in \mathbb{N}^+$, $\lambda > 0$ and $I_n(x)$ is the modified Bessel function of the first kind with order $n$. Support: $x \in [0, \infty)$.
+ * with $k \in \mathbb{N}^+$, $\lambda \ge 0$ and $I_n(x)$ is the modified Bessel function of the first kind with order $n$. Support: $x \in [0, \infty)$. When $\lambda = 0$ the distribution degenerates to a central $\chi^2(k)$.
  *
  * @class NoncentralChi2
  * @memberof ran.dist
@@ -25,7 +25,7 @@ export default class extends Distribution {
     this.p = { k: ki, lambda }
     Distribution.validate({ k: ki, lambda }, [
       'k > 0',
-      'lambda > 0'
+      'lambda >= 0'
     ])
 
     // Set support
@@ -49,6 +49,18 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
+    if (this.p.lambda === 0) {
+      // Bessel form divides by λ and is undefined at zero; fall back to central chi-squared density
+      if (this.p.k === 2 && x === 0) {
+        // 0*log(0) = NaN without the guard; limit is 0.5
+        return 0.5
+      }
+      return Math.exp(
+        (this.p.k / 2 - 1) * Math.log(x) - x / 2 -
+        (this.p.k / 2) * Math.LN2 - logGamma(this.p.k / 2)
+      )
+    }
+
     if (this.c[0]) {
       // k is even
       if (this.p.k === 2 && x === 0) {

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -1763,7 +1763,7 @@ export default [{
   invalidParams: [
     [], // all params required
     [-1, 1], [0, 1], // k > 0
-    [2, -1], [2, 0] // lambda > 0
+    [2, -1] // lambda >= 0
   ],
   cases: [{
     name: 'odd k',
@@ -1771,6 +1771,13 @@ export default [{
   }, {
     name: 'even k',
     params: () => [10, 2]
+  }, {
+    name: 'central (lambda = 0), even k',
+    params: () => [10, 0]
+  }, {
+    // k=2, lambda=0, x=0 is the specific boundary where 0*log(0)=NaN without the guard; exercises that path
+    name: 'central (lambda = 0), k=2',
+    params: () => [2, 0]
   }],
   // even and odd k share the same Gamma-based noncentralChi2 sampler; the even/odd branch is in _pdf only
   sampleParams: [{ name: 'odd k', params: () => [11, 2] }],


### PR DESCRIPTION
## Summary

- `NoncentralChi2` validator relaxed from `lambda > 0` to `lambda >= 0`; `_pdf` gains a `lambda === 0` guard that falls back to the central chi-squared formula (Bessel form divides by λ and is undefined at zero)
- `DoublyNoncentralChi2` rewritten as a constructor-only subclass of `NoncentralChi2` — `_pdf`, `_cdf`, and `_generator` are fully deleted and inherited; net ~−50 lines
- AIC/BIC model complexity changes from 4 to 2 (intentional: only 2 parameters are identifiable in the collapsed form); documented in CHANGELOG

Closes #316.

## Test plan

- [ ] `NoncentralChi2(2, 0)` constructs without error
- [ ] `NoncentralChi2(10, 0).pdf(x)` matches central chi-squared(10) PDF
- [ ] `NoncentralChi2(10, 0).cdf(x)` matches central chi-squared(10) CDF
- [ ] `NoncentralChi2(2, 0).pdf(0)` returns 0.5 (k=2, x=0 NaN guard)
- [ ] `[2, 0]` removed from NoncentralChi2 `invalidParams`; `[2, -1]` still throws
- [ ] `DoublyNoncentralChi2(3, 4, 2, 3).pdf(5)` === `NoncentralChi2(7, 5).pdf(5)`
- [ ] All existing `DoublyNoncentralChi2` `invalidParams` still throw
- [ ] All existing `DoublyNoncentralChi2` refVals pass (3059 tests total)
- [ ] `npm run standard` passes
- [ ] `npm test` passes

https://claude.ai/code/session_014H7jeA4mL2EQqKwrz5c8jP

---
_Generated by [Claude Code](https://claude.ai/code/session_014H7jeA4mL2EQqKwrz5c8jP)_