### PR TITLE
Fix NoncentralBeta _pdf returning NaN at x=0 when alpha <= 1

### DIFF
--- a/src/dist/noncentral-beta.js
+++ b/src/dist/noncentral-beta.js
@@ -63,9 +63,14 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    // recursiveSum produces 0/0 = NaN at the closed-support boundary; limit is 0 for alpha > 1.
-    // For alpha <= 1 the PDF is non-zero or divergent at 0 — out of scope, leave as NaN until fixed.
-    if (x === 0 && this.p.alpha > 1) return 0
+    // At x=0: x^(alpha+k-1) collapses to 0 for all k when alpha>1; only k=0 survives when alpha=1;
+    // diverges for alpha<1 since x^(alpha-1) → +∞.
+    if (x === 0) {
+      if (this.p.alpha > 1) return 0
+      if (this.p.alpha < 1) return Infinity
+      // alpha===1: k=0 term is e^(-lambda/2)*(1-0)^(beta-1)/B(1,beta); all k>=1 vanish since 0^k=0.
+      return this.c[0] / this.c[1]
+    }
 
     // Speed-up variables.
     const l2 = this.p.lambda / 2

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -1739,13 +1739,20 @@ export default [{
       { x: 0.99, pdf: 1.653231233465270e+01, cdf: 9.006079598702932e-01 }
     ]
   }, {
+    // alpha=1 boundary: only the k=0 Poisson term survives at x=0 (x^k=0 for k>=1), giving e^(-lambda/2)/B(1,beta).
+    // Reference value computed analytically: 5*exp(-5) = 3.368973499542734e-02.
+    name: 'alpha=1 (finite pdf at x=0)',
+    params: () => [1, 5, 10],
+    refVals: [
+      { x: 0, pdf: 3.368973499542734e-02, cdf: 0 }
+    ]
+  }, {
     // Stress test: asymmetric shapes with non-trivial lambda; exercises series near support boundary.
-    // alpha=0.5 (< 1) means _pdf(0) returns NaN (known open defect, noncentral-beta.js:66-68), but
-    // pdfRange uses a golden-ratio step that does not land on x=0 exactly, so the harness still passes.
-    // Reference values from mpmath (dps=20): interior points only (x=0 pdf excluded due to above defect).
+    // Reference values from mpmath (dps=20).
     name: 'asymmetric shapes',
     params: () => [0.5, 5, 10],
     refVals: [
+      { x: 0, pdf: Infinity, cdf: 0 },
       { x: 0.3, pdf: 1.109454870961770e+00, cdf: 1.492809427219101e-01 },
       { x: 0.5, pdf: 2.015251093123254e+00, cdf: 4.715604423604929e-01 },
       { x: 0.7, pdf: 1.488828919050658e+00, cdf: 8.557627658350277e-01 }

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -289,7 +289,11 @@ export function checkRefVals (dist, refVals) {
   for (const { x, pdf, pmf, cdf } of refVals) {
     if (pdf !== undefined) {
       const actual = dist.pdf(x)
-      assert(Math.abs(actual - pdf) < refValTol(pdf), `pdf(${x}) = ${actual}, expected ${pdf}`)
+      if (!Number.isFinite(pdf)) {
+        assert(actual === pdf, `pdf(${x}) = ${actual}, expected ${pdf}`)
+      } else {
+        assert(Math.abs(actual - pdf) < refValTol(pdf), `pdf(${x}) = ${actual}, expected ${pdf}`)
+      }
     }
     if (pmf !== undefined) {
       const actual = dist.pdf(x)


### PR DESCRIPTION
Closes #326

## Summary
- `NoncentralBeta._pdf(0)` returned `NaN` for all `alpha <= 1` due to an incomplete boundary guard that only handled the `alpha > 1` case
- For `alpha < 1` the PDF diverges to `+Infinity` at `x = 0`; for `alpha = 1` only the `k = 0` Poisson term survives, giving `e^(-λ/2) / B(1, β)`
- `checkRefVals` in the test harness extended to handle non-finite expected values via strict equality, enabling boundary tests that include `Infinity`

## Non-trivial changes
- **`src/dist/noncentral-beta.js`**: Replaced the single-branch guard `if (x === 0 && alpha > 1) return 0` with a 3-way dispatch: `alpha > 1` → `0`, `alpha < 1` → `Infinity`, `alpha === 1` → `this.c[0] / this.c[1]` (= `β · e^(-λ/2)`). The `alpha === 1` limit is derived analytically: at `x = 0`, `x^k = 0` for all `k ≥ 1` so the Poisson mixture collapses to the single `k = 0` term.
- **`test/test-utils.js`**: `checkRefVals` now uses `actual === expected` (strict equality) when the reference value is non-finite, instead of `Math.abs(actual - expected) < tol` which produces `NaN` for `Infinity - Infinity`.
- **`test/dist-cases-continuous.js`**: Added `alpha=1` boundary case with analytically verified `refVal` at `x = 0`; added `{x: 0, pdf: Infinity, cdf: 0}` to the `asymmetric shapes` case (alpha=0.5) that previously had to skip `x = 0` due to the defect.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Removed the workaround comment that documented the NaN defect; simplified the `asymmetric shapes` case comment now that the workaround is gone.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_013iNtUudR3YZC2sF7DeoXiS)_