### PR TITLE
Correct distribution JSDoc: remove false optional markers and default-value claims

### DIFF
--- a/src/dist/_beta.js
+++ b/src/dist/_beta.js
@@ -6,8 +6,8 @@ import gamma from './_gamma'
  * @method normal
  * @memberof ran.dist
  * @param {ran.core.Xoshiro128p} r Random generator.
- * @param {number=} a First shape parameter.
- * @param {number=} b Second shape parameter.
+ * @param {number} a First shape parameter.
+ * @param {number} b Second shape parameter.
  * @returns {number} Random variate.
  * @ignore
  */

--- a/src/dist/_chi2.js
+++ b/src/dist/_chi2.js
@@ -6,7 +6,7 @@ import gamma from './_gamma'
  * @method chi2
  * @memberof ran.dist
  * @param {ran.core.Xoshiro128p} r Random generator.
- * @param {number=} nu Degrees of freedom.
+ * @param {number} nu Degrees of freedom.
  * @returns {number} Random variate.
  * @ignore
  */

--- a/src/dist/_exponential.js
+++ b/src/dist/_exponential.js
@@ -4,7 +4,7 @@
  * @method exponential
  * @memberof ran.dist
  * @param {ran.core.Xoshiro128p} r Random generator.
- * @param {number=} lambda Rate parameter. Default value is 1.
+ * @param {number} lambda Rate parameter.
  * @returns {number} Random variate.
  * @ignore
  */

--- a/src/dist/_gamma.js
+++ b/src/dist/_gamma.js
@@ -7,7 +7,7 @@ import normal from './_normal'
  * @memberof ran.dist
  * @param {ran.core.Xoshiro128p} r Random generator.
  * @param {number} a Shape parameter.
- * @param {number=} b Rate parameter. Default value is 1.
+ * @param {number} b Rate parameter.
  * @returns {number} Random variate.
  * @ignore
  */

--- a/src/dist/_normal.js
+++ b/src/dist/_normal.js
@@ -4,8 +4,8 @@
  * @method normal
  * @memberof ran.dist
  * @param {ran.core.Xoshiro128p} r Random generator.
- * @param {number=} mu Distribution mean. Default value is 0.
- * @param {number=} sigma Distribution standard deviation. Default value is 1.
+ * @param {number} mu Distribution mean.
+ * @param {number} sigma Distribution standard deviation.
  * @returns {number} Random variate.
  * @ignore
  */

--- a/src/dist/_sign.js
+++ b/src/dist/_sign.js
@@ -4,7 +4,7 @@
  * @method sign
  * @memberof ran.dist
  * @param {ran.core.Xoshiro128p} r Random generator.
- * @param {number=} p Probability of +1. Default value is 0.5.
+ * @param {number} p Probability of +1.
  * @return {number} Random sign (-1 or +1).
  * @ignore
  */

--- a/src/dist/alpha.js
+++ b/src/dist/alpha.js
@@ -12,8 +12,8 @@ import { erf, erfinv } from '../special'
  *
  * @class Alpha
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter. Default value is 1.
- * @param {number=} beta Scale parameter. Default value is 1.
+ * @param {number} alpha Shape parameter.
+ * @param {number} beta Scale parameter.
  * @see https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/alppdf.htm
  * @constructor
  */

--- a/src/dist/anglit.js
+++ b/src/dist/anglit.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Anglit
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} beta Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} beta Scale parameter.
  * @see https://docs.scipy.org/doc/scipy-1.0.0/reference/tutorial/stats/continuous_anglit.html
  * @constructor
  */

--- a/src/dist/arcsine.js
+++ b/src/dist/arcsine.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Arcsine
  * @memberof ran.dist
- * @param {number=} a Lower boundary. Default value is 0.
- * @param {number=} b Upper boundary. Default value is 1.
+ * @param {number} a Lower boundary.
+ * @param {number} b Upper boundary.
  * @see https://en.wikipedia.org/wiki/Arcsine_distribution#Arbitrary_bounded_support
  * @constructor
  */

--- a/src/dist/balding-nichols.js
+++ b/src/dist/balding-nichols.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class BaldingNichols
  * @memberof ran.dist
- * @param {number=} F Fixation index. Default value is 0.5.
- * @param {number=} p Allele frequency. Default value is 0.5.
+ * @param {number} F Fixation index.
+ * @param {number} p Allele frequency.
  * @see https://en.wikipedia.org/wiki/Balding%E2%80%93Nichols_model
  * @constructor
  */

--- a/src/dist/bates.js
+++ b/src/dist/bates.js
@@ -11,9 +11,9 @@ import Distribution from './_distribution'
  *
  * @class Bates
  * @memberof ran.dist
- * @param {number=} n Number of uniform variates to sum. If not an integer, it is rounded to the nearest one. Default value is 10.
- * @param {number=} a Lower boundary of the uniform variate. Default value is 0.
- * @param {number=} b Upper boundary of the uniform variate. Default value is 1.
+ * @param {number} n Number of uniform variates to sum. If not an integer, it is rounded to the nearest one.
+ * @param {number} a Lower boundary of the uniform variate.
+ * @param {number} b Upper boundary of the uniform variate.
  * @see https://en.wikipedia.org/wiki/Bates_distribution
  * @constructor
  */

--- a/src/dist/benini.js
+++ b/src/dist/benini.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class Benini
  * @memberof ran.dist
- * @param {number=} alpha First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 1.
- * @param {number=} sigma Scale parameter. Default value is 1.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
+ * @param {number} sigma Scale parameter.
  * @see https://en.wikipedia.org/wiki/Benini_distribution
  * @constructor
  */

--- a/src/dist/benktander-ii.js
+++ b/src/dist/benktander-ii.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class BenktanderII
  * @memberof ran.dist
- * @param {number=} a Scale parameter. Default value is 1.
- * @param {number=} b Shape parameter. Default value is 0.5.
+ * @param {number} a Scale parameter.
+ * @param {number} b Shape parameter.
  * @see https://en.wikipedia.org/wiki/Benktander_type_II_distribution
  * @constructor
  */

--- a/src/dist/bernoulli.js
+++ b/src/dist/bernoulli.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class Bernoulli
  * @memberof ran.dist
- * @param {number=} p Probability of the outcome 1. Default value is 0.5.
+ * @param {number} p Probability of the outcome 1.
  * @see https://en.wikipedia.org/wiki/Bernoulli_distribution
  * @constructor
  */

--- a/src/dist/beta-binomial.js
+++ b/src/dist/beta-binomial.js
@@ -11,9 +11,9 @@ import Distribution from './_distribution'
  *
  * @class BetaBinomial
  * @memberof ran.dist
- * @param {number=} n Number of trials. Default value is 10.
- * @param {number=} alpha First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 2.
+ * @param {number} n Number of trials.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Beta-binomial_distribution
  * @constructor
  */

--- a/src/dist/beta-geometric.js
+++ b/src/dist/beta-geometric.js
@@ -12,8 +12,8 @@ import rBeta from './_beta'
  *
  * @class BetaGeometric
  * @memberof ran.dist
- * @param {number=} alpha First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 1.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
  * @see https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/bgepdf.htm
  * @constructor
  */

--- a/src/dist/beta-prime.js
+++ b/src/dist/beta-prime.js
@@ -12,8 +12,8 @@ import Beta from './beta'
  *
  * @class BetaPrime
  * @memberof ran.dist
- * @param {number=} alpha First shape parameter. Default value is 2.
- * @param {number=} beta Second shape parameter. Default value is 2.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Beta_prime_distribution
  * @constructor
  */

--- a/src/dist/beta-rectangular.js
+++ b/src/dist/beta-rectangular.js
@@ -10,11 +10,11 @@ import Distribution from './_distribution'
  *
  * @class BetaRectangular
  * @memberof ran.dist
- * @param {number=} alpha First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 1.
- * @param {number=} theta Mixture parameter. Default value is 0.5.
- * @param {number=} a Lower boundary of the support. Default value is 0.
- * @param {number=} b Upper boundary of the support. Default value is 1.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
+ * @param {number} theta Mixture parameter.
+ * @param {number} a Lower boundary of the support.
+ * @param {number} b Upper boundary of the support.
  * @see https://en.wikipedia.org/wiki/Beta_rectangular_distribution
  * @constructor
  */

--- a/src/dist/beta.js
+++ b/src/dist/beta.js
@@ -12,8 +12,8 @@ import Distribution from './_distribution'
  *
  * @class Beta
  * @memberof ran.dist
- * @param {number=} alpha First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 1.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Beta_distribution
  * @constructor
  */

--- a/src/dist/binomial.js
+++ b/src/dist/binomial.js
@@ -11,8 +11,8 @@ import Categorical from './categorical'
  *
  * @class Binomial
  * @memberof ran.dist
- * @param {number=} n Number of trials. Default value is 100.
- * @param {number=} p Probability of success. Default value is 0.5.
+ * @param {number} n Number of trials.
+ * @param {number} p Probability of success.
  * @see https://en.wikipedia.org/wiki/Binomial_distribution
  * @constructor
  */

--- a/src/dist/birnbaum-saunders.js
+++ b/src/dist/birnbaum-saunders.js
@@ -10,9 +10,9 @@ import Distribution from './_distribution'
  *
  * @class BirnbaumSaunders
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} beta Scale parameter. Default value is 1.
- * @param {number=} gamma Shape parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} beta Scale parameter.
+ * @param {number} gamma Shape parameter.
  * @see https://en.wikipedia.org/wiki/Birnbaum%E2%80%93Saunders_distribution
  * @constructor
  */

--- a/src/dist/borel-tanner.js
+++ b/src/dist/borel-tanner.js
@@ -11,9 +11,8 @@ import Distribution from './_distribution'
  *
  * @class BorelTanner
  * @memberof ran.dist
- * @param {number} mu Distribution parameter. Default value is 0.5.
+ * @param {number} mu Distribution parameter.
  * @param {number} n Number of Borel distributed variates to add. If not an integer, it is rounded to the nearest one.
- * Default value is 2.
  * @see https://en.wikipedia.org/wiki/Borel_distribution#Borel%E2%80%93Tanner_distribution
  * @constructor
  */

--- a/src/dist/borel.js
+++ b/src/dist/borel.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * @class Borel
  * @memberof ran.dist
- * @param {number} mu Distribution parameter. Default value is 0.5.
+ * @param {number} mu Distribution parameter.
  * @see https://en.wikipedia.org/wiki/Borel_distribution
  * @constructor
  */

--- a/src/dist/bounded-pareto.js
+++ b/src/dist/bounded-pareto.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class BoundedPareto
  * @memberof ran.dist
- * @param {number=} L Lower boundary. Default value is 1.
- * @param {number=} H Upper boundary. Default value is 10.
- * @param {number=} alpha Shape parameter. Default value is 1.
+ * @param {number} L Lower boundary.
+ * @param {number} H Upper boundary.
+ * @param {number} alpha Shape parameter.
  * @see https://en.wikipedia.org/wiki/Pareto_distribution#Bounded_Pareto_distribution
  * @constructor
  */

--- a/src/dist/bradford.js
+++ b/src/dist/bradford.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * @class Bradford
  * @memberof ran.dist
- * @param {number=} c Shape parameter. Default value is 1.
+ * @param {number} c Shape parameter.
  * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bradford.html
  * @constructor
  */

--- a/src/dist/burr.js
+++ b/src/dist/burr.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Burr
  * @memberof ran.dist
- * @param {number=} c First shape parameter. Default value is 1.
- * @param {number=} k Second shape parameter. Default value is 1.
+ * @param {number} c First shape parameter.
+ * @param {number} k Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Burr_distribution
  * @constructor
  */

--- a/src/dist/categorical.js
+++ b/src/dist/categorical.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Categorical
  * @memberof ran.dist
- * @param {number[]=} weights Weights for the distribution (doesn't need to be normalized). Default value is an array with a single value of 1.
- * @param {number=} min Lowest value to sample (support starts at this value). Default value is [1, 1, 1].
+ * @param {number[]} weights Weights for the distribution (doesn't need to be normalized).
+ * @param {number} min Lowest value to sample (support starts at this value).
  * @see https://en.wikipedia.org/wiki/Categorical_distribution
  * @constructor
  */

--- a/src/dist/cauchy.js
+++ b/src/dist/cauchy.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class Cauchy
  * @memberof ran.dist
- * @param {number=} x0 Location parameter. Default value is 0.
- * @param {number=} gamma Scale parameter. Default value is 1.
+ * @param {number} x0 Location parameter.
+ * @param {number} gamma Scale parameter.
  * @see https://en.wikipedia.org/wiki/Cauchy_distribution
  * @constructor
  */

--- a/src/dist/chi.js
+++ b/src/dist/chi.js
@@ -10,7 +10,7 @@ import Chi2 from './chi2'
  *
  * @class Chi
  * @memberof ran.dist
- * @param {number=} k Degrees of freedom. If not an integer, is rounded to the nearest integer. Default value is 2.
+ * @param {number} k Degrees of freedom. If not an integer, is rounded to the nearest integer.
  * @see https://en.wikipedia.org/wiki/Chi_distribution
  * @constructor
  */

--- a/src/dist/chi2.js
+++ b/src/dist/chi2.js
@@ -10,7 +10,7 @@ import Gamma from './gamma'
  *
  * @class Chi2
  * @memberof ran.dist
- * @param {number=} k Degrees of freedom. If not an integer, is rounded to the nearest one. Default value is 2.
+ * @param {number} k Degrees of freedom. If not an integer, is rounded to the nearest one.
  * @see https://en.wikipedia.org/wiki/Chi-squared_distribution
  * @constructor
  */

--- a/src/dist/dagum.js
+++ b/src/dist/dagum.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class Dagum
  * @memberof ran.dist
- * @param {number=} p First shape parameter. Default value is 1.
- * @param {number=} a Second shape parameter. Default value is 1.
- * @param {number=} b Scale parameter. Default value is 1.
+ * @param {number} p First shape parameter.
+ * @param {number} a Second shape parameter.
+ * @param {number} b Scale parameter.
  * @see https://en.wikipedia.org/wiki/Dagum_distribution
  * @constructor
  */

--- a/src/dist/degenerate.js
+++ b/src/dist/degenerate.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * @class Degenerate
  * @memberof ran.dist
- * @param {number=} x0 Location of the distribution. Default value is 0.
+ * @param {number} x0 Location of the distribution.
  * @see https://en.wikipedia.org/wiki/Degenerate_distribution
  * @constructor
  */

--- a/src/dist/delaporte.js
+++ b/src/dist/delaporte.js
@@ -13,9 +13,9 @@ import PreComputed from './_pre-computed'
  *
  * @class Delaporte
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter of the gamma component. Default component is 1.
- * @param {number=} beta Scale parameter of the gamma component. Default value is 1.
- * @param {number=} lambda Mean of the Poisson component. Default value is 1.
+ * @param {number} alpha Shape parameter of the gamma component. Default component is 1.
+ * @param {number} beta Scale parameter of the gamma component.
+ * @param {number} lambda Mean of the Poisson component.
  * @see https://en.wikipedia.org/wiki/Delaporte_distribution
  * @constructor
  */

--- a/src/dist/discrete-uniform.js
+++ b/src/dist/discrete-uniform.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class DiscreteUniform
  * @memberof ran.dist
- * @param {number=} xmin Lower boundary. If not an integer, it is rounded to the nearest one. Default value is 0.
- * @param {number=} xmax Upper boundary. If not an integer, it is rounded to the nearest one. Default value is 100.
+ * @param {number} xmin Lower boundary. If not an integer, it is rounded to the nearest one.
+ * @param {number} xmax Upper boundary. If not an integer, it is rounded to the nearest one.
  * @see https://en.wikipedia.org/wiki/Discrete_uniform_distribution
  * @constructor
  */

--- a/src/dist/discrete-weibull.js
+++ b/src/dist/discrete-weibull.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class DiscreteWeibull
  * @memberof ran.dist
- * @param {number=} q First shape parameter. Default value is 0.5.
- * @param {number=} beta Second shape parameter. Default value is 1.
+ * @param {number} q First shape parameter.
+ * @param {number} beta Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Discrete_Weibull_distribution
  * @constructor
  */

--- a/src/dist/double-gamma.js
+++ b/src/dist/double-gamma.js
@@ -10,8 +10,8 @@ import Gamma from './gamma'
  *
  * @class DoubleGamma
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter. Default value is 1.
- * @param {number=} beta Rate parameter. Default value is 1.
+ * @param {number} alpha Shape parameter.
+ * @param {number} beta Rate parameter.
  * @see https://docs.scipy.org/doc/scipy/tutorial/stats/continuous_dgamma.html
  * @constructor
  */

--- a/src/dist/double-weibull.js
+++ b/src/dist/double-weibull.js
@@ -9,8 +9,8 @@ import Weibull from './weibull'
  *
  * @class DoubleWeibull
  * @memberof ran.dist
- * @param {number=} lambda Scale parameter. Default value is 1.
- * @param {number=} k Shape parameter. Default value is 1.
+ * @param {number} lambda Scale parameter.
+ * @param {number} k Shape parameter.
  * @see https://docs.scipy.org/doc/scipy/tutorial/stats/continuous_dweibull.html
  * @constructor
  */

--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -16,10 +16,10 @@ import Distribution from './_distribution'
  *
  * @class DoublyNoncentralBeta
  * @memberof ran.dist
- * @param {number=} alpha First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 1.
- * @param {number=} lambda1 First non-centrality parameter. Default value is 1.
- * @param {number=} lambda2 Second non-centrality parameter. Default value is 1.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
+ * @param {number} lambda1 First non-centrality parameter.
+ * @param {number} lambda2 Second non-centrality parameter.
  * @see https://arxiv.org/abs/1706.08557
  * @constructor
  */

--- a/src/dist/doubly-noncentral-chi2.js
+++ b/src/dist/doubly-noncentral-chi2.js
@@ -11,10 +11,10 @@ import NoncentralChi2 from './noncentral-chi2'
  *
  * @class DoublyNoncentralChi2
  * @memberof ran.dist
- * @param {number=} k1 First degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 1.
- * @param {number=} k2 Second degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 1.
- * @param {number=} lambda1 First non-centrality parameter. Default value is 1.
- * @param {number=} lambda2 Second non-centrality parameter. Default value is 1.
+ * @param {number} k1 First degrees of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} k2 Second degrees of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} lambda1 First non-centrality parameter.
+ * @param {number} lambda2 Second non-centrality parameter.
  * @see https://doi.org/10.1093/biomet/36.1-2.202
  * @constructor
  */

--- a/src/dist/doubly-noncentral-f.js
+++ b/src/dist/doubly-noncentral-f.js
@@ -10,10 +10,10 @@ import DoublyNoncentralBeta from './doubly-noncentral-beta'
  *
  * @class DoublyNoncentralF
  * @memberof ran.dist
- * @param {number=} d1 First degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
- * @param {number=} d2 Second degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
- * @param {number=} lambda1 First non-centrality parameter. Default value is 1.
- * @param {number=} lambda2 Second non-centrality parameter. Default value is 1.
+ * @param {number} d1 First degrees of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} d2 Second degrees of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} lambda1 First non-centrality parameter.
+ * @param {number} lambda2 Second non-centrality parameter.
  * @see https://doi.org/10.1111/j.1467-842X.1965.tb00036.x
  * @constructor
  */

--- a/src/dist/doubly-noncentral-t.js
+++ b/src/dist/doubly-noncentral-t.js
@@ -16,9 +16,9 @@ import NoncentralT from './noncentral-t'
  *
  * @class DoublyNoncentralT
  * @memberof ran.dist
- * @param {number} nu Degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 1.
- * @param {number} mu Location parameter. Default value is 1.
- * @param {number} theta Shape parameter. Default value is 1.
+ * @param {number} nu Degrees of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} mu Location parameter.
+ * @param {number} theta Shape parameter.
  * @see https://www.wiley.com/en-us/Intermediate+Probability%3A+A+Computational+Approach-p-9780470026373
  * @constructor
  */

--- a/src/dist/erlang.js
+++ b/src/dist/erlang.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Erlang
  * @memberof ran.dist
- * @param {number=} k Shape parameter. It is rounded to the nearest integer. Default value is 1.
- * @param {number=} lambda Rate parameter. Default value is 1.
+ * @param {number} k Shape parameter. It is rounded to the nearest integer.
+ * @param {number} lambda Rate parameter.
  * @see https://en.wikipedia.org/wiki/Erlang_distribution
  * @constructor
  */

--- a/src/dist/exponential-logarithmic.js
+++ b/src/dist/exponential-logarithmic.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class ExponentialLogarithmic
  * @memberof ran.dist
- * @param {number=} p Shape parameter. Default value is 0.5.
- * @param {number=} beta Scale parameter. Default value is 1.
+ * @param {number} p Shape parameter.
+ * @param {number} beta Scale parameter.
  * @see https://en.wikipedia.org/wiki/Exponential-logarithmic_distribution#Related_distribution
  * @constructor
  */

--- a/src/dist/exponential.js
+++ b/src/dist/exponential.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class Exponential
  * @memberof ran.dist
- * @param {number=} lambda Rate parameter. Default value is 1.
+ * @param {number} lambda Rate parameter.
  * @see https://en.wikipedia.org/wiki/Exponential_distribution
  * @constructor
  */

--- a/src/dist/exponentiated-weibull.js
+++ b/src/dist/exponentiated-weibull.js
@@ -10,9 +10,9 @@ import Distribution from './_distribution'
  *
  * @class ExponentiatedWeibull
  * @memberof ran.dist
- * @param {number=} lambda Scale parameter. Default value is 1.
- * @param {number=} k First shape parameter. Default value is 1.
- * @param {number=} alpha Second shape parameter. Default value is 1.
+ * @param {number} lambda Scale parameter.
+ * @param {number} k First shape parameter.
+ * @param {number} alpha Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Exponentiated_Weibull_distribution
  * @constructor
  */

--- a/src/dist/f.js
+++ b/src/dist/f.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class F
  * @memberof ran.dist
- * @param {number=} d1 First degree of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
- * @param {number=} d2 Second degree of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
+ * @param {number} d1 First degree of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} d2 Second degree of freedom. If not an integer, it is rounded to the nearest one.
  * @see https://en.wikipedia.org/wiki/F-distribution
  * @constructor
  */

--- a/src/dist/fisher-z.js
+++ b/src/dist/fisher-z.js
@@ -9,8 +9,8 @@ import F from './f'
  *
  * @class FisherZ
  * @memberof ran.dist
- * @param {number=} d1 First degree of freedom. Default value is 2.
- * @param {number=} d2 Second degree of freedom. Default value is 2.
+ * @param {number} d1 First degree of freedom.
+ * @param {number} d2 Second degree of freedom.
  * @see https://en.wikipedia.org/wiki/Fisher%27s_z-distribution
  * @constructor
  */

--- a/src/dist/flory-schulz.js
+++ b/src/dist/flory-schulz.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * @class FlorySchulz
  * @memberof ran.dist
- * @param {number=} a Shape parameter. Default value is 0.5.
+ * @param {number} a Shape parameter.
  * @see https://en.wikipedia.org/wiki/Flory%E2%80%93Schulz_distribution
  * @constructor
  */

--- a/src/dist/frechet.js
+++ b/src/dist/frechet.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class Frechet
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter. Default value is 1.
- * @param {number=} s Scale parameter. Default value is 1.
- * @param {number=} m Location parameter. Default value is 0.
+ * @param {number} alpha Shape parameter.
+ * @param {number} s Scale parameter.
+ * @param {number} m Location parameter.
  * @see https://en.wikipedia.org/wiki/Frechet_distribution
  * @constructor
  */

--- a/src/dist/gamma-gompertz.js
+++ b/src/dist/gamma-gompertz.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class GammaGompertz
  * @memberof ran.dist
- * @param {number=} b Scale parameter. Default value is 1.
- * @param {number=} s First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 1.
+ * @param {number} b Scale parameter.
+ * @param {number} s First shape parameter.
+ * @param {number} beta Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Gamma/Gompertz_distribution
  * @constructor
  */

--- a/src/dist/gamma.js
+++ b/src/dist/gamma.js
@@ -12,8 +12,8 @@ import Distribution from './_distribution'
  *
  * @class Gamma
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter. Default value is 1.
- * @param {number=} beta Rate parameter. Default value is 1.
+ * @param {number} alpha Shape parameter.
+ * @param {number} beta Rate parameter.
  * @see https://en.wikipedia.org/wiki/Gamma_distribution
  * @see G. Marsaglia and W. W. Tsang, "A Simple Method for Generating Gamma Variables", ACM Trans. Math. Softw. 26(3), 363–372, 2000.
  * @constructor

--- a/src/dist/generalized-exponential.js
+++ b/src/dist/generalized-exponential.js
@@ -10,9 +10,9 @@ import { lambertW0 } from '../special'
  *
  * @class GeneralizedExponential
  * @memberof ran.dist
- * @param {number=} a First shape parameter. Default value is 1.
- * @param {number=} b Second shape parameter. Default value is 1.
- * @param {number=} c Third shape parameter. Default value is 1.
+ * @param {number} a First shape parameter.
+ * @param {number} b Second shape parameter.
+ * @param {number} c Third shape parameter.
  * @see https://docs.scipy.org/doc/scipy/tutorial/stats/continuous_genexpon.html
  * @constructor
  */

--- a/src/dist/generalized-extreme-value.js
+++ b/src/dist/generalized-extreme-value.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedExtremeValue
  * @memberof ran.dist
- * @param {number=} c Shape parameter. Default value is 2.
+ * @param {number} c Shape parameter.
  * @see https://en.wikipedia.org/wiki/Generalized_extreme_value_distribution
  * @constructor
  */

--- a/src/dist/generalized-gamma.js
+++ b/src/dist/generalized-gamma.js
@@ -10,9 +10,9 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedGamma
  * @memberof ran.dist
- * @param {number=} a Scale parameter. Default value is 1.
- * @param {number=} d Shape parameter. Default value is 1.
- * @param {number=} p Shape parameter. Default value is 1.
+ * @param {number} a Scale parameter.
+ * @param {number} d Shape parameter.
+ * @param {number} p Shape parameter.
  * @see https://en.wikipedia.org/wiki/Generalized_gamma_distribution
  * @constructor
  */

--- a/src/dist/generalized-hermite.js
+++ b/src/dist/generalized-hermite.js
@@ -15,9 +15,9 @@ import PreComputed from './_pre-computed'
  *
  * @class GeneralizedHermite
  * @memberof ran.dist
- * @param {number=} a1 Mean of the first Poisson component. Default value is 1.
- * @param {number=} am Mean of the second Poisson component. Default value is 1.
- * @param {number=} m Multiplier of the second Poisson. If not an integer, it is rounded to the nearest one. Default value is 2.
+ * @param {number} a1 Mean of the first Poisson component.
+ * @param {number} am Mean of the second Poisson component.
+ * @param {number} m Multiplier of the second Poisson. If not an integer, it is rounded to the nearest one.
  * @see https://journal.r-project.org/archive/2015/RJ-2015-035/RJ-2015-035.pdf
  * @constructor
  */

--- a/src/dist/generalized-logistic.js
+++ b/src/dist/generalized-logistic.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedLogistic
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} s Scale parameter. Default value is 1.
- * @param {number=} c Shape parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} s Scale parameter.
+ * @param {number} c Shape parameter.
  * @see https://en.wikipedia.org/wiki/Generalized_logistic_distribution
  * @constructor
  */

--- a/src/dist/generalized-normal.js
+++ b/src/dist/generalized-normal.js
@@ -11,9 +11,9 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedNormal
  * @memberof ran.dist
- * @param {number=} mu Location paramameter. Default value is 0.
- * @param {number=} alpha Scale parameter. Default value is 1.
- * @param {number=} beta Shape parameter. Default value is 1.
+ * @param {number} mu Location paramameter.
+ * @param {number} alpha Scale parameter.
+ * @param {number} beta Shape parameter.
  * @see https://en.wikipedia.org/wiki/Generalized_normal_distribution
  * @constructor
  */

--- a/src/dist/generalized-pareto.js
+++ b/src/dist/generalized-pareto.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedPareto
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} sigma Scale parameter. Default value is 1.
- * @param {number=} xi Shape parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} sigma Scale parameter.
+ * @param {number} xi Shape parameter.
  * @see https://en.wikipedia.org/wiki/Generalized_Pareto_distribution
  * @constructor
  */

--- a/src/dist/geometric.js
+++ b/src/dist/geometric.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class Geometric
  * @memberof ran.dist
- * @param {number} p Probability of success. Default value is 0.5.
+ * @param {number} p Probability of success.
  * @see https://en.wikipedia.org/wiki/Geometric_distribution
  * @constructor
  */

--- a/src/dist/gompertz.js
+++ b/src/dist/gompertz.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class Gompertz
  * @memberof ran.dist
- * @param {number=} eta Shape parameter. Default value is 1.
- * @param {number=} beta Scale parameter. Default value is 1.
+ * @param {number} eta Shape parameter.
+ * @param {number} beta Scale parameter.
  * @see https://en.wikipedia.org/wiki/Gompertz_distribution
  * @constructor
  */

--- a/src/dist/gumbel.js
+++ b/src/dist/gumbel.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class Gumbel
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} beta Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} beta Scale parameter.
  * @see https://en.wikipedia.org/wiki/Gumbel_distribution
  * @constructor
  */

--- a/src/dist/half-generalized-normal.js
+++ b/src/dist/half-generalized-normal.js
@@ -9,8 +9,8 @@ import GeneralizedNormal from './generalized-normal'
  *
  * @class HalfGeneralizedNormal
  * @memberof ran.dist
- * @param {number=} alpha Scale parameter. Default value is 1.
- * @param {number=} beta Shape parameter. Default value is 1.
+ * @param {number} alpha Scale parameter.
+ * @param {number} beta Shape parameter.
  * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.halfgennorm.html
  * @constructor
  */

--- a/src/dist/half-normal.js
+++ b/src/dist/half-normal.js
@@ -10,7 +10,7 @@ import { erfinv } from '../special'
  *
  * @class HalfNormal
  * @memberof ran.dist
- * @param {number=} sigma Scale parameter. Default value is 1.
+ * @param {number} sigma Scale parameter.
  * @see https://en.wikipedia.org/wiki/Half-normal_distribution
  * @constructor
  */

--- a/src/dist/heads-minus-tails.js
+++ b/src/dist/heads-minus-tails.js
@@ -11,7 +11,7 @@ import { logBinomial } from '../special'
  *
  * @class HeadsMinusTails
  * @memberof ran.dist
- * @param {number=} n Half number of trials. Default value is 10.
+ * @param {number} n Half number of trials.
  * @see http://mathworld.wolfram.com/Heads-Minus-TailsDistribution.html
  * @constructor
  */

--- a/src/dist/hoyt.js
+++ b/src/dist/hoyt.js
@@ -10,8 +10,8 @@ import Nakagami from './nakagami'
  *
  * @class Hoyt
  * @memberof ran.dist
- * @param {number=} q Shape parameter (same as m in Nakagami). Default value is 0.5.
- * @param {number=} omega Spread parameter. Default value is 1.
+ * @param {number} q Shape parameter (same as m in Nakagami).
+ * @param {number} omega Spread parameter.
  * @deprecated Use [ran.dist.Nakagami]{@link ran.dist.Nakagami} instead. This class will be removed in a future major release.
  * @see ran.dist.Nakagami
  * @constructor

--- a/src/dist/hyperexponential.js
+++ b/src/dist/hyperexponential.js
@@ -12,9 +12,8 @@ import neumaier from '../algorithms/neumaier'
  *
  * @class Hyperexponential
  * @memberof ran.dist
- * @param {Object[]=} parameters Array containing the rates and corresponding weights. Each array element must be an
- * object with twp properties: weight and rate. Default value is
- * <code>[{weight: 1, rate: 1}, {weight: 1, rate: 1}]</code>.
+ * @param {Object[]} parameters Array containing the rates and corresponding weights. Each array element must be an
+ * object with two properties: weight and rate.
  * @see https://en.wikipedia.org/wiki/Hyperexponential_distribution
  * @constructor
  */

--- a/src/dist/hypergeometric.js
+++ b/src/dist/hypergeometric.js
@@ -11,9 +11,9 @@ import Distribution from './_distribution'
  *
  * @class Hypergeometric
  * @memberof ran.dist
- * @param {number=} N Total number of elements to sample from. If not an integer, it is rounded to the nearest one. Default value is 10.
- * @param {number=} K Total number of successes. If not an integer, it is rounded to the nearest one. Default value is 5.
- * @param {number=} n If not an integer, it is rounded to the nearest one. Number of draws. Default value is 5.
+ * @param {number} N Total number of elements to sample from. If not an integer, it is rounded to the nearest one.
+ * @param {number} K Total number of successes. If not an integer, it is rounded to the nearest one.
+ * @param {number} n If not an integer, it is rounded to the nearest one. Number of draws.
  * @see https://en.wikipedia.org/wiki/Hypergeometric_distribution
  * @constructor
  */

--- a/src/dist/inverse-chi2.js
+++ b/src/dist/inverse-chi2.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * @class InverseChi2
  * @memberof ran.dist
- * @param {number=} nu Degrees of freedom. Default value is 1.
+ * @param {number} nu Degrees of freedom.
  * @see https://en.wikipedia.org/wiki/Inverse-chi-squared_distribution
  * @constructor
  */

--- a/src/dist/inverse-gamma.js
+++ b/src/dist/inverse-gamma.js
@@ -10,8 +10,8 @@ import Gamma from './gamma'
  *
  * @class InverseGamma
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter. Default value is 1.
- * @param {number=} beta Scale parameter. Default value is 1.
+ * @param {number} alpha Shape parameter.
+ * @param {number} beta Scale parameter.
  * @see https://en.wikipedia.org/wiki/Inverse-gamma_distribution
  * @constructor
  */

--- a/src/dist/inverse-gaussian.js
+++ b/src/dist/inverse-gaussian.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class InverseGaussian
  * @memberof ran.dist
- * @param {number=} mu Mean of the distribution. Default value is 1.
- * @param {number=} lambda Shape parameter. Default value is 1.
+ * @param {number} mu Mean of the distribution.
+ * @param {number} lambda Shape parameter.
  * @see https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution
  * @see J. R. Michael, W. R. Schucany and R. W. Haas, "Generating Random Variates Using Transformations with Multiple Roots", Am. Stat. 30(2), 88–90, 1976.
  * @constructor

--- a/src/dist/inverted-weibull.js
+++ b/src/dist/inverted-weibull.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * @class InvertedWeibull
  * @memberof ran.dist
- * @param {number=} c Shape parameter. Default value is 2.
+ * @param {number} c Shape parameter.
  * @see https://docs.scipy.org/doc/scipy/tutorial/stats/continuous_invweibull.html
  * @constructor
  */

--- a/src/dist/irwin-hall.js
+++ b/src/dist/irwin-hall.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * @class IrwinHall
  * @memberof ran.dist
- * @param {number=} n Number of uniform variates to sum. If not an integer, it is rounded to the nearest one. Default
+ * @param {number} n Number of uniform variates to sum. If not an integer, it is rounded to the nearest one. Default
  * value is 1.
  * @see https://en.wikipedia.org/wiki/Irwin%E2%80%93Hall_distribution
  * @constructor

--- a/src/dist/johnson-sb.js
+++ b/src/dist/johnson-sb.js
@@ -10,10 +10,10 @@ import Distribution from './_distribution'
  *
  * @class JohnsonSB
  * @memberof ran.dist
- * @param {number=} gamma First location parameter. Default value is 0.
- * @param {number=} delta First scale parameter. Default value is 1.
- * @param {number=} lambda Second scale parameter. Default value is 1.
- * @param {number=} xi Second location parameter. Default value is 0.
+ * @param {number} gamma First location parameter.
+ * @param {number} delta First scale parameter.
+ * @param {number} lambda Second scale parameter.
+ * @param {number} xi Second location parameter.
  * @see https://en.wikipedia.org/wiki/Johnson%27s_SU-distribution#Johnson's_SB-distribution
  * @constructor
  */

--- a/src/dist/johnson-su.js
+++ b/src/dist/johnson-su.js
@@ -10,10 +10,10 @@ import Distribution from './_distribution'
  *
  * @class JohnsonSU
  * @memberof ran.dist
- * @param {number=} gamma First location parameter. Default value is 0.
- * @param {number=} delta First scale parameter. Default value is 1.
- * @param {number=} lambda Second scale parameter. Default value is 1.
- * @param {number=} xi Second location parameter. Default value is 0.
+ * @param {number} gamma First location parameter.
+ * @param {number} delta First scale parameter.
+ * @param {number} lambda Second scale parameter.
+ * @param {number} xi Second location parameter.
  * @see https://en.wikipedia.org/wiki/Johnson%27s_SU-distribution
  * @constructor
  */

--- a/src/dist/kumaraswamy.js
+++ b/src/dist/kumaraswamy.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Kumaraswamy
  * @memberof ran.dist
- * @param {number=} alpha First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 1.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Kumaraswamy_distribution
  * @constructor
  */

--- a/src/dist/laplace.js
+++ b/src/dist/laplace.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class Laplace
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} b Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} b Scale parameter.
  * @see https://en.wikipedia.org/wiki/Laplace_distribution
  * @constructor
  */

--- a/src/dist/levy.js
+++ b/src/dist/levy.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class Levy
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} c Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} c Scale parameter.
  * @see https://en.wikipedia.org/wiki/Lévy_distribution
  * @constructor
  */

--- a/src/dist/lindley.js
+++ b/src/dist/lindley.js
@@ -10,7 +10,7 @@ import { lambertW1m } from '../special'
  *
  * @class Lindley
  * @memberof ran.dist
- * @param {number=} theta Shape parameter. Default value is 1.
+ * @param {number} theta Shape parameter.
  * @see http://www.hjms.hacettepe.edu.tr/uploads/b35d591c-22f6-4136-8735-20c82936cd64.pdf
  * @constructor
  */

--- a/src/dist/log-cauchy.js
+++ b/src/dist/log-cauchy.js
@@ -9,8 +9,8 @@ import Cauchy from './cauchy'
  *
  * @class LogCauchy
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} sigma Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} sigma Scale parameter.
  * @see https://en.wikipedia.org/wiki/Log-Cauchy_distribution
  * @constructor
  */

--- a/src/dist/log-gamma.js
+++ b/src/dist/log-gamma.js
@@ -11,9 +11,9 @@ import Distribution from './_distribution'
  *
  * @class LogGamma
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter. Default value is 1.
- * @param {number=} beta Rate parameter. Default value is 1.
- * @param {number=} mu Location parameter. Default value is 0.
+ * @param {number} alpha Shape parameter.
+ * @param {number} beta Rate parameter.
+ * @param {number} mu Location parameter.
  * @see https://reference.wolfram.com/language/ref/LogGammaDistribution.html
  * @constructor
  */

--- a/src/dist/log-laplace.js
+++ b/src/dist/log-laplace.js
@@ -9,8 +9,8 @@ import Laplace from './laplace'
  *
  * @class LogLaplace
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} b Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} b Scale parameter.
  * @see https://en.wikipedia.org/wiki/Log-Laplace_distribution
  * @constructor
  */

--- a/src/dist/log-logistic.js
+++ b/src/dist/log-logistic.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class LogLogistic
  * @memberof ran.dist
- * @param {number=} alpha Scale parameter. Default value is 1.
- * @param {number=} beta Shape parameter. Default value is 1.
+ * @param {number} alpha Scale parameter.
+ * @param {number} beta Shape parameter.
  * @see https://en.wikipedia.org/wiki/Log-logistic_distribution
  * @constructor
  */

--- a/src/dist/log-normal.js
+++ b/src/dist/log-normal.js
@@ -9,8 +9,8 @@ import Normal from './normal'
  *
  * @class LogNormal
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} sigma Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} sigma Scale parameter.
  * @see https://en.wikipedia.org/wiki/Log-normal_distribution
  * @constructor
  */

--- a/src/dist/log-series.js
+++ b/src/dist/log-series.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class LogSeries
  * @memberof ran.dist
- * @param {number=} p Distribution parameter. Default value is 0.5.
+ * @param {number} p Distribution parameter.
  * @see https://en.wikipedia.org/wiki/Logarithmic_distribution
  * @see A. Kemp, "Efficient generation of logarithmically distributed pseudo-random variables", Appl. Stat. 30(3), 249–253, 1981.
  * @constructor

--- a/src/dist/logarithmic.js
+++ b/src/dist/logarithmic.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Logarithmic
  * @memberof ran.dist
- * @param {number=} a Lower boundary of the distribution. Default value is 1.
- * @param {number=} b Upper boundary of the distribution. Default value is 2.
+ * @param {number} a Lower boundary of the distribution.
+ * @param {number} b Upper boundary of the distribution.
  * @see http://mathworld.wolfram.com/LogarithmicDistribution.html
  * @constructor
  */

--- a/src/dist/logistic-exponential.js
+++ b/src/dist/logistic-exponential.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class LogisticExponential
  * @memberof ran.dist
- * @param {number=} lambda Scale parameter. Default value is 1.
- * @param {number=} kappa Shape parameter. Default value is 1.
+ * @param {number} lambda Scale parameter.
+ * @param {number} kappa Shape parameter.
  * @see http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.295.8653&rep=rep1&type=pdf
  * @constructor
  */

--- a/src/dist/logistic.js
+++ b/src/dist/logistic.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class Logistic
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} s Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} s Scale parameter.
  * @see https://en.wikipedia.org/wiki/Logistic_distribution
  * @constructor
  */

--- a/src/dist/logit-normal.js
+++ b/src/dist/logit-normal.js
@@ -9,8 +9,8 @@ import Normal from './normal'
  *
  * @class LogitNormal
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} sigma Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} sigma Scale parameter.
  * @see https://en.wikipedia.org/wiki/Logit-normal_distribution
  * @constructor
  */

--- a/src/dist/lomax.js
+++ b/src/dist/lomax.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class Lomax
  * @memberof ran.dist
- * @param {number=} lambda Scale parameter. Default value is 1.
- * @param {number=} alpha Shape parameter. Default value is 1.
+ * @param {number} lambda Scale parameter.
+ * @param {number} alpha Shape parameter.
  * @see https://en.wikipedia.org/wiki/Lomax_distribution
  * @constructor
  */

--- a/src/dist/makeham.js
+++ b/src/dist/makeham.js
@@ -11,9 +11,9 @@ import Distribution from './_distribution'
  *
  * @class Makeham
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter. Default value is 1.
- * @param {number=} beta Rate parameter. Default value is 1.
- * @param {number=} lambda Scale parameter. Default value is 1.
+ * @param {number} alpha Shape parameter.
+ * @param {number} beta Rate parameter.
+ * @param {number} lambda Scale parameter.
  * @see https://en.wikipedia.org/wiki/Gompertz%E2%80%93Makeham_law_of_mortality
  * @constructor
  */

--- a/src/dist/maxwell-boltzmann.js
+++ b/src/dist/maxwell-boltzmann.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class MaxwellBoltzmann
  * @memberof ran.dist
- * @param {number=} a Scale parameter. Default value is 1.
+ * @param {number} a Scale parameter.
  * @see https://en.wikipedia.org/wiki/Maxwell%E2%80%93Boltzmann_distribution
  * @constructor
  */

--- a/src/dist/mielke.js
+++ b/src/dist/mielke.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Mielke
  * @memberof ran.dist
- * @param {number=} k First shape parameter. Default value is 2.
- * @param {number=} s Second shape parameter. Default value is 1.
+ * @param {number} k First shape parameter.
+ * @param {number} s Second shape parameter.
  * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mielke.html#r7049b665a02e-2
  * @constructor
  */

--- a/src/dist/moyal.js
+++ b/src/dist/moyal.js
@@ -11,8 +11,8 @@ import { gammaUpperIncomplete } from '../special'
  *
  * @class Moyal
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} sigma Scale parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} sigma Scale parameter.
  * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.moyal.html#r7049b665a02e-2
  * @constructor
  */

--- a/src/dist/muth.js
+++ b/src/dist/muth.js
@@ -12,7 +12,7 @@ import { lambertW1m } from '../special'
  *
  * @class Muth
  * @memberof ran.dist
- * @param {number=} alpha Shape parameter. Default value is 0.5.
+ * @param {number} alpha Shape parameter.
  * @see https://www.tandfonline.com/doi/abs/10.3846/13926292.2015.1048540
  * @constructor
  */

--- a/src/dist/nakagami.js
+++ b/src/dist/nakagami.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class Nakagami
  * @memberof ran.dist
- * @param {number=} m Shape parameter. Default value is 1.
- * @param {number=} omega Spread parameter. Default value is 1.
+ * @param {number} m Shape parameter.
+ * @param {number} omega Spread parameter.
  * @see https://en.wikipedia.org/wiki/Nakagami_distribution
  * @constructor
  */

--- a/src/dist/negative-binomial.js
+++ b/src/dist/negative-binomial.js
@@ -13,9 +13,9 @@ import Distribution from './_distribution'
  *
  * @class NegativeBinomial
  * @memberof ran.dist
- * @param {number=} r Number of failures until the experiment is stopped. If not an integer, it is rounded to the nearest
- * integer. Default value is 10.
- * @param {number=} p Probability of success. Default value is 0.5.
+ * @param {number} r Number of failures until the experiment is stopped. If not an integer, it is rounded to the nearest
+ * integer.
+ * @param {number} p Probability of success.
  * @see https://en.wikipedia.org/wiki/Negative_binomial_distribution
  * @constructor
  */

--- a/src/dist/negative-hypergeometric.js
+++ b/src/dist/negative-hypergeometric.js
@@ -11,9 +11,9 @@ import Distribution from './_distribution'
  *
  * @class NegativeHypergeometric
  * @memberof ran.dist
- * @param {number=} N Total number of elements to sample from. If not an integer, it is rounded to the nearest one. Default value is 10.
- * @param {number=} K Total number of successes. If not an integer, it is rounded to the nearest one. Default value is 5.
- * @param {number=} r Total number of failures to stop at. If not an integer, it is rounded to the nearest one. Default value is 5.
+ * @param {number} N Total number of elements to sample from. If not an integer, it is rounded to the nearest one.
+ * @param {number} K Total number of successes. If not an integer, it is rounded to the nearest one.
+ * @param {number} r Total number of failures to stop at. If not an integer, it is rounded to the nearest one.
  * @see https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution
  * @constructor
  */

--- a/src/dist/neyman-a.js
+++ b/src/dist/neyman-a.js
@@ -11,8 +11,8 @@ import PreComputed from './_pre-computed'
  *
  * @class NeymanA
  * @memberof ran.dist
- * @param {number=} lambda Mean of the number of clusters. Default value is 1.
- * @param {number=} phi Mean of the cluster size. Default value is 1.
+ * @param {number} lambda Mean of the number of clusters.
+ * @param {number} phi Mean of the cluster size.
  * @see http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.527.574&rep=rep1&type=pdf
  * @constructor
  */

--- a/src/dist/noncentral-beta.js
+++ b/src/dist/noncentral-beta.js
@@ -13,9 +13,9 @@ import Distribution from './_distribution'
  *
  * @class NoncentralBeta
  * @memberof ran.dist
- * @param {number=} alpha First shape parameter. Default value is 1.
- * @param {number=} beta Second shape parameter. Default value is 1.
- * @param {number=} lambda Non-centrality parameter. Default value is 1.
+ * @param {number} alpha First shape parameter.
+ * @param {number} beta Second shape parameter.
+ * @param {number} lambda Non-centrality parameter.
  * @see https://en.wikipedia.org/wiki/Noncentral_beta_distribution
  * @constructor
  */

--- a/src/dist/noncentral-chi.js
+++ b/src/dist/noncentral-chi.js
@@ -10,8 +10,8 @@ import NoncentralChi2 from './noncentral-chi2'
  *
  * @class NoncentralChi
  * @memberof ran.dist
- * @param {number=} k Degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
- * @param {number=} lambda Non-centrality parameter. Default value is 1.
+ * @param {number} k Degrees of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} lambda Non-centrality parameter.
  * @see https://en.wikipedia.org/wiki/Noncentral_chi_distribution
  * @constructor
  */

--- a/src/dist/noncentral-chi2.js
+++ b/src/dist/noncentral-chi2.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class NoncentralChi2
  * @memberof ran.dist
- * @param {number=} k Degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
- * @param {number=} lambda Non-centrality parameter. Default value is 1.
+ * @param {number} k Degrees of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} lambda Non-centrality parameter.
  * @see https://en.wikipedia.org/wiki/Noncentral_chi-squared_distribution
  * @constructor
  */

--- a/src/dist/noncentral-f.js
+++ b/src/dist/noncentral-f.js
@@ -10,9 +10,9 @@ import NoncentralBeta from './noncentral-beta'
  *
  * @class NoncentralF
  * @memberof ran.dist
- * @param {number=} d1 First degree of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
- * @param {number=} d2 Second degree of freedom. If not an integer, it is rounded to the nearest one. Default value is 2.
- * @param {number=} lambda Non-centrality parameter. Default value is 1.
+ * @param {number} d1 First degree of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} d2 Second degree of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} lambda Non-centrality parameter.
  * @see https://en.wikipedia.org/wiki/Noncentral_F-distribution
  * @constructor
  */

--- a/src/dist/noncentral-t.js
+++ b/src/dist/noncentral-t.js
@@ -13,8 +13,8 @@ import Distribution from './_distribution'
  *
  * @class NoncentralT
  * @memberof ran.dist
- * @param {number=} nu Degrees of freedom. If not an integer, it is rounded to the nearest one. Default value is 1.
- * @param {number=} mu Non-centrality parameter. Default value is 1.
+ * @param {number} nu Degrees of freedom. If not an integer, it is rounded to the nearest one.
+ * @param {number} mu Non-centrality parameter.
  * @see https://en.wikipedia.org/wiki/Noncentral_t-distribution
  * @constructor
  */

--- a/src/dist/normal.js
+++ b/src/dist/normal.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class Normal
  * @memberof ran.dist
- * @param {number=} mu Location parameter (mean). Default value is 0.
- * @param {number=} sigma Squared scale parameter (variance). Default value is 1.
+ * @param {number} mu Location parameter (mean).
+ * @param {number} sigma Squared scale parameter (variance).
  * @see https://en.wikipedia.org/wiki/Normal_distribution
  * @see https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform Box–Muller transform (sampling algorithm)
  * @constructor

--- a/src/dist/pareto.js
+++ b/src/dist/pareto.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class Pareto
  * @memberof ran.dist
- * @param {number=} xmin Scale parameter. Default value is 1.
- * @param {number=} alpha Shape parameter. Default value is 1.
+ * @param {number} xmin Scale parameter.
+ * @param {number} alpha Shape parameter.
  * @see https://en.wikipedia.org/wiki/Pareto_distribution
  * @constructor
  */

--- a/src/dist/pert.js
+++ b/src/dist/pert.js
@@ -10,9 +10,9 @@ import Distribution from './_distribution'
  *
  * @class PERT
  * @memberof ran.dist
- * @param {number=} a Lower boundary of the support. Default value is 0.
- * @param {number=} b Mode of the distribution. Default value is 0.5.
- * @param {number=} c Upper boundary of the support. Default value is 1.
+ * @param {number} a Lower boundary of the support.
+ * @param {number} b Mode of the distribution.
+ * @param {number} c Upper boundary of the support.
  * @see https://en.wikipedia.org/wiki/PERT_distribution
  * @constructor
  */

--- a/src/dist/poisson.js
+++ b/src/dist/poisson.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * @class Poisson
  * @memberof ran.dist
- * @param {number=} lambda Mean of the distribution. Default value is 1.
+ * @param {number} lambda Mean of the distribution.
  * @see https://en.wikipedia.org/wiki/Poisson_distribution
  * @see D. E. Knuth, "Seminumerical Algorithms", The Art of Computer Programming vol. 2, 1969 (small λ). A. C. Atkinson, "The Computer Generation of Poisson Random Variables", Appl. Stat. 28(1), 29–35, 1979 (large λ).
  * @constructor

--- a/src/dist/polya-aeppli.js
+++ b/src/dist/polya-aeppli.js
@@ -11,8 +11,8 @@ import poisson from './_poisson'
  *
  * @class PolyaAeppli
  * @memberof ran.dist
- * @param {number=} lambda Mean of the Poisson component. Default value is 1.
- * @param {number=} theta Parameter of the shifted geometric component. Default value is 0.5.
+ * @param {number} lambda Mean of the Poisson component.
+ * @param {number} theta Parameter of the shifted geometric component.
  * @see https://arxiv.org/abs/1406.2780
  * @constructor
  */

--- a/src/dist/power-law.js
+++ b/src/dist/power-law.js
@@ -9,7 +9,7 @@ import Kumaraswamy from './kumaraswamy'
  *
  * @class PowerLaw
  * @memberof ran.dist
- * @param {number=} a One plus the exponent of the distribution. Default value is 1.
+ * @param {number} a One plus the exponent of the distribution.
  * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.powerlaw.html
  * @constructor
  */

--- a/src/dist/q-exponential.js
+++ b/src/dist/q-exponential.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class QExponential
  * @memberof ran.dist
- * @param {number=} q Shape parameter. Default value is 1.5.
- * @param {number=} lambda Rate parameter. Default value is 1.
+ * @param {number} q Shape parameter.
+ * @param {number} lambda Rate parameter.
  * @see https://en.wikipedia.org/wiki/Q-exponential_distribution
  * @constructor
  */

--- a/src/dist/r.js
+++ b/src/dist/r.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class R
  * @memberof ran.dist
- * @param {number=} c Shape parameter. Default value is 1.
+ * @param {number} c Shape parameter.
  * @see https://docs.scipy.org/doc/scipy-1.5.4/reference/tutorial/stats/continuous_rdist.html
  * @constructor
  */

--- a/src/dist/raised-cosine.js
+++ b/src/dist/raised-cosine.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class RaisedCosine
  * @memberof ran.dist
- * @param {number=} mu Location paramter. Default value is 0.
- * @param {number=} s Scale parameter. Default value is 1.
+ * @param {number} mu Location paramter.
+ * @param {number} s Scale parameter.
  * @see https://en.wikipedia.org/wiki/Raised_cosine_distribution
  * @constructor
  */

--- a/src/dist/rayleigh.js
+++ b/src/dist/rayleigh.js
@@ -9,7 +9,7 @@ import Weibull from './weibull'
  *
  * @class Rayleigh
  * @memberof ran.dist
- * @param {number=} sigma Scale parameter. Default value is 1.
+ * @param {number} sigma Scale parameter.
  * @see https://en.wikipedia.org/wiki/Rayleigh_distribution
  * @constructor
  */

--- a/src/dist/reciprocal-inverse-gaussian.js
+++ b/src/dist/reciprocal-inverse-gaussian.js
@@ -9,8 +9,8 @@ import InverseGaussian from './inverse-gaussian'
  *
  * @class ReciprocalInverseGaussian
  * @memberof ran.dist
- * @param {number=} mu Mean of the inverse Gaussian distribution. Default value is 1.
- * @param {number=} lambda Shape parameter. Default value is 1.
+ * @param {number} mu Mean of the inverse Gaussian distribution.
+ * @param {number} lambda Shape parameter.
  * @see https://docs.scipy.org/doc/scipy-1.7.0/reference/tutorial/stats/continuous_recipinvgauss.html
  * @constructor
  */

--- a/src/dist/reciprocal.js
+++ b/src/dist/reciprocal.js
@@ -9,8 +9,8 @@ import Distribution from './_distribution'
  *
  * @class Reciprocal
  * @memberof ran.dist
- * @param {number=} a Lower boundary of the support. Default value is 1.
- * @param {number=} b Upper boundary of the support. Default value is 2.
+ * @param {number} a Lower boundary of the support.
+ * @param {number} b Upper boundary of the support.
  * @see https://en.wikipedia.org/wiki/Reciprocal_distribution
  * @constructor
  */

--- a/src/dist/rice.js
+++ b/src/dist/rice.js
@@ -12,8 +12,8 @@ import Distribution from './_distribution'
  *
  * @class Rice
  * @memberof ran.dist
- * @param {number=} nu First shape parameter. Default value is 1.
- * @param {number=} sigma Second shape parameter. Default value is 1.
+ * @param {number} nu First shape parameter.
+ * @param {number} sigma Second shape parameter.
  * @see https://en.wikipedia.org/wiki/Rice_distribution
  * @constructor
  */

--- a/src/dist/shifted-log-logistic.js
+++ b/src/dist/shifted-log-logistic.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class ShiftedLogLogistic
  * @memberof ran.dist
- * @param {number=} mu Location parameter. Default value is 0.
- * @param {number=} sigma Scale parameter. Default value is 1.
- * @param {number=} xi Shape parameter. Default value is 1.
+ * @param {number} mu Location parameter.
+ * @param {number} sigma Scale parameter.
+ * @param {number} xi Shape parameter.
  * @see https://en.wikipedia.org/wiki/Shifted_log-logistic_distribution
  * @constructor
  */

--- a/src/dist/skellam.js
+++ b/src/dist/skellam.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class Skellam
  * @memberof ran.dist
- * @param {number=} mu1 Mean of the first Poisson distribution. Default value is 1.
- * @param {number=} mu2 Mean of the second Poisson distribution. Default value is 1.
+ * @param {number} mu1 Mean of the first Poisson distribution.
+ * @param {number} mu2 Mean of the second Poisson distribution.
  * @see https://en.wikipedia.org/wiki/Skellam_distribution
  * @constructor
  */

--- a/src/dist/skew-normal.js
+++ b/src/dist/skew-normal.js
@@ -13,9 +13,9 @@ import Normal from './normal'
  *
  * @class SkewNormal
  * @memberof ran.dist
- * @param {number=} xi Location parameter. Default value is 0.
- * @param {number=} omega Scale parameter. Default value is 1.
- * @param {number=} alpha Shape parameter. Default value is 1.
+ * @param {number} xi Location parameter.
+ * @param {number} omega Scale parameter.
+ * @param {number} alpha Shape parameter.
  * @see https://en.wikipedia.org/wiki/Skew_normal_distribution
  * @see A. Azzalini, "SN package FAQ", https://azzalini.stat.unipd.it/SN/faq-r.html (sampling algorithm)
  * @constructor

--- a/src/dist/soliton.js
+++ b/src/dist/soliton.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class Soliton
  * @memberof ran.dist
- * @param {number=} N Number of blocks in the messaging model. If not an integer, it is rounded to the nearest one. Default value is 1.
+ * @param {number} N Number of blocks in the messaging model. If not an integer, it is rounded to the nearest one.
  * @see https://en.wikipedia.org/wiki/Soliton_distribution
  * @constructor
  */

--- a/src/dist/student-t.js
+++ b/src/dist/student-t.js
@@ -12,7 +12,7 @@ import Distribution from './_distribution'
  *
  * @class StudentT
  * @memberof ran.dist
- * @param {number=} nu Degrees of freedom. Default value is 1.
+ * @param {number} nu Degrees of freedom.
  * @see https://en.wikipedia.org/wiki/Student%27s_t-distribution
  * @constructor
  */

--- a/src/dist/student-z.js
+++ b/src/dist/student-z.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class StudentZ
  * @memberof ran.dist
- * @param {number=} n Degrees of freedom. Default value is 2.
+ * @param {number} n Degrees of freedom.
  * @see http://mathworld.wolfram.com/Studentsz-Distribution.html
  * @constructor
  */

--- a/src/dist/trapezoidal.js
+++ b/src/dist/trapezoidal.js
@@ -9,10 +9,10 @@ import Distribution from './_distribution'
  *
  * @class Trapezoidal
  * @memberof ran.dist
- * @param {number=} a Lower bound of the support. Default value is 0.
- * @param {number=} b Start of the level part. Default value is 0.33.
- * @param {number=} c End of the level part. Default value is 0.67.
- * @param {number=} d Upper bound of the support. Default value is 1.
+ * @param {number} a Lower bound of the support.
+ * @param {number} b Start of the level part.
+ * @param {number} c End of the level part.
+ * @param {number} d Upper bound of the support.
  * @see https://en.wikipedia.org/wiki/Trapezoidal_distribution
  * @constructor
  */

--- a/src/dist/triangular.js
+++ b/src/dist/triangular.js
@@ -9,9 +9,9 @@ import Distribution from './_distribution'
  *
  * @class Triangular
  * @memberof ran.dist
- * @param {number=} a Lower bound of the support. Default value is 0.
- * @param {number=} b Upper bound of the support. Default value is 1.
- * @param {number=} c Mode of the distribution. Default value is 0.5.
+ * @param {number} a Lower bound of the support.
+ * @param {number} b Upper bound of the support.
+ * @param {number} c Mode of the distribution.
  * @see https://en.wikipedia.org/wiki/Triangular_distribution
  * @constructor
  */

--- a/src/dist/truncated-normal.js
+++ b/src/dist/truncated-normal.js
@@ -12,10 +12,10 @@ import Distribution from './_distribution'
  *
  * @class TruncatedNormal
  * @memberof ran.dist
- * @param {number=} mu Mean of the underlying normal distribution. Default value is 0.
- * @param {number=} sigma Variance of the underlying normal distribution. Default value is 1.
- * @param {number=} a Lower boundary of the support. Default value is 0.
- * @param {number=} b Upper boundary of the support. Default value is 1.
+ * @param {number} mu Mean of the underlying normal distribution.
+ * @param {number} sigma Variance of the underlying normal distribution.
+ * @param {number} a Lower boundary of the support.
+ * @param {number} b Upper boundary of the support.
  * @see https://en.wikipedia.org/wiki/Truncated_normal_distribution
  * @constructor
  */

--- a/src/dist/tukey-lambda.js
+++ b/src/dist/tukey-lambda.js
@@ -10,7 +10,7 @@ import brent from '../algorithms/brent'
  *
  * @class TukeyLambda
  * @memberof ran.dist
- * @param {number=} lambda Shape parameter. Default value is 1.5.
+ * @param {number} lambda Shape parameter.
  * @see https://en.wikipedia.org/wiki/Tukey_lambda_distribution
  * @constructor
  */

--- a/src/dist/u-quadratic.js
+++ b/src/dist/u-quadratic.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class UQuadratic
  * @memberof ran.dist
- * @param {number=} a Lower bound of the support. Default value is 0.
- * @param {number=} b Upper bound of the support. Default value is 1.
+ * @param {number} a Lower bound of the support.
+ * @param {number} b Upper bound of the support.
  * @see https://en.wikipedia.org/wiki/U-quadratic_distribution
  * @constructor
  */

--- a/src/dist/uniform-product.js
+++ b/src/dist/uniform-product.js
@@ -11,7 +11,7 @@ import { gamma, gammaUpperIncomplete } from '../special'
  *
  * @class UniformProduct
  * @memberof ran.dist
- * @param {number=} n Number of uniform factors. If not an integer, it is rounded to the nearest one. Default value is 2.
+ * @param {number} n Number of uniform factors. If not an integer, it is rounded to the nearest one.
  * @see https://mathworld.wolfram.com/UniformProductDistribution.html
  * @constructor
  */

--- a/src/dist/uniform.js
+++ b/src/dist/uniform.js
@@ -11,8 +11,8 @@ import Distribution from './_distribution'
  *
  * @class Uniform
  * @memberof ran.dist
- * @param {number=} xmin Lower boundary. Default value is 0.
- * @param {number=} xmax Upper boundary. Default value is 1.
+ * @param {number} xmin Lower boundary.
+ * @param {number} xmax Upper boundary.
  * @see https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)
  * @constructor
  */

--- a/src/dist/von-mises.js
+++ b/src/dist/von-mises.js
@@ -12,7 +12,7 @@ import { MAX_ITER } from '../core/constants'
  *
  * @class VonMises
  * @memberof ran.dist
- * @param {number=} kappa Shape parameter. Default value is 1.
+ * @param {number} kappa Shape parameter.
  * @see https://en.wikipedia.org/wiki/Von_Mises_distribution
  * @see L. Barabesi, "Generating von Mises variates by the ratio-of-uniforms method", Statistica Applicata 7(4), 417–426, 1995.
  * @constructor

--- a/src/dist/weibull.js
+++ b/src/dist/weibull.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Weibull
  * @memberof ran.dist
- * @param {number=} lambda Scale parameter. Default value is 1.
- * @param {number=} k Shape parameter. Default value is 1.
+ * @param {number} lambda Scale parameter.
+ * @param {number} k Shape parameter.
  * @see https://en.wikipedia.org/wiki/Weibull_distribution
  * @constructor
  */

--- a/src/dist/wigner.js
+++ b/src/dist/wigner.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * @class Wigner
  * @memberof ran.dist
- * @param {number=} R Radius of the distribution. Default value is 1.
+ * @param {number} R Radius of the distribution.
  * @see https://en.wikipedia.org/wiki/Wigner_semicircle_distribution
  * @constructor
  */

--- a/src/dist/yule-simon.js
+++ b/src/dist/yule-simon.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class YuleSimon
  * @memberof ran.dist
- * @param {number=} rho Shape parameter. Default value is 1.
+ * @param {number} rho Shape parameter.
  * @see https://en.wikipedia.org/wiki/Yule%E2%80%93Simon_distribution
  * @constructor
  */

--- a/src/dist/zeta.js
+++ b/src/dist/zeta.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * @class Zeta
  * @memberof ran.dist
- * @param {number=} s Exponent of the distribution. Default value is 3.
+ * @param {number} s Exponent of the distribution.
  * @see https://en.wikipedia.org/wiki/Zeta_distribution
  * @see L. Devroye, "Non-Uniform Random Variate Generation", Springer-Verlag, 1986, ch. 10.
  * @constructor

--- a/src/dist/zipf.js
+++ b/src/dist/zipf.js
@@ -10,8 +10,8 @@ import Distribution from './_distribution'
  *
  * @class Zipf
  * @memberof ran.dist
- * @param {number=} s Exponent of the distribution. Default value is 1.
- * @param {number=} N Number of words. If not an integer, it is rounded to the nearest integer. Default is 100.
+ * @param {number} s Exponent of the distribution.
+ * @param {number} N Number of words. If not an integer, it is rounded to the nearest integer. Default is 100.
  * @see https://en.wikipedia.org/wiki/Zipf%27s_law
  * @constructor
  */


### PR DESCRIPTION
Closes #306

## Summary
- Removed `{type=}` optional markers from all required constructor `@param` tags in `src/dist/*.js` — constructors never provide defaults and `Distribution.validate` throws on `undefined`
- Removed trailing "Default value is X." sentences from the same tags — no constructor provides defaults
- Preserved `{number=}` on `sample(n = 1)` in `_distribution.js` since `n` is genuinely optional with a JS default

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/*.js` (132 files)**: Removed `{type=}` → `{type}` on required constructor params and deleted "Default value is X." sentences from `@param` descriptions
- **`src/dist/_distribution.js`**: Restored `{number=}` on `sample()`'s `n` param (genuinely optional, JS default = 1)
- **`src/dist/hyperexponential.js`**: Fixed "twp" → "two" typo in `@param` description (also closes #351)

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhSQ82YvA8ynEPcGmxdA2m)_