### PR TITLE
Fix HeadsMinusTails JSDoc: correct support to [0, 2n] and clarify folded variant

### DIFF
--- a/src/dist/heads-minus-tails.js
+++ b/src/dist/heads-minus-tails.js
@@ -3,11 +3,14 @@ import PreComputed from './_pre-computed'
 import { logBinomial } from '../special'
 
 /**
- * Generator for the [heads-minus-tails distribution]{@link http://mathworld.wolfram.com/Heads-Minus-TailsDistribution.html}:
+ * Generator for the absolute-value (folded) heads-minus-tails distribution, i.e. the distribution of
+ * $|H - T|$ where $H$ is the number of heads in $2n$ fair coin flips and $T = 2n - H$ is the number
+ * of tails. This is the non-negative folded variant; the signed $H - T$ distribution (support
+ * $[-2n, 2n]$) is described at the MathWorld reference below:
  *
  * $f(k; n) = \begin{cases}\Big(\frac{1}{2}\Big)^{2n} \begin{pmatrix}2n \\\\ n \\\\ \end{pmatrix} &\quad\text{if $k = 0$},\\\\2 \Big(\frac{1}{2}\Big)^{2n} \begin{pmatrix}2n \\\\ m + n \\\\ \end{pmatrix} &\quad\text{if $k = 2m$},\\\\0 &\quad\text{else}\\\\ \end{cases}$
  *
- * where $n \in \mathbb{N}^+$. Support: $k \in \[0, n\]$.
+ * where $n \in \mathbb{N}^+$. Support: $k \in \[0, 2n\]$.
  *
  * @class HeadsMinusTails
  * @memberof ran.dist


### PR DESCRIPTION
Closes #360

## Summary
- Corrects the JSDoc support annotation from `k ∈ [0, n]` to `k ∈ [0, 2n]` — the previous bound was wrong; with 2n fair coin flips, `|H − T|` ranges from 0 to 2n, not n.
- Updates the class description to explicitly name this as the **absolute-value (folded) variant** (`|H − T|`), distinguishing it from the signed `H − T` distribution (support `[−2n, 2n]`) described by the MathWorld reference.

## Non-trivial changes
_No non-trivial changes — this PR is purely documentation._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYeQd79gEVY7ZYejevbqhk)_