### PR TITLE
Migrate this.c to named objects in 21 distributions

### DIFF
--- a/decisions/0008-this-c-named-object-convention.md
+++ b/decisions/0008-this-c-named-object-convention.md
@@ -1,0 +1,46 @@
+# ADR-0008: `this.c` must be a named object, never a positional array
+
+**Date**: 2026-05-22
+**Status**: Accepted
+
+## Context
+
+Every `Distribution` subclass pre-computes expensive constants in its constructor and stores them on `this.c` so that `_pdf`, `_cdf`, and `_q` can reuse them without recomputing on every call.
+
+Historically these were stored as positional arrays:
+
+```js
+this.c = [Math.pow(L, alpha), Math.pow(H, alpha), 1 - Math.pow(L / H, alpha)]
+// used as: this.c[0], this.c[1], this.c[2]
+```
+
+The array form was originally motivated by a belief that V8 optimises small-integer array index access more aggressively than named property access. That belief is obsolete: modern V8 uses hidden classes and inline caches for both patterns, and the difference is not measurable in micro-benchmarks against the numerical work done inside each call.
+
+The positional array form has two active costs:
+
+1. **Magic indices**: `this.c[2]` communicates nothing about what the constant represents. Readers must cross-reference the constructor assignment to understand any usage site.
+2. **Silent breakage on reorder**: swapping two entries in the constructor silently produces wrong results everywhere they are used, with no type-checker or linter catching the error.
+
+Issue #172 identified this as a cross-cutting convention debt and tracked its elimination across all distributions.
+
+## Decision
+
+`this.c` must always be assigned a **named object literal**:
+
+```js
+this.c = {
+  Lalpha: Math.pow(L, alpha),
+  Halpha: Math.pow(H, alpha),
+  denom: 1 - Math.pow(L / H, alpha)
+}
+```
+
+All usage sites reference constants by name (`this.c.Lalpha`, `this.c.denom`, etc.). Positional index access (`this.c[N]`) is never permitted.
+
+The sole exception is `irwin-hall.js`, where `this.c` is a runtime-indexed lookup table built with `Array.from` and accessed as `this.c[k]` inside a loop. That is a genuinely array-shaped data structure, not a bag of named constants, and is exempt from this rule.
+
+## Consequences
+
+- **Easier**: Every usage site is self-documenting. Reordering entries in the constructor is safe — the name change is caught at every call site. New contributors can read `_pdf` or `_cdf` without needing to trace back to the constructor.
+- **Harder**: Nothing. Named property access in modern V8 is not measurably slower than integer-indexed array access for the small constant objects used here.
+- **Tooling**: `this.c = {}` is the default initialised in `_distribution.js` (line 35), consistent with this convention. The `state.constants` restore path (line 368) is also object-shaped and unaffected.

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -31,7 +31,8 @@ class Distribution {
     // Pseudo random number generator
     this.r = new Xoshiro128p()
 
-    // Speed-up constants
+    // Speed-up constants — must be a named object, never a positional array
+    // decisions/0008-this-c-named-object-convention.md
     this.c = {}
   }
 

--- a/src/dist/benini.js
+++ b/src/dist/benini.js
@@ -37,11 +37,11 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      alpha * alpha,
-      4 * beta,
-      0.5 / beta
-    ]
+    this.c = {
+      alpha2: alpha * alpha,
+      fourBeta: 4 * beta,
+      halfInvBeta: 0.5 / beta
+    }
   }
 
   _generator () {
@@ -62,6 +62,6 @@ export default class extends Distribution {
   }
 
   _q (p) {
-    return this.p.sigma * Math.exp(this.c[2] * (Math.sqrt(this.c[0] - this.c[1] * Math.log(1 - p)) - this.p.alpha))
+    return this.p.sigma * Math.exp(this.c.halfInvBeta * (Math.sqrt(this.c.alpha2 - this.c.fourBeta * Math.log(1 - p)) - this.p.alpha))
   }
 }

--- a/src/dist/benktander-ii.js
+++ b/src/dist/benktander-ii.js
@@ -36,13 +36,13 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      (1 - b) / a,
-      Math.exp(-a / b),
-      b / (b - 1),
-      Math.log(a / (1 - b)) + a / (1 - b),
-      1 - b < Number.EPSILON
-    ]
+    this.c = {
+      bm1OverA: (1 - b) / a,
+      expNegAOverB: Math.exp(-a / b),
+      bOverBm1: b / (b - 1),
+      logScaled: Math.log(a / (1 - b)) + a / (1 - b),
+      bIsOne: 1 - b < Number.EPSILON
+    }
   }
 
   _generator () {
@@ -52,7 +52,7 @@ export default class extends Distribution {
 
   _pdf (x) {
     // b = 1
-    if (this.c[4]) {
+    if (this.c.bIsOne) {
       return this.p.a * Math.exp(this.p.a * (1 - x))
     }
 
@@ -63,7 +63,7 @@ export default class extends Distribution {
 
   _cdf (x) {
     // b = 1
-    if (this.c[4]) {
+    if (this.c.bIsOne) {
       // expm1 avoids 1 - exp(arg) cancellation when arg → 0 near x = 1
       return -Math.expm1(this.p.a * (1 - x))
     }
@@ -82,22 +82,22 @@ export default class extends Distribution {
 
   _q (p) {
     // b = 1
-    if (this.c[4]) {
+    if (this.c.bIsOne) {
       return 1 - Math.log(1 - p) / this.p.a
     }
 
     // Check if b is too close to 1
-    const w = lambertW0(Math.pow(this.c[1] * (1 - p), this.c[2]) / this.c[0])
+    const w = lambertW0(Math.pow(this.c.expNegAOverB * (1 - p), this.c.bOverBm1) / this.c.bm1OverA)
     if (!Number.isFinite(w)) {
       // 1 - b << 1, use logarithms
-      const l1 = this.c[3] + this.c[2] * Math.log(1 - p)
+      const l1 = this.c.logScaled + this.c.bOverBm1 * Math.log(1 - p)
       const l2 = Math.log(l1)
 
       // W(x) ~= ln(x) - ln ln(x) - ln(x) / (ln ln(x))
-      return Math.pow(this.c[0] * (l1 - l2 + l2 / l1), 1 / this.p.b)
+      return Math.pow(this.c.bm1OverA * (l1 - l2 + l2 / l1), 1 / this.p.b)
     } else {
       // All other cases
-      return Math.pow(this.c[0] * w, 1 / this.p.b)
+      return Math.pow(this.c.bm1OverA * w, 1 / this.p.b)
     }
   }
 }

--- a/src/dist/bounded-pareto.js
+++ b/src/dist/bounded-pareto.js
@@ -38,11 +38,11 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      Math.pow(L, alpha),
-      Math.pow(H, alpha),
-      (1 - Math.pow(L / H, alpha))
-    ]
+    this.c = {
+      Lalpha: Math.pow(L, alpha),
+      Halpha: Math.pow(H, alpha),
+      denom: 1 - Math.pow(L / H, alpha)
+    }
   }
 
   _generator () {
@@ -51,14 +51,14 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.p.alpha * Math.pow(this.p.L / x, this.p.alpha) / (x * this.c[2])
+    return this.p.alpha * Math.pow(this.p.L / x, this.p.alpha) / (x * this.c.denom)
   }
 
   _cdf (x) {
-    return (1 - this.c[0] * Math.pow(x, -this.p.alpha)) / this.c[2]
+    return (1 - this.c.Lalpha * Math.pow(x, -this.p.alpha)) / this.c.denom
   }
 
   _q (p) {
-    return Math.pow((this.c[1] + p * (this.c[0] - this.c[1])) / (this.c[0] * this.c[1]), -1 / this.p.alpha)
+    return Math.pow((this.c.Halpha + p * (this.c.Lalpha - this.c.Halpha)) / (this.c.Lalpha * this.c.Halpha), -1 / this.p.alpha)
   }
 }

--- a/src/dist/bradford.js
+++ b/src/dist/bradford.js
@@ -33,11 +33,11 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    const c0 = Math.log(1 + c)
-    this.c = [
-      c0,
-      c / c0
-    ]
+    const log1pc = Math.log(1 + c)
+    this.c = {
+      log1pc,
+      cOverLog1pc: c / log1pc
+    }
   }
 
   _generator () {
@@ -46,14 +46,14 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.c[1] / (1 + this.p.c * x)
+    return this.c.cOverLog1pc / (1 + this.p.c * x)
   }
 
   _cdf (x) {
-    return Math.log(1 + this.p.c * x) / this.c[0]
+    return Math.log(1 + this.p.c * x) / this.c.log1pc
   }
 
   _q (p) {
-    return (Math.exp(this.c[0] * p) - 1) / this.p.c
+    return (Math.exp(this.c.log1pc * p) - 1) / this.p.c
   }
 }

--- a/src/dist/burr.js
+++ b/src/dist/burr.js
@@ -36,11 +36,11 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      c * k,
-      -1 / k,
-      1 / c
-    ]
+    this.c = {
+      ck: c * k,
+      negInvK: -1 / k,
+      invC: 1 / c
+    }
   }
 
   _generator () {
@@ -50,7 +50,7 @@ export default class extends Distribution {
 
   _pdf (x) {
     const y = Math.pow(x, this.p.c)
-    return this.c[0] * y / (x * Math.pow(1 + y, this.p.k + 1))
+    return this.c.ck * y / (x * Math.pow(1 + y, this.p.k + 1))
   }
 
   _cdf (x) {
@@ -59,6 +59,6 @@ export default class extends Distribution {
   }
 
   _q (p) {
-    return Math.pow(Math.pow(1 - p, this.c[1]) - 1, this.c[2])
+    return Math.pow(Math.pow(1 - p, this.c.negInvK) - 1, this.c.invC)
   }
 }

--- a/src/dist/champernowne.js
+++ b/src/dist/champernowne.js
@@ -20,9 +20,9 @@ export default class extends Distribution {
       closed: false
     }]
 
-    this.c = [
-      1
-    ]
+    this.c = {
+      norm: 1
+    }
   }
 
   _generator () {
@@ -31,10 +31,10 @@ export default class extends Distribution {
 
   _pdf (x) {
     // TODO Add normalization factor
-    return this.c[0] / (Math.cosh(this.p.alpha * (x - this.p.x0)) + this.p.lambda)
+    return this.c.norm / (Math.cosh(this.p.alpha * (x - this.p.x0)) + this.p.lambda)
   }
 
   _cdf () {
-    return this.c[0]
+    return this.c.norm
   }
 }

--- a/src/dist/delaporte.js
+++ b/src/dist/delaporte.js
@@ -43,11 +43,11 @@ export default class extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = [
-      beta / (lambda * (1 + beta)),
-      -lambda - alpha * Math.log(1 + beta),
-      Math.log(lambda)
-    ]
+    this.c = {
+      r: beta / (lambda * (1 + beta)),
+      baseLogProb: -lambda - alpha * Math.log(1 + beta),
+      logLambda: Math.log(lambda)
+    }
   }
 
   _pk (k) {
@@ -58,19 +58,19 @@ export default class extends PreComputed {
 
     // Advance until k - 1
     for (let j = 1; j < k; j++) {
-      dz *= (this.p.alpha + j - 1) * this.c[0] * ki / j
+      dz *= (this.p.alpha + j - 1) * this.c.r * ki / j
       ki--
       z += dz
     }
 
     // If k > 0, add last term
     if (k > 0) {
-      dz *= (this.p.alpha + k - 1) * this.c[0] / k
+      dz *= (this.p.alpha + k - 1) * this.c.r / k
       z += dz
     }
 
     // Return sum with constants
-    return Math.log(z) + k * this.c[2] - logGamma(k + 1) + this.c[1]
+    return Math.log(z) + k * this.c.logLambda - logGamma(k + 1) + this.c.baseLogProb
   }
 
   _generator () {

--- a/src/dist/flory-schulz.js
+++ b/src/dist/flory-schulz.js
@@ -33,29 +33,29 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      1 - a
-    ]
+    this.c = {
+      oneMinusA: 1 - a
+    }
   }
 
   _generator () {
     let k = 1
     const r = this.r.next()
     let ak = 1 + this.p.a
-    let p = this.c[0]
+    let p = this.c.oneMinusA
     while (r < p * ak) {
       ak += this.p.a
-      p *= this.c[0]
+      p *= this.c.oneMinusA
       k++
     }
     return k
   }
 
   _pdf (x) {
-    return this.p.a * this.p.a * x * Math.pow(this.c[0], x - 1)
+    return this.p.a * this.p.a * x * Math.pow(this.c.oneMinusA, x - 1)
   }
 
   _cdf (x) {
-    return 1 - Math.pow(this.c[0], x) * (1 + this.p.a * x)
+    return 1 - Math.pow(this.c.oneMinusA, x) * (1 + this.p.a * x)
   }
 }

--- a/src/dist/generalized-hermite.js
+++ b/src/dist/generalized-hermite.js
@@ -46,24 +46,24 @@ export default class extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = [
-      Math.log(a1 + m * a2),
-      (a1 + m * m * a2) / (a1 + m * a2),
-      -a1 - a2
-    ]
+    this.c = {
+      logMu: Math.log(a1 + m * a2),
+      d: (a1 + m * m * a2) / (a1 + m * a2),
+      baseLogProb: -a1 - a2
+    }
   }
 
   _pk (k) {
     if (k === 0) {
-      return this.c[2]
+      return this.c.baseLogProb
     }
 
     if (k < this.p.m) {
-      return this.c[2] + k * this.c[0] - logGamma(k + 1) + k * Math.log((this.p.m - this.c[1]) / (this.p.m - 1))
+      return this.c.baseLogProb + k * this.c.logMu - logGamma(k + 1) + k * Math.log((this.p.m - this.c.d) / (this.p.m - 1))
     }
 
-    return this.c[0] +
-      Math.log((this.c[1] - 1) * Math.exp(this.pdfTable[k - this.p.m]) + (this.p.m - this.c[1]) * Math.exp(this.pdfTable[k - 1])) -
+    return this.c.logMu +
+      Math.log((this.c.d - 1) * Math.exp(this.pdfTable[k - this.p.m]) + (this.p.m - this.c.d) * Math.exp(this.pdfTable[k - 1])) -
       Math.log((k * (this.p.m - 1)))
   }
 

--- a/src/dist/heads-minus-tails.js
+++ b/src/dist/heads-minus-tails.js
@@ -37,17 +37,17 @@ export default class extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = [
-      2 * ni * Math.log(0.5)
-    ]
+    this.c = {
+      baseLogProb: 2 * ni * Math.log(0.5)
+    }
   }
 
   _pk (k) {
     if (k === 0) {
-      return this.c[0] + logBinomial(2 * this.p.n, this.p.n)
+      return this.c.baseLogProb + logBinomial(2 * this.p.n, this.p.n)
     } else {
       return k % 2 === 0
-        ? Math.log(2) + this.c[0] + logBinomial(2 * this.p.n, Math.round(k / 2) + this.p.n)
+        ? Math.log(2) + this.c.baseLogProb + logBinomial(2 * this.p.n, Math.round(k / 2) + this.p.n)
         : -Infinity
     }
   }

--- a/src/dist/inverse-gamma.js
+++ b/src/dist/inverse-gamma.js
@@ -30,7 +30,7 @@ export default class extends Gamma {
     }]
 
     // Speed-up constants
-    this.c = [Math.pow(beta, alpha)]
+    this.c = { betaAlpha: Math.pow(beta, alpha) }
   }
 
   _generator () {

--- a/src/dist/log-logistic.js
+++ b/src/dist/log-logistic.js
@@ -35,9 +35,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      beta / alpha
-    ]
+    this.c = {
+      betaOverAlpha: beta / alpha
+    }
   }
 
   _generator () {
@@ -48,7 +48,7 @@ export default class extends Distribution {
   _pdf (x) {
     const xa = x / this.p.alpha
     const y = Math.pow(xa, this.p.beta - 1)
-    return this.c[0] * y / Math.pow(1 + xa * y, 2)
+    return this.c.betaOverAlpha * y / Math.pow(1 + xa * y, 2)
   }
 
   _cdf (x) {

--- a/src/dist/logarithmic.js
+++ b/src/dist/logarithmic.js
@@ -37,10 +37,10 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      a * (1 - Math.log(a)),
-      b * (1 - Math.log(b))
-    ]
+    this.c = {
+      fa: a * (1 - Math.log(a)),
+      fb: b * (1 - Math.log(b))
+    }
   }
 
   _generator () {
@@ -49,15 +49,15 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return Math.log(x) / (this.c[0] - this.c[1])
+    return Math.log(x) / (this.c.fa - this.c.fb)
   }
 
   _cdf (x) {
-    return (this.c[0] - x * (1 - Math.log(x))) / (this.c[0] - this.c[1])
+    return (this.c.fa - x * (1 - Math.log(x))) / (this.c.fa - this.c.fb)
   }
 
   _q (p) {
-    const z = p * (this.c[0] - this.c[1]) - this.c[0]
+    const z = p * (this.c.fa - this.c.fb) - this.c.fa
     return z / lambertW0(z / Math.E)
   }
 }

--- a/src/dist/makeham.js
+++ b/src/dist/makeham.js
@@ -39,11 +39,11 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants.
-    this.c = [
-      alpha / (beta * lambda),
-      alpha * Math.exp(alpha / lambda) / lambda,
-      -beta / lambda
-    ]
+    this.c = {
+      alphaOverBetaLambda: alpha / (beta * lambda),
+      expFactor: alpha * Math.exp(alpha / lambda) / lambda,
+      negBetaOverLambda: -beta / lambda
+    }
   }
 
   _generator () {
@@ -68,15 +68,15 @@ export default class extends Distribution {
   }
 
   _q (p) {
-    const z = this.c[1] * Math.pow(1 - p, this.c[2])
+    const z = this.c.expFactor * Math.pow(1 - p, this.c.negBetaOverLambda)
 
     // Handle z >> 1 case.
     const w = lambertW0(z)
     if (Number.isFinite(w)) {
-      return this.c[0] - Math.log(1 - p) / this.p.lambda - w / this.p.beta
+      return this.c.alphaOverBetaLambda - Math.log(1 - p) / this.p.lambda - w / this.p.beta
     } else {
-      const t = Math.log(this.c[1]) + this.c[2] * Math.log(1 - p)
-      return this.c[0] - Math.log(1 - p) / this.p.lambda - (t - Math.log(t)) / this.p.beta
+      const t = Math.log(this.c.expFactor) + this.c.negBetaOverLambda * Math.log(1 - p)
+      return this.c.alphaOverBetaLambda - Math.log(1 - p) / this.p.lambda - (t - Math.log(t)) / this.p.beta
     }
   }
 }

--- a/src/dist/nakagami.js
+++ b/src/dist/nakagami.js
@@ -37,9 +37,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      2 * Math.pow(this.p.m, this.p.m) / Math.pow(this.p.omega, this.p.m)
-    ]
+    this.c = {
+      normFactor: 2 * Math.pow(this.p.m, this.p.m) / Math.pow(this.p.omega, this.p.m)
+    }
   }
 
   _generator () {
@@ -48,7 +48,7 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.c[0] * Math.pow(x, 2 * this.p.m - 1) * Math.exp(-this.p.m * x * x / this.p.omega - logGamma(this.p.m))
+    return this.c.normFactor * Math.pow(x, 2 * this.p.m - 1) * Math.exp(-this.p.m * x * x / this.p.omega - logGamma(this.p.m))
   }
 
   _cdf (x) {

--- a/src/dist/neyman-a.js
+++ b/src/dist/neyman-a.js
@@ -39,16 +39,16 @@ export default class extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = [
-      Math.exp(-lambda * (1 - Math.exp(-phi))),
-      lambda * phi * Math.exp(-phi)
-    ]
+    this.c = {
+      p0: Math.exp(-lambda * (1 - Math.exp(-phi))),
+      r: lambda * phi * Math.exp(-phi)
+    }
   }
 
   // Using Eq. (131) in Johnson, Kotz, Kemp: Univariate Discrete Distributions.
   _pk (k) {
     if (k === 0) {
-      return this.c[0]
+      return this.c.p0
     }
 
     let dz = 1
@@ -57,7 +57,7 @@ export default class extends PreComputed {
       dz *= this.p.phi / j
       z += dz * this.pdfTable[k - j - 1]
     }
-    return this.c[1] * z / k
+    return this.c.r * z / k
   }
 
   _generator () {

--- a/src/dist/polya-aeppli.js
+++ b/src/dist/polya-aeppli.js
@@ -39,9 +39,9 @@ export default class extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = [
-      Math.log(lambda * (1 - theta)) - lambda
-    ]
+    this.c = {
+      logP1: Math.log(lambda * (1 - theta)) - lambda
+    }
   }
 
   _pk (k) {
@@ -50,7 +50,7 @@ export default class extends PreComputed {
     }
 
     if (k === 1) {
-      return this.c[0]
+      return this.c.logP1
     }
 
     return this.pdfTable[k - 1] + Math.log((this.p.lambda * (1 - this.p.theta) + 2 * (k - 1) * this.p.theta - this.p.theta * this.p.theta * (k - 2) * Math.exp(this.pdfTable[k - 2] - this.pdfTable[k - 1])) / k)

--- a/src/dist/rice.js
+++ b/src/dist/rice.js
@@ -37,31 +37,31 @@ export default class extends Distribution {
       closed: false
     }]
 
-    // Speet-up constants
-    this.c = [
-      0.5 * Math.pow(nu / sigma, 2),
-      sigma * sigma,
-      nu / (sigma * sigma),
-      nu * nu
-    ]
+    // Speed-up constants
+    this.c = {
+      halfNuSqRatio: 0.5 * Math.pow(nu / sigma, 2),
+      sigma2: sigma * sigma,
+      nuOverSigma2: nu / (sigma * sigma),
+      nu2: nu * nu
+    }
   }
 
   _generator () {
     // Direct sampling using Poisson and gamma
-    const p = poisson(this.r, this.c[0])
+    const p = poisson(this.r, this.c.halfNuSqRatio)
     const x = gamma(this.r, p + 1, 0.5)
     return this.p.sigma * Math.sqrt(x)
   }
 
   _pdf (x) {
-    const z = x * this.p.nu / this.c[1]
+    const z = x * this.p.nu / this.c.sigma2
     const b = besselI(0, z)
 
     // Handle z >> 1 case (using asymptotic form of Bessel)
     if (Number.isFinite(b)) {
-      return x * Math.exp(-0.5 * (x * x + this.c[3]) / this.c[1]) * besselI(0, x * this.c[2]) / this.c[1]
+      return x * Math.exp(-0.5 * (x * x + this.c.nu2) / this.c.sigma2) * besselI(0, x * this.c.nuOverSigma2) / this.c.sigma2
     } else {
-      return x * Math.exp(-0.5 * (x * x + this.c[3]) / this.c[1] + z - 0.5 * Math.log(2 * Math.PI * z)) / this.c[1]
+      return x * Math.exp(-0.5 * (x * x + this.c.nu2) / this.c.sigma2 + z - 0.5 * Math.log(2 * Math.PI * z)) / this.c.sigma2
     }
   }
 
@@ -69,6 +69,6 @@ export default class extends Distribution {
     // Complementary Marcum Q avoids catastrophic cancellation in the
     // lower tail: `1 - marcumQ(...)` would lose precision because
     // marcumQ internally forms `1 - P` to deliver Q (#246).
-    return marcumP(1, this.c[0], Math.pow(x / this.p.sigma, 2) / 2)
+    return marcumP(1, this.c.halfNuSqRatio, Math.pow(x / this.p.sigma, 2) / 2)
   }
 }

--- a/src/dist/skellam.js
+++ b/src/dist/skellam.js
@@ -37,12 +37,12 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      Math.exp(-mu1 - mu2),
-      Math.sqrt(mu1 / mu2),
-      2 * Math.sqrt(mu1 * mu2),
-      marcumQ(1, mu2, mu1)
-    ]
+    this.c = {
+      expNeg: Math.exp(-mu1 - mu2),
+      sqrtRatio: Math.sqrt(mu1 / mu2),
+      twoSqrtProd: 2 * Math.sqrt(mu1 * mu2),
+      cdfAtZero: marcumQ(1, mu2, mu1)
+    }
   }
 
   _generator () {
@@ -51,7 +51,7 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.c[0] * Math.pow(this.c[1], x) * besselI(Math.abs(x), this.c[2])
+    return this.c.expNeg * Math.pow(this.c.sqrtRatio, x) * besselI(Math.abs(x), this.c.twoSqrtProd)
   }
 
   _cdf (x) {
@@ -61,7 +61,7 @@ export default class extends Distribution {
     if (x >= 1) {
       return marcumQ(x + 1, this.p.mu2, this.p.mu1)
     }
-    return this.c[3]
+    return this.c.cdfAtZero
   }
 
   _q (p) {

--- a/src/dist/yule-simon.js
+++ b/src/dist/yule-simon.js
@@ -34,9 +34,9 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      this.p.rho + 1
-    ]
+    this.c = {
+      rhoPlus1: this.p.rho + 1
+    }
   }
 
   _generator () {
@@ -52,10 +52,10 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return this.p.rho * beta(x, this.c[0])
+    return this.p.rho * beta(x, this.c.rhoPlus1)
   }
 
   _cdf (x) {
-    return 1 - x * beta(x, this.c[0])
+    return 1 - x * beta(x, this.c.rhoPlus1)
   }
 }

--- a/src/dist/zeta.js
+++ b/src/dist/zeta.js
@@ -36,9 +36,10 @@ export default class extends Distribution {
     }]
 
     // Speed-up constants
-    this.c = [
-      riemannZeta(s), Math.pow(2, s - 1)
-    ]
+    this.c = {
+      zetaS: riemannZeta(s),
+      pow2sm1: Math.pow(2, s - 1)
+    }
   }
 
   _generator () {
@@ -47,10 +48,10 @@ export default class extends Distribution {
   }
 
   _pdf (x) {
-    return Math.pow(x, -this.p.s) / this.c[0]
+    return Math.pow(x, -this.p.s) / this.c.zetaS
   }
 
   _cdf (x) {
-    return generalizedHarmonic(x, this.p.s) / this.c[0]
+    return generalizedHarmonic(x, this.p.s) / this.c.zetaS
   }
 }


### PR DESCRIPTION
## Summary

- Converts `this.c = [...]` positional arrays to `this.c = { name: value }` named objects in all 21 remaining distributions, closing issues #175, #176, #177, #178, and #179
- Adds ADR-0008 documenting the `this.c` named-object convention with rationale
- Adds inline ADR reference at the `this.c` initialisation site in `_distribution.js`

## Distributions migrated

| File | Keys |
|---|---|
| `bounded-pareto.js` | `Lalpha`, `Halpha`, `denom` |
| `burr.js` | `ck`, `negInvK`, `invC` |
| `benini.js` | `alpha2`, `fourBeta`, `halfInvBeta` |
| `benktander-ii.js` | `bm1OverA`, `expNegAOverB`, `bOverBm1`, `logScaled`, `bIsOne` |
| `bradford.js` | `log1pc`, `cOverLog1pc` |
| `champernowne.js` | `norm` |
| `log-logistic.js` | `betaOverAlpha` |
| `inverse-gamma.js` | `betaAlpha` |
| `makeham.js` | `alphaOverBetaLambda`, `expFactor`, `negBetaOverLambda` |
| `delaporte.js` | `r`, `baseLogProb`, `logLambda` |
| `generalized-hermite.js` | `logMu`, `d`, `baseLogProb` |
| `neyman-a.js` | `p0`, `r` |
| `polya-aeppli.js` | `logP1` |
| `skellam.js` | `expNeg`, `sqrtRatio`, `twoSqrtProd`, `cdfAtZero` |
| `flory-schulz.js` | `oneMinusA` |
| `heads-minus-tails.js` | `baseLogProb` |
| `logarithmic.js` | `fa`, `fb` |
| `yule-simon.js` | `rhoPlus1` |
| `zeta.js` | `zetaS`, `pow2sm1` |
| `nakagami.js` | `normFactor` |
| `rice.js` | `halfNuSqRatio`, `sigma2`, `nuOverSigma2`, `nu2` |

`irwin-hall.js` is intentionally exempt — its `this.c` is a runtime-indexed lookup table, not a bag of named constants.

## ADR

ADR-0008 (`decisions/0008-this-c-named-object-convention.md`) documents the rationale: positional arrays produce magic indices that are opaque at usage sites and silently produce wrong results when reordered; the original V8 performance justification for arrays is obsolete in modern engines.

## Test plan

- [x] `npm run standard` — clean
- [x] `npm test` — 3101 passing
- [x] All 21 index-to-name mappings verified by correctness review

Closes #175, #176, #177, #178, #179

---
_Generated by [Claude Code](https://claude.ai/code/session_012cqHjf2bc7xZyTeNWtcEM1)_