### PR TITLE
Add lower-bound guard to NoncentralBeta._cdf

### DIFF
--- a/src/dist/noncentral-beta.js
+++ b/src/dist/noncentral-beta.js
@@ -181,6 +181,7 @@ export default class extends Distribution {
       }, t => t.p * t.ib)
     }
 
-    return Math.min(1, z)
+    // Series can produce a small negative value via floating-point cancellation; symmetric guard with Math.min(1, ...).
+    return Math.max(0, Math.min(1, z))
   }
 }

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -1728,6 +1728,28 @@ export default [{
     // Regression: lambda=0 produced NaN via 0*log(0) in Poisson weights (issue #267).
     name: 'lambda=0 (degenerate to Beta)',
     params: () => [2, 2, 0]
+  }, {
+    // Stress test: large lambda forces many Poisson terms; floating-point cancellation risk.
+    // Reference values from mpmath (dps=20): ncbeta_cdf(2, 2, 100, x).
+    name: 'large lambda',
+    params: () => [2, 2, 100],
+    refVals: [
+      { x: 0.9, pdf: 1.395361444040611e+00, cdf: 3.110910129477763e-02 },
+      { x: 0.95, pdf: 9.931823105374480e+00, cdf: 2.574339466217881e-01 },
+      { x: 0.99, pdf: 1.653231233465270e+01, cdf: 9.006079598702932e-01 }
+    ]
+  }, {
+    // Stress test: asymmetric shapes with non-trivial lambda; exercises series near support boundary.
+    // alpha=0.5 (< 1) means _pdf(0) returns NaN (known open defect, noncentral-beta.js:66-68), but
+    // pdfRange uses a golden-ratio step that does not land on x=0 exactly, so the harness still passes.
+    // Reference values from mpmath (dps=20): interior points only (x=0 pdf excluded due to above defect).
+    name: 'asymmetric shapes',
+    params: () => [0.5, 5, 10],
+    refVals: [
+      { x: 0.3, pdf: 1.109454870961770e+00, cdf: 1.492809427219101e-01 },
+      { x: 0.5, pdf: 2.015251093123254e+00, cdf: 4.715604423604929e-01 },
+      { x: 0.7, pdf: 1.488828919050658e+00, cdf: 8.557627658350277e-01 }
+    ]
   }],
   // Reference values from R: dbeta(x, 2, 2, ncp=2), pbeta(x, 2, 2, ncp=2)
   refVals: [

--- a/test/dist.js
+++ b/test/dist.js
@@ -103,7 +103,8 @@ const UnitTests = {
     // Test cases
     const cases = tc.cases.map(c => ({
       name: c.name || 'random parameters',
-      generate: () => new dist[tc.name](...c.params())
+      generate: () => new dist[tc.name](...c.params()),
+      refVals: c.refVals
     }))
 
     cases.forEach(c => {
@@ -139,6 +140,12 @@ const UnitTests = {
         it('quantile should round-trip through cdf', () => {
           Tests.quantileRoundtrip(c.generate())
         })
+
+        if (c.refVals) {
+          it('pdf and cdf should match per-case reference values', () => {
+            checkRefVals(c.generate(), c.refVals)
+          })
+        }
       })
     })
 


### PR DESCRIPTION
Closes #302

## Summary
- Adds `Math.max(0, ...)` to the final return of `NoncentralBeta._cdf`, making it symmetric with the existing `Math.min(1, z)` upper-bound guard. The Poisson-weighted series can produce a small negative value via floating-point cancellation for extreme parameters; the guard ensures the CDF always stays in `[0, 1]`.
- Adds two mpmath-validated stress-test cases (`lambda=100` and `alpha=0.5, beta=5, lambda=10`) that would catch a regression in the series for these regimes.
- Extends `test/dist.js` to support per-case `refVals` alongside the existing distribution-level `refVals`, so future cases can carry their own reference values without touching the shared block.

## Non-trivial changes
- **`src/dist/noncentral-beta.js:185`**: `_cdf` now returns `Math.max(0, Math.min(1, z))` instead of `Math.min(1, z)`. For the extremely rare case where the series undershoots zero due to floating-point cancellation, the return value changes from a small negative number to `0`. No currently-known input triggers this — the guard is preventive.
- **`test/dist.js:104,140-146`**: `cases.map` now carries the `refVals` field through, and a new `it` block fires per case when `refVals` is present. This is a small but general infrastructure extension; any future stress-test case can now pin reference values without a separate distribution-level `refVals` block.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Two new `cases` entries with `name`, `params`, and `refVals` fields — purely additive, no changes to existing entries.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2doMntMN1QRbaAknSPuTX)_