### PR TITLE
Replace erfinv seed in gammaLowerIncompleteInv with A&S §26.2.17 approximation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Gamma.q(p)` (and `Chi2.q(p)`, `InverseGamma.q(p)`) Wilson-Hilferty seed now uses
+  an A&S §26.2.17 rational approximation instead of `erfinv`, eliminating nested
+  Newton iteration inside the outer Halley loop and accelerating quantile throughput.
+  Closes #384.
+
 - `Normal.q(p)` now uses an A&S §26.2.17 rational approximation seed with two fixed
   Newton refinement steps instead of `erfinv`, removing the convergent Newton loop
   and reducing from 3–5 `erf` evaluations to exactly 2. Closes #385.

--- a/src/special/gamma-incomplete.js
+++ b/src/special/gamma-incomplete.js
@@ -1,6 +1,5 @@
 import { MAX_ITER, EPS, DELTA } from '../core/constants'
 import logGamma from './log-gamma'
-import { erfinv } from './error'
 
 /**
  * Computes the regularized lower incomplete gamma function.
@@ -119,7 +118,12 @@ export function gammaLowerIncompleteInv (a, p) {
   // leading-term series inversion for a < 1 (or when W-H produces a non-positive value).
   let x
   if (a >= 1) {
-    const z = Math.SQRT2 * erfinv(2 * p - 1)
+    // A&S §26.2.17 rational approximation: |error| < 4.5e-4, avoids nested erfinv iteration.
+    const q = p <= 0.5 ? p : 1 - p
+    const t = Math.sqrt(-2 * Math.log(q))
+    const z0 = t - (2.515517 + t * (0.802853 + t * 0.010328)) /
+                (1 + t * (1.432788 + t * (0.189269 + t * 0.001308)))
+    const z = p <= 0.5 ? -z0 : z0
     const h = 9 * a
     x = a * Math.pow(1 - 1 / h + z / Math.sqrt(h), 3)
   }


### PR DESCRIPTION
Closes #384

## Summary
- The Wilson-Hilferty seed in `gammaLowerIncompleteInv` previously called `erfinv(2*p - 1)` to compute the standard normal quantile, which internally runs a convergent Newton loop (3–5 `erf` evaluations per call) — nested inside the outer Halley refinement loop.
- Replaced with the A&S §26.2.17 closed-form rational approximation (`|error| < 4.5e-4`), eliminating nested iteration entirely. The Halley loop corrects any seed error to machine precision regardless.
- The now-unused `import { erfinv } from './error'` is removed.

## Non-trivial changes
- **`src/special/gamma-incomplete.js`**: Seed computation for `a >= 1` path changed from `erfinv`-based normal quantile (iterative) to inline A&S §26.2.17 rational approximation (closed-form). Sign convention: `q = min(p, 1-p)`, `t = sqrt(-2 ln q)`, `z0 = A&S formula` (positive), `z = -z0` if `p ≤ 0.5` else `+z0`. This matches the established pattern in `Normal._q` (#385) and `StudentT._q` (#368, #381).

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `## [Unreleased]` entry for #384.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdQ35c2sTBkEw3nzoNgJxK)_