### PR TITLE
Remove unused betaAlpha pre-computation from InverseGamma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Quantile throughput restored for 10 derived distributions (`BirnbaumSaunders`, `DoubleWeibull`, `ExponentiatedWeibull`, `JohnsonSB`, `JohnsonSU`, `LogCauchy`, `LogLaplace`, `LogNormal`, `LogitNormal`, `TruncatedNormal`): `super._q` calls replaced with inlined closed-form formulas, eliminating the V8 megamorphic deoptimization that caused up to 56× slowdown. Closes #366.
 - `HeadsMinusTails` now rejects `n = 0`: constraint tightened from `n >= 0` to `n > 0`, matching the documented domain $n \in \mathbb{N}^+$. Closes #363.
+- `InverseGamma`: removed unused `this.c.betaAlpha` pre-computation (`Math.pow(beta, alpha)`) that was computed on every construction but never read. Closes #373.
 
 ### Added
 

--- a/src/dist/inverse-gamma.js
+++ b/src/dist/inverse-gamma.js
@@ -30,9 +30,6 @@ export default class InverseGamma extends Gamma {
       value: Infinity,
       closed: false
     }]
-
-    // Speed-up constants
-    this.c = { betaAlpha: Math.pow(beta, alpha) }
   }
 
   _generator () {


### PR DESCRIPTION
Closes #373

## Summary
- Deletes the unused `this.c = { betaAlpha: Math.pow(beta, alpha) }` line from the `InverseGamma` constructor — the constant was computed on every instantiation but never read anywhere in the class.
- The `_pdf` method delegates to `super._pdf(1/x) / (x*x)` (`Gamma._pdf`), which already recomputes `beta^alpha` inline; the cached value served no purpose.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/inverse-gamma.js`**: Removed dead-code constant `betaAlpha` from `this.c`; all 4629 tests continue to pass.
- **`CHANGELOG.md`**: Added Fixed entry for #373.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_0174y4bcd3NxhFaG4JEUeQ4g)_