### PR TITLE
Add bounded() method to Distribution base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Distribution` base class now exposes `bounded()`, returning `'bounded'`, `'lower'`, `'upper'`, or `'unbounded'` based on whether the support endpoints are finite. `type()` and `support()` are documented as stable public API. TypeScript declarations updated accordingly. Closes #119.
+
 - `GeneralizedPareto`, `ShiftedLogLogistic`, and `TukeyLambda` GoF sampling tests now cover the boundary branches (`xi=0` / `lambda=0`) in `_q`, exercising the `−log(1−p)`, logistic, and `log(p/(1−p))` code paths respectively. Closes #270.
 
 ### Changed

--- a/dist/ranjs.d.ts
+++ b/dist/ranjs.d.ts
@@ -3,6 +3,7 @@ declare module 'ranjs' {
 
   export namespace dist {
     type DistributionType = 'continuous' | 'discrete'
+    type BoundedType = 'bounded' | 'lower' | 'upper' | 'unbounded'
 
     interface SupportBound {
       value: number
@@ -24,6 +25,7 @@ declare module 'ranjs' {
     class Distribution {
       type(): DistributionType
       support(): SupportBound[]
+      bounded(): BoundedType
       seed(value: number | string): this
       save(): DistributionState
       load(state: DistributionState): this

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -289,6 +289,28 @@ class Distribution {
   }
 
   /**
+   * Returns the boundedness category of the distribution's support:
+   * <ul>
+   *   <li><code>'bounded'</code>: both lower and upper bounds are finite.</li>
+   *   <li><code>'lower'</code>: only the lower bound is finite (lower-bounded, unbounded above).</li>
+   *   <li><code>'upper'</code>: only the upper bound is finite (upper-bounded, unbounded below).</li>
+   *   <li><code>'unbounded'</code>: neither bound is finite.</li>
+   * </ul>
+   *
+   * @method bounded
+   * @memberof ran.dist.Distribution
+   * @returns {string} The boundedness category of the support.
+   */
+  bounded () {
+    const lowerFinite = Number.isFinite(this.s[0].value)
+    const upperFinite = Number.isFinite(this.s[1].value)
+    if (lowerFinite && upperFinite) return 'bounded'
+    if (lowerFinite) return 'lower'
+    if (upperFinite) return 'upper'
+    return 'unbounded'
+  }
+
+  /**
    * Sets the seed for the distribution generator. Distributions implement the same PRNG
    * ([xoshiro128+]{@link http://vigna.di.unimi.it/ftp/papers/ScrambledLinear.pdf}) that is used in the core functions.
    *

--- a/test/dist.js
+++ b/test/dist.js
@@ -356,6 +356,28 @@ describe('dist', () => {
         }, 'Distribution._pdf() is not implemented')
       })
     })
+
+    describe('.bounded()', () => {
+      it('should return "bounded" for Beta (finite lower and upper)', () => {
+        assert.equal(new dist.Beta(1, 1).bounded(), 'bounded')
+      })
+
+      it('should return "lower" for Exponential (finite lower, infinite upper)', () => {
+        assert.equal(new dist.Exponential(1).bounded(), 'lower')
+      })
+
+      it('should return "unbounded" for Normal (infinite lower and upper)', () => {
+        assert.equal(new dist.Normal(0, 1).bounded(), 'unbounded')
+      })
+
+      it('should return "bounded" for Binomial (finite discrete support)', () => {
+        assert.equal(new dist.Binomial(10, 0.5).bounded(), 'bounded')
+      })
+
+      it('should return "lower" for Poisson (semi-infinite discrete support)', () => {
+        assert.equal(new dist.Poisson(3).bounded(), 'lower')
+      })
+    })
   })
 
   describe('PreComputed', () => {


### PR DESCRIPTION
Closes #119

## Summary
- Added `bounded()` method to the `Distribution` base class, returning `'bounded'`, `'lower'`, `'upper'`, or `'unbounded'` based on whether `this.s` endpoints are finite — no per-subclass changes needed.
- Added `BoundedType` union type and `bounded(): BoundedType` signature to `dist/ranjs.d.ts`.
- Five representative tests added to the `Distribution` base class section of `test/dist.js`.

## Non-trivial changes
- **`src/dist/_distribution.js`**: New `bounded()` public method — reads `this.s[0].value` and `this.s[1].value`, calls `Number.isFinite()` on each, and returns the four-way category string. Logic is exhaustive and matches the four possible finiteness combinations.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`dist/ranjs.d.ts`**: Added `BoundedType = 'bounded' | 'lower' | 'upper' | 'unbounded'` and `bounded(): BoundedType` to the `Distribution` class block.
- **`test/dist.js`**: Five `assert.equal` checks covering bounded (Beta, Binomial), lower-bounded (Exponential, Poisson), and unbounded (Normal) distributions.
- **`CHANGELOG.md`**: Unreleased entry documenting the new method.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFYdota7YSFXsEa8Vev7Ae)_