### PR TITLE
Migrate this.c to named object in bounded uniform-shape distributions

### DIFF
--- a/src/dist/arcsine.js
+++ b/src/dist/arcsine.js
@@ -37,11 +37,11 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      1 / Math.PI,
-      b - a,
-      0.5 * Math.PI
-    ]
+    this.c = {
+      invPi: 1 / Math.PI,
+      range: b - a,
+      halfPi: 0.5 * Math.PI
+    }
   }
 
   _generator () {
@@ -50,15 +50,15 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.c[0] / Math.sqrt((x - this.p.a) * (this.p.b - x))
+    return this.c.invPi / Math.sqrt((x - this.p.a) * (this.p.b - x))
   }
 
   _cdf (x) {
-    return 2 * this.c[0] * Math.asin(Math.sqrt((x - this.p.a) / this.c[1]))
+    return 2 * this.c.invPi * Math.asin(Math.sqrt((x - this.p.a) / this.c.range))
   }
 
   _q (p) {
-    const s = Math.sin(this.c[2] * p)
-    return (s * s) * this.c[1] + this.p.a
+    const s = Math.sin(this.c.halfPi * p)
+    return (s * s) * this.c.range + this.p.a
   }
 }

--- a/src/dist/discrete-uniform.js
+++ b/src/dist/discrete-uniform.js
@@ -37,9 +37,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      this.p.xmax - this.p.xmin + 1
-    ]
+    this.c = {
+      n: this.p.xmax - this.p.xmin + 1
+    }
   }
 
   _generator () {
@@ -48,16 +48,16 @@ export default class extends Distribution {
   }
 
   _pdf () {
-    return 1 / this.c[0]
+    return 1 / this.c.n
   }
 
   _cdf (x) {
-    return (1 + x - this.p.xmin) / this.c[0]
+    return (1 + x - this.p.xmin) / this.c.n
   }
 
   _q (p) {
     // ceil(x)-1 equals floor(x) for non-integer x but gives x-1 when x is exactly an integer,
     // which is needed when p*N is exact so CDF(k) = p and the correct quantile is k, not k+1.
-    return Math.ceil(p * this.c[0]) - 1 + this.p.xmin
+    return Math.ceil(p * this.c.n) - 1 + this.p.xmin
   }
 }

--- a/src/dist/trapezoidal.js
+++ b/src/dist/trapezoidal.js
@@ -38,12 +38,12 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      d + c - a - b,
-      b - a,
-      d - c,
-      a + b
-    ]
+    this.c = {
+      scale: d + c - a - b,
+      ba: b - a,
+      dc: d - c,
+      aPb: a + b
+    }
   }
 
   _generator () {
@@ -53,31 +53,31 @@ export default class extends Distribution {
 
   _pdf (x) {
     if (x < this.p.b) {
-      return 2 * (x - this.p.a) / (this.c[1] * this.c[0])
+      return 2 * (x - this.p.a) / (this.c.ba * this.c.scale)
     } else if (x < this.p.c) {
-      return 2 / this.c[0]
+      return 2 / this.c.scale
     } else {
-      return 2 * (this.p.d - x) / (this.c[2] * this.c[0])
+      return 2 * (this.p.d - x) / (this.c.dc * this.c.scale)
     }
   }
 
   _cdf (x) {
     if (x < this.p.b) {
-      return Math.pow(x - this.p.a, 2) / (this.c[1] * this.c[0])
+      return Math.pow(x - this.p.a, 2) / (this.c.ba * this.c.scale)
     } else if (x < this.p.c) {
-      return (2 * x - this.c[3]) / this.c[0]
+      return (2 * x - this.c.aPb) / this.c.scale
     } else {
-      return 1 - Math.pow(this.p.d - x, 2) / (this.c[2] * this.c[0])
+      return 1 - Math.pow(this.p.d - x, 2) / (this.c.dc * this.c.scale)
     }
   }
 
   _q (p) {
-    if (p < this.c[1] / this.c[0]) {
-      return this.p.a + Math.sqrt(this.c[0] * this.c[1] * p)
-    } else if (p < (2 * this.p.c - this.c[3]) / this.c[0]) {
-      return (this.c[0] * p + this.c[3]) / 2
+    if (p < this.c.ba / this.c.scale) {
+      return this.p.a + Math.sqrt(this.c.scale * this.c.ba * p)
+    } else if (p < (2 * this.p.c - this.c.aPb) / this.c.scale) {
+      return (this.c.scale * p + this.c.aPb) / 2
     } else {
-      return this.p.d - Math.sqrt(this.c[0] * this.c[2] * (1 - p))
+      return this.p.d - Math.sqrt(this.c.scale * this.c.dc * (1 - p))
     }
   }
 }

--- a/src/dist/triangular.js
+++ b/src/dist/triangular.js
@@ -39,13 +39,13 @@ export default class extends Distribution {
     const ba = b - a
     const bc = b - c
     const ca = c - a
-    this.c = [
+    this.c = {
       ba,
       bc,
       ca,
-      ba * bc,
-      ba * ca
-    ]
+      baBc: ba * bc,
+      baCa: ba * ca
+    }
   }
 
   _generator () {
@@ -55,19 +55,19 @@ export default class extends Distribution {
 
   _pdf (x) {
     return x < this.p.c
-      ? 2 * (x - this.p.a) / this.c[4]
-      : 2 * (this.p.b - x) / this.c[3]
+      ? 2 * (x - this.p.a) / this.c.baCa
+      : 2 * (this.p.b - x) / this.c.baBc
   }
 
   _cdf (x) {
     return x < this.p.c
-      ? Math.pow(x - this.p.a, 2) / this.c[4]
-      : 1 - Math.pow(this.p.b - x, 2) / this.c[3]
+      ? Math.pow(x - this.p.a, 2) / this.c.baCa
+      : 1 - Math.pow(this.p.b - x, 2) / this.c.baBc
   }
 
   _q (p) {
-    return p < this.c[2] / this.c[0]
-      ? this.p.a + Math.sqrt(p * this.c[4])
-      : this.p.b - Math.sqrt((1 - p) * this.c[3])
+    return p < this.c.ca / this.c.ba
+      ? this.p.a + Math.sqrt(p * this.c.baCa)
+      : this.p.b - Math.sqrt((1 - p) * this.c.baBc)
   }
 }

--- a/src/dist/u-quadratic.js
+++ b/src/dist/u-quadratic.js
@@ -35,11 +35,11 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      12 / Math.pow(b - a, 3),
-      (a + b) / 2,
-      Math.pow((b - a) / 2, 3)
-    ]
+    this.c = {
+      alpha: 12 / Math.pow(b - a, 3),
+      beta: (a + b) / 2,
+      halfRangeCubed: Math.pow((b - a) / 2, 3)
+    }
   }
 
   _generator () {
@@ -48,14 +48,14 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.c[0] * Math.pow(x - this.c[1], 2)
+    return this.c.alpha * Math.pow(x - this.c.beta, 2)
   }
 
   _cdf (x) {
-    return this.c[0] * (Math.pow(x - this.c[1], 3) + this.c[2]) / 3
+    return this.c.alpha * (Math.pow(x - this.c.beta, 3) + this.c.halfRangeCubed) / 3
   }
 
   _q (p) {
-    return Math.cbrt(3 * p / this.c[0] - this.c[2]) + this.c[1]
+    return Math.cbrt(3 * p / this.c.alpha - this.c.halfRangeCubed) + this.c.beta
   }
 }

--- a/src/dist/uniform.js
+++ b/src/dist/uniform.js
@@ -36,9 +36,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      xmax - xmin
-    ]
+    this.c = {
+      range: xmax - xmin
+    }
   }
 
   _generator () {
@@ -47,14 +47,14 @@ export default class extends Distribution {
   }
 
   _pdf () {
-    return 1 / this.c[0]
+    return 1 / this.c.range
   }
 
   _cdf (x) {
-    return (x - this.p.xmin) / this.c[0]
+    return (x - this.p.xmin) / this.c.range
   }
 
   _q (p) {
-    return p * this.c[0] + this.p.xmin
+    return p * this.c.range + this.p.xmin
   }
 }


### PR DESCRIPTION
Closes #174

## Summary
- Migrates `this.c` from positional arrays to named objects in 6 bounded uniform-shape distributions: `Uniform`, `DiscreteUniform`, `Triangular`, `Trapezoidal`, `UQuadratic`, and `Arcsine`
- Replaces all `this.c[N]` index accesses with named property accesses (e.g. `this.c[0]` → `this.c.range`) — no logic or formula changes

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/uniform.js`**: `this.c = [range]` → `this.c = { range }`
- **`src/dist/discrete-uniform.js`**: `this.c = [n]` → `this.c = { n }`
- **`src/dist/triangular.js`**: `this.c = [ba, bc, ca, ba*bc, ba*ca]` → named object with `ba`, `bc`, `ca`, `baBc`, `baCa`
- **`src/dist/trapezoidal.js`**: 4-element array → `{ scale, ba, dc, aPb }`
- **`src/dist/u-quadratic.js`**: 3-element array → `{ alpha, beta, halfRangeCubed }`
- **`src/dist/arcsine.js`**: 3-element array → `{ invPi, range, halfPi }`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_011BHBronsmxbXJ7gTDmHMDh)_