### PR TITLE
Fix HeadsMinusTails constraint to reject n = 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `HeadsMinusTails` now rejects `n = 0`: constraint tightened from `n >= 0` to `n > 0`, matching the documented domain $n \in \mathbb{N}^+$. Closes #363.
+
 ### Added
 
 - TypeScript declarations are now generated from JSDoc via `tsc --allowJs --declaration --emitDeclarationOnly` as part of `npm run build`. The generated `dist/index.d.ts` replaces the hand-written `dist/ranjs.d.ts`, making type drift structurally impossible. Includes `@overload` annotations for `sample()`, `float()`, `int()`, `choice()`, `shuffle()`, and `coin()`. Closes #170.

--- a/src/dist/heads-minus-tails.js
+++ b/src/dist/heads-minus-tails.js
@@ -19,7 +19,7 @@ import { logBinomial } from '../special'
  */
 export default class HeadsMinusTails extends PreComputed {
   /**
-   * @param {number} n Half number of trials.
+   * @param {number} n Half number of trials (n > 0).
    */
   constructor (n) {
     super(true)
@@ -29,7 +29,7 @@ export default class HeadsMinusTails extends PreComputed {
     const ni = Math.round(n)
     this.p = { n: ni }
     Distribution.validate({ n: ni }, [
-      'n >= 0'
+      'n > 0'
     ])
 
     // Set support

--- a/test/dist-cases-discrete.js
+++ b/test/dist-cases-discrete.js
@@ -497,7 +497,8 @@ export default [{
   name: 'HeadsMinusTails',
   invalidParams: [
     [], // all params required
-    [-1] // n > 0
+    [-1], // n > 0
+    [0] // n > 0
   ],
   cases: [{
     params: () => [5]


### PR DESCRIPTION
Closes #363

## Summary
- Tightened `HeadsMinusTails` parameter constraint from `n >= 0` to `n > 0`, so `new ran.dist.HeadsMinusTails(0)` now throws instead of silently constructing a degenerate point-mass distribution
- Updated `@param` JSDoc to document the `n > 0` requirement
- Added `[0]` to `invalidParams` in the test suite to cover the newly rejected boundary value

## Non-trivial changes
- **`src/dist/heads-minus-tails.js`**: Behavioral change — `n = 0` now throws. Matches the documented domain $n \in \mathbb{N}^+$ stated in the class JSDoc and the MathWorld definition.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `### Fixed` entry for this constraint tightening
- **`test/dist-cases-discrete.js`**: Added `[0]` to `invalidParams` array and trailing comma on `[-1]`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGAxnMBXpKj85hcTeQRVhA)_