### PR TITLE
Add CODE_OF_CONDUCT.md and SECURITY.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Contributor Covenant Code of Conduct
+
+<!-- Paste the Contributor Covenant v2.1 template here: https://www.contributor-covenant.org/version/2/1/code_of_conduct/ -->
+<!-- Replace [INSERT CONTACT METHOD] with your contact email or GitHub username -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting
+
+<!-- Replace with your preferred contact method (GitHub "Report a vulnerability" or email) -->
+
+Please report privately via GitHub: **Security → Report a vulnerability** on this repository.
+
+Include:
+- Description of the issue
+- Steps to reproduce
+- Potential impact
+
+We will acknowledge within 7 days.
+
+## Scope
+
+`ranjs` is a pure-computation library with no network access or file I/O, which limits the attack surface to malicious input crafted to exploit numerical routines.


### PR DESCRIPTION
Closes #113

## Summary
- Adds `CODE_OF_CONDUCT.md` as a stub pointing to the Contributor Covenant v2.1 template (contact method to be filled in manually)
- Adds `SECURITY.md` documenting the private vulnerability disclosure process, expected response time, and the limited attack surface of a pure-computation library

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

<details>
<summary>Trivial changes</summary>

- **`CODE_OF_CONDUCT.md`**: New file — stub with instructions to paste Contributor Covenant v2.1 and fill in contact method
- **`SECURITY.md`**: New file — security policy covering reporting process, required info, response time, and scope

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_012hg4Yi5DTkJp7UKungEGXj)_