### PR TITLE
Add refVals to DoublyNoncentralT mu=0 test case

### DIFF
--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -1029,7 +1029,19 @@ export default [{
   cases: [{
     params: () => [5, 1, 2]
   }, {
-    params: () => [5, 0, 2]
+    name: 'mu=0',
+    params: () => [5, 0, 2],
+    // Poisson mixture of Student-t: T|L=l ~ t(5+2l)*sqrt(5/(5+2l)), L~Pois(1); mu=0 collapses NCT to t
+    refVals: [
+      { x: -3, pdf: 9.72574017736815323032e-03, cdf: 7.56414510159157497948e-03 },
+      { x: -2, pdf: 4.61984789839845338966e-02, cdf: 3.06789735179859926473e-02 },
+      { x: -1, pdf: 2.15258609533600542285e-01, cdf: 1.43285545250342594148e-01 },
+      { x: 0, pdf: 4.50645852994852602613e-01, cdf: 5.00000000000000000000e-01 },
+      { x: 1, pdf: 2.15258609533600542285e-01, cdf: 8.56714454749657350341e-01 },
+      { x: 2, pdf: 4.61984789839845338966e-02, cdf: 9.69321026482014014292e-01 },
+      { x: 3, pdf: 9.72574017736815323032e-03, cdf: 9.92435854898408464919e-01 },
+      { x: 5, pdf: 7.88941311192887682543e-04, cdf: 9.99127993039473527581e-01 }
+    ]
   }],
   // theta=0 uses the identical sampler path (normal(r,mu)/sqrt(noncentralChi2(r,nu,theta))); no theta branch in _sample
   sampleParams: [{ params: () => [5, 1, 2] }],


### PR DESCRIPTION
Closes #359

## Summary
- The second `DoublyNoncentralT` test case (`params: [5, 0, 2]`) had no `refVals`, meaning any formula regression at `mu=0` would pass silently
- Added `name: 'mu=0'` and 8 `refVals` entries computed via a Poisson mixture of Student-t distributions (since `mu=0` collapses each `NCT(ν+2l, 0)` component to `t(ν+2l)`)
- Values cover the body symmetrically (`x = ±3, ±2, ±1, 0`) plus a right-tail point (`x = 5`), verifying symmetry, `CDF(0) = 0.5`, monotonicity, and tail behavior

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Added `name: 'mu=0'`, a provenance comment, and 8 `refVals` entries to the second `DoublyNoncentralT` case object

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_0164cxs1YXy4BSbzSRz1L8KX)_