### PR TITLE
Fix StudentT._q infinite loop at nu=10 via Newton cycle detection

### DIFF
--- a/src/dist/student-t.js
+++ b/src/dist/student-t.js
@@ -88,12 +88,17 @@ export default class StudentT extends Distribution {
       (5 * z2 * z2 * z + 16 * z2 * z + 3 * z) / (96 * this.p.nu * this.p.nu)
 
     // Newton refinement: t <- t - (F(t; nu) - p) / f(t; nu)
+    // tPrev detects period-2 oscillation: when regularizedBetaIncomplete lands 1 ULP
+    // off the true p, Newton bounces between two adjacent floats indefinitely.
+    let tPrev = NaN
     for (let i = 0; i < MAX_ITER; i++) {
       const dt = (this._cdf(t) - p) / this._pdf(t)
+      const tOld = t
       t -= dt
-      if (Math.abs(dt) <= EPS * Math.max(Math.abs(t), 1)) {
+      if (t === tPrev || Math.abs(dt) <= EPS * Math.max(Math.abs(t), 1)) {
         break
       }
+      tPrev = tOld
     }
     return t
   }


### PR DESCRIPTION
## Summary
- `StudentT._q` ran 100 Newton iterations on every call for `nu=10`, making it 20× slower than every other `nu` value (24K ops/sec vs 490K)
- Root cause: `regularizedBetaIncomplete` returns `0.9750000000000001` (1 ULP above 0.975) at the exact solution for `nu=10`. Newton bounces between two adjacent floats at `±2.619e-15`, which exceeds the `EPS * |t| ≈ 4.95e-16` convergence threshold, so it never exits
- Fix: `tPrev` tracks the previous iterate; `t === tPrev` (period-2 cycle) breaks the loop after 2 oscillations instead of 100 iterations

## Non-trivial changes
- **`src/dist/student-t.js`**: Added `tPrev = NaN` before the Newton loop and `t === tPrev` cycle-detection check. One extra variable write per iteration; zero cost on normal convergence paths.

## Before / after (quantile ops/sec, nu=10)
| | ranjs | jStat | ratio |
|---|---|---|---|
| Before fix | 24K | 1,008K | 0.02× |
| After fix | 490K | 1,008K | **0.49×** |

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWo1fBxLu4XV36hxatKiLy)_