### PR TITLE
Migrate this.c to named object in location-scale distributions

### DIFF
--- a/src/dist/cauchy.js
+++ b/src/dist/cauchy.js
@@ -34,9 +34,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      Math.PI * this.p.gamma
-    ]
+    this.c = {
+      piGamma: Math.PI * this.p.gamma
+    }
   }
 
   _generator () {
@@ -46,7 +46,7 @@ export default class extends Distribution {
 
   _pdf (x) {
     const y = (x - this.p.x0) / this.p.gamma
-    return 1 / (this.c[0] * (1 + y * y))
+    return 1 / (this.c.piGamma * (1 + y * y))
   }
 
   _cdf (x) {

--- a/src/dist/moyal.js
+++ b/src/dist/moyal.js
@@ -36,9 +36,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      sigma * Math.sqrt(2 * Math.PI)
-    ]
+    this.c = {
+      sigmaRoot2Pi: sigma * Math.sqrt(2 * Math.PI)
+    }
   }
 
   _generator () {
@@ -54,7 +54,7 @@ export default class extends Distribution {
 
   _pdf (x) {
     const z = (x - this.p.mu) / this.p.sigma
-    return Math.exp(-0.5 * (z + Math.exp(-z))) / this.c[0]
+    return Math.exp(-0.5 * (z + Math.exp(-z))) / this.c.sigmaRoot2Pi
   }
 
   _cdf (x) {

--- a/src/dist/normal.js
+++ b/src/dist/normal.js
@@ -37,10 +37,10 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      sigma * Math.sqrt(2 * Math.PI),
-      sigma * Math.SQRT2
-    ]
+    this.c = {
+      sigmaRoot2Pi: sigma * Math.sqrt(2 * Math.PI),
+      sigmaRoot2: sigma * Math.SQRT2
+    }
   }
 
   _generator () {
@@ -49,14 +49,14 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return Math.exp(-0.5 * Math.pow((x - this.p.mu) / this.p.sigma, 2)) / this.c[0]
+    return Math.exp(-0.5 * Math.pow((x - this.p.mu) / this.p.sigma, 2)) / this.c.sigmaRoot2Pi
   }
 
   _cdf (x) {
-    return 0.5 * (1 + erf((x - this.p.mu) / this.c[1]))
+    return 0.5 * (1 + erf((x - this.p.mu) / this.c.sigmaRoot2))
   }
 
   _q (p) {
-    return this.p.mu + this.c[1] * erfinv(2 * p - 1)
+    return this.p.mu + this.c.sigmaRoot2 * erfinv(2 * p - 1)
   }
 }

--- a/src/dist/reciprocal.js
+++ b/src/dist/reciprocal.js
@@ -36,22 +36,22 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      Math.log(a),
-      Math.log(b)
-    ]
+    this.c = {
+      logA: Math.log(a),
+      logB: Math.log(b)
+    }
   }
 
   _generator () {
     // Direct sampling
-    return this.p.a * Math.exp((this.c[1] - this.c[0]) * this.r.next())
+    return this.p.a * Math.exp((this.c.logB - this.c.logA) * this.r.next())
   }
 
   _pdf (x) {
-    return 1 / (x * (this.c[1] - this.c[0]))
+    return 1 / (x * (this.c.logB - this.c.logA))
   }
 
   _cdf (x) {
-    return (Math.log(x) - this.c[0]) / (this.c[1] - this.c[0])
+    return (Math.log(x) - this.c.logA) / (this.c.logB - this.c.logA)
   }
 }


### PR DESCRIPTION
Closes #180

## Summary
- Replaces positional array `this.c = [...]` with named object `this.c = { name: value, ... }` in four location-scale distributions (Cauchy, Normal, Moyal, Reciprocal)
- Updates all `this.c[N]` access sites to named property access throughout `_pdf`, `_cdf`, `_q`, and `_generator`
- Part of the broader `this.c` migration tracked in #172

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/cauchy.js`**: `this.c[0]` → `this.c.piGamma`
- **`src/dist/normal.js`**: `this.c[0]` → `this.c.sigmaRoot2Pi`, `this.c[1]` → `this.c.sigmaRoot2`
- **`src/dist/moyal.js`**: `this.c[0]` → `this.c.sigmaRoot2Pi`
- **`src/dist/reciprocal.js`**: `this.c[0]` → `this.c.logA`, `this.c[1]` → `this.c.logB`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7yGEi7EnaGUVEbPm4YAs7)_