### PR TITLE
Fix off-by-one in Romberg interpolation window start condition

### DIFF
--- a/src/algorithms/romberg.js
+++ b/src/algorithms/romberg.js
@@ -71,7 +71,7 @@ export default function (f, a, b) {
 
   for (let j = 0; j < MAX_STEPS; j++) {
     s[j] = trapezoid(f, a, b, j + 1)
-    if (j >= POLYNOMIAL_ORDER - 1) {
+    if (j >= POLYNOMIAL_ORDER) {
       const { dy, y } = interpolate(h.slice(j - POLYNOMIAL_ORDER), s.slice(j - POLYNOMIAL_ORDER), POLYNOMIAL_ORDER, 0)
       if (Math.abs(dy) < EPS * Math.abs(y)) {
         return y

--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -135,6 +135,14 @@ describe('algorithms', () => {
       }
     })
 
+    it('should compute ∫sin(x)dx = 2 over [0,π] to machine precision', () => {
+      // Regression guard for the j=POLYNOMIAL_ORDER-1 off-by-one: sin(x) on [0,π]
+      // requires only a few Romberg steps. Any result worse than 1e-12 would indicate
+      // the polynomial interpolation window is receiving bad data.
+      const result = algorithms.romberg(t => Math.sin(t), 0, Math.PI)
+      assert(Math.abs(result - 2) < 1e-12)
+    })
+
     it('should return the best available extrapolate when budget is exhausted', () => {
       // A step-function integrand (true integral 1.7) defeats Richardson
       // extrapolation: O(1/n) trapezoid convergence cannot satisfy the O(h^2)


### PR DESCRIPTION
Closes #317

## Summary
- Changed `j >= POLYNOMIAL_ORDER - 1` to `j >= POLYNOMIAL_ORDER` so the first `interpolate` call only fires when a full `POLYNOMIAL_ORDER`-length window is available — `h.slice(j - POLYNOMIAL_ORDER)` evaluates as `h.slice(0)` at j=5, giving 6 valid elements for 1-indexed access up to `xa[5]`
- Under the old condition, j=4 passed a 1-element slice (`h.slice(-1)`) to `interpolate`, causing `xa[1]..xa[5]` to be `undefined` and producing NaN for both `dy` and `y`
- Added a regression test: `∫sin(x)dx = 2` over `[0,π]` verified to `1e-12` precision

## Non-trivial changes
- **`src/algorithms/romberg.js:74`**: Off-by-one corrected — interpolation now starts at the first iteration where the sliding window contains a full `POLYNOMIAL_ORDER` data points rather than one step too early

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/algorithms.js`**: New `∫sin(x)dx` test case added to the romberg suite

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WurrJUAudEZphbUddRtYW4)_