### PR TITLE
Migrate this.c to named object: simple continuous distributions

### DIFF
--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -32,7 +32,7 @@ class Distribution {
     this.r = new Xoshiro128p()
 
     // Speed-up constants
-    this.c = []
+    this.c = {}
   }
 
   /**

--- a/src/dist/alpha.js
+++ b/src/dist/alpha.js
@@ -40,10 +40,10 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      this._phi(alpha),
-      this._phi(alpha) * Math.sqrt(2 * Math.PI)
-    ]
+    this.c = {
+      phiAlpha: this._phi(alpha),
+      phiAlphaSqrt2Pi: this._phi(alpha) * Math.sqrt(2 * Math.PI)
+    }
   }
 
   _phi (x) {
@@ -60,14 +60,14 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.p.beta * Math.exp(-0.5 * Math.pow(this.p.alpha - this.p.beta / x, 2)) / (x * x * this.c[1])
+    return this.p.beta * Math.exp(-0.5 * Math.pow(this.p.alpha - this.p.beta / x, 2)) / (x * x * this.c.phiAlphaSqrt2Pi)
   }
 
   _cdf (x) {
-    return this._phi(this.p.alpha - this.p.beta / x) / this.c[0]
+    return this._phi(this.p.alpha - this.p.beta / x) / this.c.phiAlpha
   }
 
   _q (p) {
-    return this.p.beta / (this.p.alpha - this._phiInv(p * this.c[0]))
+    return this.p.beta / (this.p.alpha - this._phiInv(p * this.c.phiAlpha))
   }
 }

--- a/src/dist/anglit.js
+++ b/src/dist/anglit.js
@@ -36,12 +36,12 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      2 / beta,
-      2 * mu / beta,
-      1 / beta,
-      mu / beta - Math.PI / 4
-    ]
+    this.c = {
+      twoOverBeta: 2 / beta,
+      twoMuOverBeta: 2 * mu / beta,
+      oneOverBeta: 1 / beta,
+      muOverBetaMinusPiOver4: mu / beta - Math.PI / 4
+    }
   }
 
   _generator () {
@@ -50,11 +50,11 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return Math.cos(this.c[0] * x - this.c[1]) / this.p.beta
+    return Math.cos(this.c.twoOverBeta * x - this.c.twoMuOverBeta) / this.p.beta
   }
 
   _cdf (x) {
-    return Math.pow(Math.sin(this.c[2] * x - this.c[3]), 2)
+    return Math.pow(Math.sin(this.c.oneOverBeta * x - this.c.muOverBetaMinusPiOver4), 2)
   }
 
   _q (p) {

--- a/src/dist/beta-rectangular.js
+++ b/src/dist/beta-rectangular.js
@@ -38,26 +38,26 @@ export default class extends Beta {
       closed: true
     }]
 
-    // Speed-up constants. Note that Beta has 3 speed-up constants
-    this.c = this.c.concat([
-      b - a,
-      1 - theta
-    ])
+    // Speed-up constants
+    Object.assign(this.c, {
+      bMinusA: b - a,
+      oneMinusTheta: 1 - theta
+    })
   }
 
   _generator () {
     // Direct sampling by mixing beta and uniform variates
     return this.r.next() < this.p.theta
-      ? super._generator() * this.c[3] + this.p.a
-      : this.r.next() * this.c[3] + this.p.a
+      ? super._generator() * this.c.bMinusA + this.p.a
+      : this.r.next() * this.c.bMinusA + this.p.a
   }
 
   _pdf (x) {
-    return (this.p.theta * super._pdf((x - this.p.a) / this.c[3]) + this.c[4]) / this.c[3]
+    return (this.p.theta * super._pdf((x - this.p.a) / this.c.bMinusA) + this.c.oneMinusTheta) / this.c.bMinusA
   }
 
   _cdf (x) {
     const y = x - this.p.a
-    return this.p.theta * super._cdf(y / this.c[3]) + this.c[4] * y / this.c[3]
+    return this.p.theta * super._cdf(y / this.c.bMinusA) + this.c.oneMinusTheta * y / this.c.bMinusA
   }
 }

--- a/src/dist/beta.js
+++ b/src/dist/beta.js
@@ -38,11 +38,11 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      logBeta(alpha, beta),
-      alpha - 1,
-      beta - 1
-    ]
+    this.c = {
+      lnBeta: logBeta(alpha, beta),
+      alphaM1: alpha - 1,
+      betaM1: beta - 1
+    }
   }
 
   _generator () {
@@ -51,16 +51,16 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    if (this.c[1] === 0 && this.c[2] === 0) {
+    if (this.c.alphaM1 === 0 && this.c.betaM1 === 0) {
       return 1
     }
 
-    const a = this.c[1] * Math.log(x)
+    const a = this.c.alphaM1 * Math.log(x)
 
-    const b = this.c[2] * Math.log(1 - x)
+    const b = this.c.betaM1 * Math.log(1 - x)
 
     // Handle x = 0 and x = 1 cases
-    return Math.exp(a + b - this.c[0])
+    return Math.exp(a + b - this.c.lnBeta)
   }
 
   _cdf (x) {

--- a/src/dist/exponential.js
+++ b/src/dist/exponential.js
@@ -34,9 +34,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      Math.exp(-lambda)
-    ]
+    this.c = {
+      expNegLambda: Math.exp(-lambda)
+    }
   }
 
   _generator () {
@@ -45,7 +45,7 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.p.lambda * Math.pow(this.c[0], x)
+    return this.p.lambda * Math.pow(this.c.expNegLambda, x)
   }
 
   _cdf (x) {

--- a/src/dist/fisher-z.js
+++ b/src/dist/fisher-z.js
@@ -23,8 +23,7 @@ export default class extends F {
     // See solutions/correctness/2026-05-18-0534-fisher-z-double-halving-subclass-delegation.md
     super(d1i, d2i)
 
-    // this.c[0] is logBeta(d1/2, d2/2) from Beta's constructor; indices 1-2 also used by Beta
-    this.c[3] = Math.LN2 + (this.p.d1 / 2) * Math.log(this.p.d1) + (this.p.d2 / 2) * Math.log(this.p.d2) - this.c[0]
+    this.c.logNorm = Math.LN2 + (this.p.d1 / 2) * Math.log(this.p.d1) + (this.p.d2 / 2) * Math.log(this.p.d2) - this.c.lnBeta
 
     // Set support
     this.s = [{
@@ -47,7 +46,7 @@ export default class extends F {
     const logSum = t >= 0
       ? t + Math.log(this.p.d1 + this.p.d2 * Math.exp(-t))
       : Math.log(this.p.d2 + this.p.d1 * Math.exp(t))
-    return Math.exp(this.c[3] + this.p.d1 * x - ((this.p.d1 + this.p.d2) / 2) * logSum)
+    return Math.exp(this.c.logNorm + this.p.d1 * x - ((this.p.d1 + this.p.d2) / 2) * logSum)
   }
 
   _cdf (x) {

--- a/src/dist/lindley.js
+++ b/src/dist/lindley.js
@@ -34,24 +34,24 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      1 + theta,
-      Math.exp(-theta - 1) * (1 + theta)
-    ]
+    this.c = {
+      thetaP1: 1 + theta,
+      expFactor: Math.exp(-theta - 1) * (1 + theta)
+    }
   }
 
   _generator () {
     // Inverse transform sampling using Lambert W.
-    return -(lambertW1m(-this.r.next() * this.c[1]) + this.c[0]) / this.p.theta
+    return -(lambertW1m(-this.r.next() * this.c.expFactor) + this.c.thetaP1) / this.p.theta
   }
 
   _pdf (x) {
-    return this.p.theta * this.p.theta * (1 + x) * Math.exp(-this.p.theta * x) / this.c[0]
+    return this.p.theta * this.p.theta * (1 + x) * Math.exp(-this.p.theta * x) / this.c.thetaP1
   }
 
   _cdf (x) {
     const tx = this.p.theta * x
     // -expm1(-tx) avoids catastrophic cancellation when theta*x is near 0
-    return -Math.expm1(-tx) - Math.exp(-tx) * tx / this.c[0]
+    return -Math.expm1(-tx) - Math.exp(-tx) * tx / this.c.thetaP1
   }
 }


### PR DESCRIPTION
Closes #181

## Summary
- Migrates `this.c` from positional arrays to named objects in `alpha.js`, `anglit.js`, `beta.js`, `exponential.js`, and `lindley.js` per the convention established in #172
- Updates two cascade child classes (`beta-rectangular.js`, `fisher-z.js`) whose `this.c` extension patterns depended on `beta.js` being an array
- Fixes the base class `_distribution.js` to initialize `this.c = {}` instead of `[]`, aligning the default with the documented convention

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/_distribution.js`**: Base class default changed from `this.c = []` to `this.c = {}` to match the named-object convention
- **`src/dist/alpha.js`**: `this.c[0]` → `phiAlpha`, `this.c[1]` → `phiAlphaSqrt2Pi`
- **`src/dist/anglit.js`**: `this.c[0..3]` → `twoOverBeta`, `twoMuOverBeta`, `oneOverBeta`, `muOverBetaMinusPiOver4`
- **`src/dist/beta.js`**: `this.c[0..2]` → `lnBeta`, `alphaM1`, `betaM1`
- **`src/dist/exponential.js`**: `this.c[0]` → `expNegLambda`
- **`src/dist/lindley.js`**: `this.c[0..1]` → `thetaP1`, `expFactor`
- **`src/dist/beta-rectangular.js`**: `this.c.concat([...])` → `Object.assign(this.c, {...})` with named keys `bMinusA`, `oneMinusTheta`
- **`src/dist/fisher-z.js`**: `this.c[3]` → `this.c.logNorm`, `this.c[0]` → `this.c.lnBeta`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01868Q7y5MJDFoheKe1TCkEi)_