### PR TITLE
Style porting guide page to match API docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - run: npm ci
         if: steps.node-cache.outputs.cache-hit != 'true'
       - run: npm run docs
-      - run: test -f docs/index.html && test -f docs/styles/style.css
+      - run: test -f docs/index.html && test -f docs/porting-scipy.html && test -f docs/styles/style.css
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quantile throughput restored for 10 derived distributions (`BirnbaumSaunders`, `DoubleWeibull`, `ExponentiatedWeibull`, `JohnsonSB`, `JohnsonSU`, `LogCauchy`, `LogLaplace`, `LogNormal`, `LogitNormal`, `TruncatedNormal`): `super._q` calls replaced with inlined closed-form formulas, eliminating the V8 megamorphic deoptimization that caused up to 56× slowdown. Closes #366.
 - `HeadsMinusTails` now rejects `n = 0`: constraint tightened from `n >= 0` to `n > 0`, matching the documented domain $n \in \mathbb{N}^+$. Closes #363.
 - `InverseGamma`: removed unused `this.c.betaAlpha` pre-computation (`Math.pow(beta, alpha)`) that was computed on every construction but never read. Closes #373.
+- `docs/porting-scipy.html` styling now matches the API page: `h2` section headings, standalone table layout, side-by-side `.code-pair` code blocks (two columns ≥ 800 px, stacked on mobile), `.callout` warning blocks, and sidebar parity for the static (non-checkbox) jump menu. Closes #209.
 
 ### Added
 

--- a/docs/styles/_porting.scss
+++ b/docs/styles/_porting.scss
@@ -1,0 +1,90 @@
+// Porting guide page. Applies to docs/porting-scipy.html, which uses
+// h2 section headings, standalone tables, .code-pair (two-column code
+// blocks), .callout (warning blocks) and a static (non-checkbox-driven)
+// sidebar — none of which the API page exercises.
+//
+// Because both pages link the single compiled docs/styles/style.css,
+// every selector in this partial is in scope for the API page too.
+// Page-specific rules either use class selectors tied to porting-only
+// markup (.code-pair, p.callout) or :has() conditions on a
+// structurally page-distinguishing element (.search-bar is in the
+// API aside but not the porting aside).
+// See solutions/tooling/2026-05-24-1439-shared-stylesheet-cross-page-selector-leak.md
+// — verify cross-page DOM impact when adding bare-tag selectors here.
+@import "colors";
+
+
+// Per-distribution section headings. Mirrors the h1 typographic system
+// in main.scss (Montserrat, normal weight, 30-px gutter) but shrinks
+// and recolors to make the h1 → h2 hierarchy scannable.
+h2 {
+  display: inline-block;
+  margin: 50px 30px 8px 30px;
+  font-size: 1.25em;
+  font-weight: normal;
+  color: $colorThemeMain;
+}
+
+// Standalone tables (the API page tables all live inside .card .margined,
+// which keeps the higher-specificity .card rules winning; main > table
+// matches only direct children of main, not .card descendants).
+main > table {
+  width: calc(100% - 60px);
+  margin: 12px 30px 24px 30px;
+  border-collapse: collapse;
+
+  th, td {
+    padding: 8px 12px;
+    border-bottom: 1px solid #eee;
+  }
+}
+
+// Side-by-side Python / JavaScript code blocks. Mobile-first single
+// column here; the two-column override lives in desktop.scss alongside
+// the other min-width: 800px page-level overrides.
+.code-pair {
+  margin: 12px 30px;
+
+  > pre {
+    min-width: 0;
+  }
+}
+
+// Parameter-difference warning blocks. Left border + amber tint matches
+// the left-border accent pattern used by .card .title (card.scss:11-14)
+// and reinforces the ⚠ symbol that already appears in the prose.
+p.callout {
+  margin: 16px 30px;
+  padding: 12px 16px;
+  border-left: 4px solid #d97706;
+  background: #fffbeb;
+  border-radius: 0 3px 3px 0;
+
+  strong {
+    color: #92400e;
+  }
+}
+
+// Static sidebar (no search bar, no checkboxes). The aside.scss rules
+// assume a .search-bar above .sections and a checkbox toggle beside
+// each label; these overrides cover what is missing. aside:not(:has(
+// .search-bar)) scopes the first-child margin to the porting page so
+// the API page's first section is not pushed down below its existing
+// search bar.
+aside:not(:has(.search-bar)) {
+  ul.sections > li:first-child {
+    margin-top: 20px;
+  }
+}
+
+aside {
+  // Labels without an adjacent checkbox sibling are decorative, not
+  // interactive — drop the pointer cursor that aside.scss applies.
+  ul.sections label:not(:has(+ input)) {
+    cursor: default;
+
+    &:hover {
+      color: inherit;
+    }
+  }
+}

--- a/docs/styles/desktop.scss
+++ b/docs/styles/desktop.scss
@@ -17,4 +17,10 @@
     margin-left: 0;
     margin-right: 0;
   }
+
+  .code-pair {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
 }

--- a/docs/styles/index.scss
+++ b/docs/styles/index.scss
@@ -9,3 +9,4 @@
 @import "main";
 @import "desktop";
 @import "table";
+@import "porting";

--- a/solutions/tooling/2026-05-24-1439-shared-stylesheet-cross-page-selector-leak.md
+++ b/solutions/tooling/2026-05-24-1439-shared-stylesheet-cross-page-selector-leak.md
@@ -1,0 +1,171 @@
+---
+date: 2026-05-24T14:39:26Z
+category: "tooling"
+problem: "New SCSS selectors authored for one docs page silently matched elements on the other page through the single shared compiled stylesheet"
+status: complete
+related_issue: "#209"
+related_plan: "thoughts/plans/2026-05-24-1402-porting-guide-styling.md"
+tags: [docs, scss, sass, cross-page-leak, has-selector, shared-stylesheet, pages-array, multi-page-build, porting-guide, sidebar, regression]
+---
+
+# Solution: Shared-stylesheet cross-page selector leak in the docs build
+
+**Date**: 2026-05-24T14:39:26Z
+**Category**: tooling
+**Related Issue**: #209
+**Related Plan**: `thoughts/plans/2026-05-24-1402-porting-guide-styling.md`
+**Related ADR**: `decisions/0002-docs-pages-array.md`
+
+## Problem
+
+When adding a new SCSS partial `docs/styles/_porting.scss` to fix styling
+gaps on the second docs page (`docs/porting-scipy.html`, added in PR #208),
+two seemingly page-specific selectors silently leaked to the API page
+(`docs/index.html`):
+
+1. `main p { margin-bottom: 12px }` — intended to give the porting guide's
+   multi-paragraph prose vertical air. `main p` matches the API page's two
+   `<p>` elements (the "what is this?" intro paragraph at `index.pug:22` and
+   the demo links paragraph at `index.pug:33-35`), overriding the
+   intentional `margin: 0` set globally in `main.scss:19-23`.
+2. `aside ul.sections > li:first-child { margin-top: 20px }` — intended to
+   give the porting sidebar's first section top air, since it has no
+   `.search-bar` sibling above. `aside ul.sections > li:first-child`
+   matches the first `<li>` on every page that links the stylesheet,
+   including the API page, where the search bar already supplies its own
+   spacing. The rule would have pushed the API sidebar's first section
+   down 20 px.
+
+The implementation's own WHY comment asserted: "Selectors are scoped
+narrowly enough... that they do not regress the API page" — a claim the
+source cannot verify on its own, and which was false for both selectors.
+
+## Root Cause
+
+The docs pipeline (ADR-0002) compiles a single `docs/styles/style.css`
+from `docs/styles/index.scss` and serves it to every page in the
+`pages` array. There is no CSS cascade boundary between pages — every
+selector in every partial is in scope for every page that links the
+stylesheet. A rule authored while looking at one page's DOM has no
+automatic restriction to that page; it takes effect wherever the
+selector matches.
+
+Because the issue scope forbade template edits, no `body.porting` /
+`main.porting` scope class could be added to the porting template.
+Without a structural firewall, any rule using a generic element
+selector (`p`, `li:first-child`, bare tag selectors) had to either:
+
+- match identically-typed elements on both pages, or
+- use a structural `:has()` condition on something that differs
+  between the two pages, or
+- be authored as a class selector (`.code-pair`, `p.callout`) tied to
+  markup that only appears on one page.
+
+The plan's risk assessment acknowledged the global-selector concern but
+applied "the API page only has one `<p>`" as evidence that `main p` was
+safe — which only proves the scope is small, not that the rule is a
+no-op. A 12 px bottom margin on a singleton paragraph that happens to
+have nothing immediately below it is still a behavioral regression, not
+a benign no-op (e.g., it affects baseline alignment with the next
+section's top margin and is observable in dev tools).
+
+## Fix
+
+Two structural fixes, no template edits:
+
+1. **`main p` rule removed entirely.** The porting page's surrounding
+   block margins on `h1` (60 px top), `h2` (50 px top), `table`
+   (24 px bottom), `.code-pair` (12 px), and `p.callout` (16 px) already
+   provide vertical rhythm between prose paragraphs. There are no
+   consecutive `<p>` siblings anywhere on the porting page, so the rule
+   was solving a non-problem and could be deleted rather than scoped.
+
+2. **`aside ul.sections > li:first-child` scoped with `aside:not(:has(
+   .search-bar))`.** This exploits the structural difference between
+   the two pages: the API page's `<aside>` contains `.search-bar`
+   (`index.pug:8-9`); the porting page's does not. The `:has()`-based
+   page distinction was already used in the same partial for the
+   non-interactive label cursor rule
+   (`ul.sections label:not(:has(+ input))`), making the pattern
+   internally consistent.
+
+A defensive CI smoke-test extension was also added
+(`.github/workflows/ci.yml:101`): the docs-build job now asserts
+`docs/porting-scipy.html` exists in addition to `docs/index.html` and
+`docs/styles/style.css`, so a future regression that silently drops
+the second page would be caught.
+
+The first leak was caught by the build pipeline's bug-triage stage
+(`ops-triage` agent), classified as a definite regression in the same
+PR, and fixed in-flight rather than filed as a follow-up issue
+(filing a separate issue against the same PR for a bug it introduces
+would have been ridiculous). The second leak was caught by the review
+stage's independent correctness re-analysis after the first patch.
+Both stages catching live regressions is evidence the post-implement
+pipeline (triage + review) is working as designed.
+
+## Prevention Strategy
+
+Before merging any new SCSS rule that uses an unclassed element
+selector (bare tag, pseudo-class on a tag, descendant/child combinator
+without a class anchor), **explicitly read the DOM tree of every other
+page that links the shared compiled stylesheet** and ask: "Does this
+selector match anything in that DOM tree?" A WHY comment asserting
+narrow scoping is not evidence — only a check against the other
+page's actual markup is.
+
+When a rule genuinely needs to be page-specific but template edits
+are out of scope, use a `:has()` condition on a **page-distinguishing
+structural element** rather than relying on DOM-count reasoning
+("the API page only has one `<p>`"). For the ranjs docs build, the
+page-distinguishing element is `.search-bar` inside `aside` — the
+API page has one, the porting page does not. Patterns:
+
+```scss
+// Match only when the page-distinguishing element is absent.
+aside:not(:has(.search-bar)) ul.sections > li:first-child {
+  margin-top: 20px;
+}
+
+// Match only when a specific sibling relationship holds (here:
+// labels that have a checkbox toggle vs. decorative labels).
+ul.sections label:not(:has(+ input)) {
+  cursor: default;
+}
+```
+
+For new selectors whose intended scope is "this one page", prefer
+class selectors on markup that only appears on that page
+(`.code-pair`, `p.callout`, `h2#dist-*`) over bare tag selectors
+(`p`, `h2`, `table`). When a bare tag selector is unavoidable
+(e.g., styling the second page's standalone tables), use a structural
+parent combinator that the other page does not satisfy:
+`main > table` matches the porting page's direct-child tables but
+not the API page's `main > .card > table.margined`.
+
+For the workflow itself: a CI smoke test that asserts every page in
+the `pages` array exists after `npm run docs` is cheap insurance.
+The pattern `test -f docs/<page>.html` per page in the workflow's
+`docs-build` job costs one line per page and catches both build
+failures and accidental drops of `pages[]` entries.
+
+## Related Solutions
+
+- `solutions/tooling/2026-05-16-1135-docs-pages-array-build.md` —
+  Established the page-list-driven build and externalized stylesheet
+  that this solution is downstream of. That solution warned about the
+  source/artifact ambiguity of `style.css`; this solution warns about
+  the cross-page leak risk of the same single stylesheet now being
+  loaded by N pages. Both lessons compound: page-list builds are
+  cheap to grow, but each new page widens the surface where unscoped
+  selectors silently regress earlier pages.
+
+## Key Insight
+
+In a single shared-stylesheet docs build, "this selector only
+matches the new page" must be **verified by inspecting the other
+page's DOM tree**, not inferred from element count or comment
+assertion — and when template-level scoping classes are unavailable,
+CSS `:has()` conditions on a structurally unique element (e.g.,
+`aside:not(:has(.search-bar))`) are the correct isolation
+mechanism.


### PR DESCRIPTION
Closes #209

## Summary
- Adds `docs/styles/_porting.scss` (new partial, ~75 lines) providing the missing rules for the porting guide page: `h2` section headings that mirror the existing `h1` typographic system, standalone-table layout, side-by-side `.code-pair` code blocks (mobile-first single column; two columns at ≥ 800 px via the existing `desktop.scss` block), amber-left-border `.callout` warning paragraphs, and sidebar parity fixes for the static (non-checkbox) jump menu.
- Both pages link a single compiled `docs/styles/style.css` (ADR-0002), so every selector must be verified against both pages' DOM trees. Two leaks to the API page were caught and fixed in-flight by the build's triage and review stages — see the linked solution.
- Extends the CI `docs-build` smoke test to assert `docs/porting-scipy.html` exists in addition to `docs/index.html` and `docs/styles/style.css`.

## Design decisions
No new ADR. Implementation-level CSS choices that don't reach the public API or cross-cutting conventions covered by CLAUDE.md's ADR gate. The cross-page leak pattern uncovered during the build is captured as a solution document:
- [`solutions/tooling/2026-05-24-1439-shared-stylesheet-cross-page-selector-leak.md`](solutions/tooling/2026-05-24-1439-shared-stylesheet-cross-page-selector-leak.md) — when a docs build emits one stylesheet for N pages, verify every bare-tag selector against every page's DOM tree, and use `:has()` conditions on a page-distinguishing structural element (here `aside:not(:has(.search-bar))`) when template-level scope classes aren't an option.

## Non-trivial changes
- **`docs/styles/_porting.scss`**: The new partial uses two non-obvious scoping patterns to prevent rules from leaking to the API page through the shared compiled stylesheet — `aside:not(:has(.search-bar))` distinguishes the porting sidebar (no search bar) from the API sidebar (has one), and `ul.sections label:not(:has(+ input))` distinguishes decorative labels from checkbox-toggle labels. Both rely on CSS `:has()`, supported in all modern browsers (Chrome 105+, Firefox 121+, Safari 15.4+). Top-of-file WHY comment + the linked solution document explain the rationale.
- **`docs/styles/desktop.scss`**: Adds `.code-pair { display: grid; grid-template-columns: 1fr 1fr; gap: 12px }` to the existing `min-width: 800px` block, keeping all desktop overrides co-located with the existing convention (`aside`, `main`, `.card`, `.margined`).

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state (CI structural smoke test extended; no JS test framework applies to CSS)
- [x] A developer encountering this code in 6 months could understand it (top-of-file comment + linked solution doc)

<details>
<summary>Trivial changes</summary>

- **`docs/styles/index.scss`**: One-line `@import "porting";` appended after the existing imports.
- **`.github/workflows/ci.yml`**: One-line addition of `test -f docs/porting-scipy.html` to the existing docs-build smoke test.
- **`CHANGELOG.md`**: One bullet under `[Unreleased]` → `Fixed` summarizing the styling additions.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sarc4dRfR4YREQtqA59U4F)_