### PR TITLE
Fix misleading invalidParams comments for NoncentralF

### DIFF
--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -1821,8 +1821,8 @@ export default [{
   name: 'NoncentralF',
   invalidParams: [
     [], // all params required
-    [-1, 2, 1], [0, 2, 1], // alpha > 0
-    [2, -1, 1], [2, 0, 1], // beta > 0
+    [-1, 2, 1], [0, 2, 1], // d1 > 0
+    [2, -1, 1], [2, 0, 1], // d2 > 0
     [2, 2, -1] // lambda >= 0
   ],
   cases: [{


### PR DESCRIPTION
Closes #301

## Summary
- Corrected two inline comments in `NoncentralF.invalidParams` from `// alpha > 0` / `// beta > 0` to `// d1 > 0` / `// d2 > 0`, matching the actual parameter names of the distribution.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Two inline comments in `NoncentralF.invalidParams` renamed from `alpha`/`beta` (copy-pasted from `NoncentralBeta`) to `d1`/`d2` (the correct parameter names).

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzPFCQbb6kS6SnhLaHHujM)_