### PR TITLE
Migrate this.c to named object in noncentral distributions

### DIFF
--- a/src/dist/doubly-noncentral-t.js
+++ b/src/dist/doubly-noncentral-t.js
@@ -44,10 +44,10 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      -0.5 * (theta + mu * mu + Math.log(Math.PI * nui)) - logGamma(nui / 2),
-      Math.exp(-theta / 2)
-    ]
+    this.c = {
+      logScale: -0.5 * (theta + mu * mu + Math.log(Math.PI * nui)) - logGamma(nui / 2),
+      expHalfTheta: Math.exp(-theta / 2)
+    }
   }
 
   /**
@@ -173,14 +173,14 @@ export default class extends Distribution {
     // the j=0-only closed form. Threshold matches NoncentralT._pdf convention.
     if (Math.abs(x) < Number.EPSILON) {
       const kj0 = (this.p.nu + 1) / 2
-      return Math.exp(this.c[0]) * gamma(kj0) * f11(kj0, this.p.nu / 2, this.p.theta / 2)
+      return Math.exp(this.c.logScale) * gamma(kj0) * f11(kj0, this.p.nu / 2, this.p.theta / 2)
     }
 
     // When mu = 0, all j > 0 terms in the series carry a factor of mu^j = 0, so only j = 0 survives.
     if (this.p.mu === 0) {
       const tk = 1 + x * x / this.p.nu
       const kj0 = (this.p.nu + 1) / 2
-      return Math.exp(this.c[0]) * gamma(kj0) * f11(kj0, this.p.nu / 2, this.p.theta / (2 * tk)) / Math.pow(tk, kj0)
+      return Math.exp(this.c.logScale) * gamma(kj0) * f11(kj0, this.p.nu / 2, this.p.theta / (2 * tk)) / Math.pow(tk, kj0)
     }
 
     // Some pre-computed constants
@@ -199,7 +199,7 @@ export default class extends Distribution {
     if (x * this.p.mu >= 0) {
       // Init terms
       let kj0 = (this.p.nu + j0 + 1) / 2
-      let gp = Math.exp(this.c[0] + j0 * lntmuk - logGamma(j0 + 1) - kj0 * lntk)
+      let gp = Math.exp(this.c.logScale + j0 * lntmuk - logGamma(j0 + 1) - kj0 * lntk)
       let gk0 = gamma(kj0)
       let f10 = f11(kj0, nu2, thetatk)
 
@@ -279,7 +279,7 @@ export default class extends Distribution {
     } else {
       // Forward
       let kj0 = (this.p.nu + j0 + 1) / 2
-      const gp0 = Math.exp(this.c[0] + (j0 - 1) * lntmuk - logGamma(j0) - (kj0 - 0.5) * lntk)
+      const gp0 = Math.exp(this.c.logScale + (j0 - 1) * lntmuk - logGamma(j0) - (kj0 - 0.5) * lntk)
       const gk0 = gamma(kj0 - 1)
       const gk1 = gamma(kj0 - 0.5)
       let gk = [gk0, gk1]
@@ -355,7 +355,7 @@ export default class extends Distribution {
     const y = Math.abs(x)
     const mu = x < 0 ? -this.p.mu : this.p.mu
     const z = recursiveSum({
-      p: this.c[1],
+      p: this.c.expHalfTheta,
       f: NoncentralT.fnm(this.p.nu, mu, y)
     }, (t, i) => {
       const i2 = 2 * i

--- a/src/dist/noncentral-beta.js
+++ b/src/dist/noncentral-beta.js
@@ -42,10 +42,10 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants.
-    this.c = [
-      Math.exp(-lambda / 2),
-      fnBeta(alpha, beta)
-    ]
+    this.c = {
+      expHalfLambda: Math.exp(-lambda / 2),
+      beta: fnBeta(alpha, beta)
+    }
   }
 
   _generator () {
@@ -69,7 +69,7 @@ export default class extends Distribution {
       if (this.p.alpha > 1) return 0
       if (this.p.alpha < 1) return Infinity
       // alpha===1: k=0 term is e^(-lambda/2)*(1-0)^(beta-1)/B(1,beta); all k>=1 vanish since 0^k=0.
-      return this.c[0] / this.c[1]
+      return this.c.expHalfLambda / this.c.beta
     }
 
     // Speed-up variables.

--- a/src/dist/noncentral-chi2.js
+++ b/src/dist/noncentral-chi2.js
@@ -38,9 +38,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      this.p.k % 2 === 0
-    ]
+    this.c = {
+      kIsEven: this.p.k % 2 === 0
+    }
   }
 
   _generator () {
@@ -61,7 +61,7 @@ export default class extends Distribution {
       )
     }
 
-    if (this.c[0]) {
+    if (this.c.kIsEven) {
       // k is even
       if (this.p.k === 2 && x === 0) {
         // k = 2, x -> 0, by differentiating F(x)

--- a/src/dist/noncentral-t.js
+++ b/src/dist/noncentral-t.js
@@ -40,10 +40,10 @@ class NoncentralT extends Distribution {
 
     // Speed-up constants
     const mu2 = mu * mu / 2
-    this.c = [
-      Math.sqrt(1 + 2 / nui),
-      Math.exp(logGamma((nui + 1) / 2) - logGamma(nui / 2) - mu2) / Math.sqrt(Math.PI * nui)
-    ]
+    this.c = {
+      nuScale: Math.sqrt(1 + 2 / nui),
+      pdfAt0: Math.exp(logGamma((nui + 1) / 2) - logGamma(nui / 2) - mu2) / Math.sqrt(Math.PI * nui)
+    }
   }
 
   /**
@@ -155,9 +155,9 @@ class NoncentralT extends Distribution {
 
   _pdf (x) {
     if (Math.abs(x) < Number.EPSILON) {
-      return this.c[1]
+      return this.c.pdfAt0
     } else {
-      return Math.max(0, this.p.nu * (NoncentralT.fnm(this.p.nu + 2, this.p.mu, x * this.c[0]) - NoncentralT.fnm(this.p.nu, this.p.mu, x)) / x)
+      return Math.max(0, this.p.nu * (NoncentralT.fnm(this.p.nu + 2, this.p.mu, x * this.c.nuScale) - NoncentralT.fnm(this.p.nu, this.p.mu, x)) / x)
     }
   }
 


### PR DESCRIPTION
Closes #173

## Summary
- Migrates `this.c` from positional arrays to named objects in `noncentral-beta.js`, `noncentral-chi2.js`, `noncentral-t.js`, and `doubly-noncentral-t.js`
- Eliminates opaque magic indices (`this.c[0]`, `this.c[1]`) in favour of self-documenting property names
- No logic changes — pure mechanical rename throughout

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/noncentral-beta.js`**: `this.c = [expHalfLambda, beta]` → `this.c = { expHalfLambda, beta }`; two access sites updated
- **`src/dist/noncentral-chi2.js`**: `this.c = [kIsEven]` → `this.c = { kIsEven }`; one access site updated
- **`src/dist/noncentral-t.js`**: `this.c = [nuScale, pdfAt0]` → `this.c = { nuScale, pdfAt0 }`; two access sites updated
- **`src/dist/doubly-noncentral-t.js`**: `this.c = [logScale, expHalfTheta]` → `this.c = { logScale, expHalfTheta }`; five access sites updated

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_0129GL1p2XQ9cGW1TBVTDJA7)_