### PR TITLE
Fix NegativeBinomial boundary cases at p=0 and p=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `NegativeBinomial` `_pdf(0)` returned `NaN` at `p=0` (`0 * -Infinity`), and `_generator()` returned `undefined` at `p=1` (`Poisson(Infinity)`). Added degenerate-case guards in `_pdf`, `_cdf`, and `_generator` for `p=0` (all mass at k=0), and tightened the parameter constraint from `p ≤ 1` to `p < 1` (p=1 yields an all-zero PMF and no valid distribution). Closes #145.
+
 - `Champernowne` distribution was a non-functional stub: `_generator()` returned `undefined`, `_cdf(x)` always returned `1`, and `_pdf(x)` lacked its normalization constant. Fixed all three: normalization constant is now `alpha * sqrt(1 - lambda²) / (2 * arccos(lambda))`, CDF uses the closed-form `arctan(k * tanh(...))` formula, and `_generator()` uses inverse-transform sampling via a new closed-form `_q(p)`. The class is now exported from `src/dist/index.js` and declared in `dist/ranjs.d.ts`. Closes #337.
 
 - `BenktanderII` near-boundary `refVals` at `x = 1+1e-6` and `x = 1+1e-4` (params `[2, 0.9995]`) were replaced with values derived independently via Python `Decimal` at 60 decimal places using the direct mathematical formula, not the `expm1`-based implementation formula. Closes #295.

--- a/src/dist/negative-binomial.js
+++ b/src/dist/negative-binomial.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * $$f(k; r, p) = \begin{pmatrix}k + r - 1 \\\\ k \\\\ \end{pmatrix} (1 - p)^r p^k,$$
  *
- * with $r \in \mathbb{N}^+$ and $p \in \[0, 1\]$. Support: $k \in \mathbb{N}_0$.
+ * with $r \in \mathbb{N}^+$ and $p \in \[0, 1)$. Support: $k \in \mathbb{N}_0$.
  *
  * @class NegativeBinomial
  * @memberof ran.dist
@@ -28,7 +28,7 @@ export default class extends Distribution {
     this.p = { r: ri, p }
     Distribution.validate({ r: ri, p }, [
       'r > 0',
-      'p >= 0', 'p <= 1'
+      'p >= 0', 'p < 1'
     ])
 
     // Set support
@@ -42,15 +42,21 @@ export default class extends Distribution {
   }
 
   _generator () {
+    // p=0 is degenerate: all mass at 0
+    if (this.p.p === 0) return 0
     // Direct sampling by compounding Poisson and gamma
     return poisson(this.r, gamma(this.r, this.p.r, 1 / this.p.p - 1))
   }
 
   _pdf (x) {
+    // p=0 is degenerate: point mass at 0
+    if (this.p.p === 0) return x === 0 ? 1 : 0
     return Math.exp(logBinomial(x + this.p.r - 1, x) + this.p.r * Math.log(1 - this.p.p) + x * Math.log(this.p.p))
   }
 
   _cdf (x) {
+    // p=0 is degenerate: all mass at 0, so CDF is 1 everywhere on support
+    if (this.p.p === 0) return 1
     return 1 - regularizedBetaIncomplete(x + 1, this.p.r, this.p.p)
   }
 }

--- a/test/dist-cases-discrete.js
+++ b/test/dist-cases-discrete.js
@@ -526,12 +526,20 @@ export default [{
   invalidParams: [
     [], // all params required
     [-1, 0.5], [0, 0.5], // r > 0
-    [10, -1], [10, 2] // 0 <= p <= 1
+    [10, -1], [10, 1], [10, 2] // 0 <= p < 1
   ],
   // p=0.4 (asymmetric) so the scipy success/failure swap in nbinom(r, 1-p) can't hide;
   // see solutions/testing/2026-05-18-1443-discrete-refvals-scipy-parameterization-traps.md
   cases: [{
     params: () => [10, 0.4]
+  }, {
+    name: 'p=0 degenerate (all mass at 0)',
+    params: () => [5, 0],
+    refVals: [
+      { x: 0, pmf: 1, cdf: 1 },
+      { x: 1, pmf: 0, cdf: 1 },
+      { x: 5, pmf: 0, cdf: 1 }
+    ]
   }],
   // scipy.stats.nbinom(10, 1-0.4 = 0.6)
   refVals: [


### PR DESCRIPTION
Closes #145

> **⚠ Missing ADR**: This PR contains non-trivial changes but no Architecture Decision Record was found.
> Consider adding one at `decisions/` to document the design rationale.
> See `decisions/0000-template.md` for the format.

## Summary
- `_pdf(0)` returned `NaN` at `p=0` due to `0 * Math.log(0) = 0 * -Infinity = NaN`; added degenerate-case guards in `_pdf`, `_cdf`, and `_generator` so `p=0` correctly behaves as a point mass at k=0
- `p=1` yielded an all-zero PMF (no valid probability distribution); tightened the parameter constraint from `p ≤ 1` to `p < 1` so it now throws, resolving the `undefined` sampler output

## Design decisions
**p=1**: rejected as invalid (throws) rather than handled as a degenerate limit. `PMF = C(k+r-1,k) · 0^r · 1^k = 0` for all k (since r > 0), so the PMF sums to 0 — this is not a valid probability distribution. Silently returning 0 everywhere would be more confusing than a clear `InvalidParameterError`. The domain is now `p ∈ [0, 1)`.

## Non-trivial changes
- **`src/dist/negative-binomial.js`**: Parameter constraint tightened from `p <= 1` to `p < 1`. Three degenerate-case guards added (`_generator` returns 0, `_pdf` returns 1 at x=0 and 0 elsewhere, `_cdf` returns 1) when `p=0`. JSDoc domain updated from `[0, 1]` to `[0, 1)`.
- **`test/dist-cases-discrete.js`**: `[10, 1]` added to `invalidParams`; new named case `p=0 degenerate (all mass at 0)` with `params: [5, 0]` and `refVals` pinning `pmf(0)=1`, `pmf(1)=0`, `pmf(5)=0`, `cdf(*)=1`.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `### Fixed` entry for this bug fix under `[Unreleased]`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_018FGhjm73YXRRF4cvedF5v5)_