### PR TITLE
Rename this.t to this._type on Distribution base class (issue #205 PR 1/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Distribution` internal field `this.t` renamed to `this._type` for readability. No behavioural change. Closes #205 (PR 1/6).
+
 - `marcumQ` and `marcumP` now evaluate the transition band `y ≈ x + μ` with `μ ≥ 135` via the large-μ uniform asymptotic expansion (Section 4.2 of Gil, Segura & Temme, arXiv:1311.0681) instead of the `O(μ)` three-term recurrence. This is the fifth and final computation branch of the source algorithm and removes the recurrence's accumulated rounding in that regime. Closes #315.
 
 - `DoublyNoncentralChi2` now extends `NoncentralChi2` instead of reimplementing its PDF and CDF. The `_pdf`, `_cdf`, and `_generator` are fully inherited. The model complexity used by `aic()` and `bic()` changes from 4 to 2, reflecting that the distribution has 2 identifiable parameters in its collapsed form `NoncentralChi2(k1+k2, λ1+λ2)`. `NoncentralChi2` now also accepts `lambda = 0` (was `lambda > 0`), degenerating correctly to a central chi-squared. Closes #316.

--- a/decisions/0009-rename-single-letter-instance-fields.md
+++ b/decisions/0009-rename-single-letter-instance-fields.md
@@ -1,0 +1,34 @@
+# ADR-0009: Rename Single-Letter Instance Fields on Distribution Base Class
+
+**Date**: 2026-05-23
+**Status**: Accepted
+
+## Context
+
+The `Distribution` base class defines six single-letter instance fields (`this.t`, `this.k`, `this.p`, `this.s`, `this.r`, `this.c`) that are referenced across 131+ distribution implementation files. Single-letter names provide no semantic signal to readers, making the codebase harder to navigate and maintain.
+
+The serialized state format (`save()`/`load()`) already uses descriptive names (`params`, `constants`, `support`, `prngState`), creating an inconsistency between in-memory field names and serialized names.
+
+Two field renames are constrained by existing public method collisions: `type()` exists (cannot rename `this.t` to `type`) and `support()` exists (cannot rename `this.s` to `support`).
+
+## Decision
+
+Rename all six fields to descriptive names, deployed as six sequential PRs (one field per PR) to stay within the 400-line production-code diff cap and keep each PR independently revertable:
+
+| Old name | New name | Notes |
+|----------|----------|-------|
+| `this.t` | `this._type` | Underscore avoids collision with `type()` method |
+| `this.k` | `this.paramCount` | No collision |
+| `this.r` | `this.prng` | No collision |
+| `this.s` | `this._support` | Underscore avoids collision with `support()` method |
+| `this.c` | `this.constants` | No collision; aligns with serialized state key |
+| `this.p` | `this.params` | No collision; aligns with serialized state key |
+
+The serialized state keys (`params`, `constants`, `support`, `prngState`) remain unchanged for backward compatibility.
+
+## Consequences
+
+- Code becomes self-documenting: `this.params.mu` is unambiguous; `this.p.mu` was not.
+- The mechanical rename touches ~131 files per PR (for the large fields), but each change is a simple find-replace with no algorithmic risk.
+- Underscored fields (`_type`, `_support`) signal intent that direct external access should go through the public methods `type()` and `support()`.
+- ADR-0008 (named-object convention for `this.c`) remains valid — it governs the shape of the value, not the field name.

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -16,7 +16,7 @@ import { MAX_ITER } from '../core/constants'
  */
 class Distribution {
   constructor (type, k) {
-    // decisions/0009-rename-single-letter-instance-fields.md
+    // decisions/0009-rename-single-letter-instance-fields.md — descriptive names replace single-letter abbreviations
     this._type = type
 
     // Number of parameters

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -16,8 +16,8 @@ import { MAX_ITER } from '../core/constants'
  */
 class Distribution {
   constructor (type, k) {
-    // Distribution type: discrete or continuous
-    this.t = type
+    // decisions/0009-rename-single-letter-instance-fields.md
+    this._type = type
 
     // Number of parameters
     this.k = k
@@ -99,7 +99,7 @@ class Distribution {
    * @private
    */
   _toInt (x) {
-    return this.t === 'discrete' ? Math.round(x) : x
+    return this._type === 'discrete' ? Math.round(x) : x
   }
 
   /**
@@ -271,7 +271,7 @@ class Distribution {
    * @returns {string} Distribution type.
    */
   type () {
-    return this.t
+    return this._type
   }
 
   /**
@@ -530,7 +530,7 @@ class Distribution {
       // root-finder for continuous
       return typeof this._q === 'function'
         ? this._q(p)
-        : this.t === 'discrete'
+        : this._type === 'discrete'
           ? this._qEstimateTable(p)
           : this._qEstimateRoot(p)
     }
@@ -735,7 +735,7 @@ class Distribution {
    *
    */
   test (values) {
-    return this.t === 'discrete'
+    return this._type === 'discrete'
       // Parameters are fixed in the constructor (known), not estimated from values — df correction is 0.
       ? chi2(values, x => this.pdf(x), 0)
       : kolmogorovSmirnov(values, x => this.cdf(x))


### PR DESCRIPTION
Closes #205

## Summary
- Renames the internal field `this.t` → `this._type` on the `Distribution` base class — first of six sequential PRs from issue #205
- Underscore prefix is required to avoid collision with the existing `type()` public method
- No behavioural change: `type()`, `test()`, `q()`, and `_toInt()` all work identically

## Design decisions
- [ADR-0009: Rename Single-Letter Instance Fields](decisions/0009-rename-single-letter-instance-fields.md) — Documents all six renames, their target names, and the collision constraints that force underscore prefixes for `_type` and `_support`

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/_distribution.js`**: `this.t` → `this._type` in 5 places (constructor, `_toInt`, `type()`, `q()`, `test()`); WHY comment updated to reference ADR-0009
- **`decisions/0009-rename-single-letter-instance-fields.md`**: New ADR documenting the full six-field rename strategy
- **`CHANGELOG.md`**: Entry added under `[Unreleased] → Changed`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_019pCG3Mx9gsTcSCgYeipB4K)_