### PR TITLE
Fix empty API documentation section on docs/index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Docs build now locates the `ran` module entry in `documentation`'s output by
+  `kind`/`name` instead of `root[0]`, restoring the API documentation section,
+  sidebar menu, and search list on `docs/index.html`.
+
 ### Changed
 
 - `Gamma.q(p)` (and `Chi2.q(p)`, `InverseGamma.q(p)`) Wilson-Hilferty seed now uses

--- a/docs/index.js
+++ b/docs/index.js
@@ -82,7 +82,15 @@ function parseEntry (entry) {
 
   // Build API documentation.
   console.log('Building API content')
-  const docs = root[0].members.static
+  // documentation@v14 returns top-level entries as a flat array; the `ran`
+  // module is not guaranteed to be root[0] (orphan classes like
+  // Hyperexponential, IrwinHall, NegativeBinomial precede it). Find it by
+  // kind+name instead of indexing positionally.
+  const moduleEntry = root.find(d => d.kind === 'module' && d.name === 'ran')
+  if (!moduleEntry) {
+    throw new Error('docs build: could not find `ran` module entry in documentation output')
+  }
+  const docs = moduleEntry.members.static
     .sort((a, b) => a.name.localeCompare(b.name))
     .map(m => ({
       name: m.name,


### PR DESCRIPTION
## Summary

The "documentation" section of the rendered `docs/index.html` was empty — no sidebar entries, empty search list, no API cards. Root cause: `documentation@v14` returns top-level entries as a flat array, and orphan classes (`Hyperexponential`, `IrwinHall`, `NegativeBinomial`) precede the `ran` module in `root`, so `root[0].members.static` returned 0 namespaces.

The build script now locates the module entry by `kind === 'module' && name === 'ran'` and throws a descriptive error if it ever goes missing.

Drive-by fix discovered while triaging #54. Not tied to an open issue.

## Verification

- `npm run docs` rebuilds cleanly; `docs/index.html` grew from 53 lines (empty) to 13,851 lines.
- Sidebar `<ul class="sections">` is populated; search list is non-empty; **195 API cards** render under the documentation heading.
- `npm run standard` passes (no lint changes were applied to the touched files).

## Checklist

- [x] `npm run standard` passes
- [ ] `npm test` — not run (docs-build-only change; no library code touched)
- [ ] `npm run typecheck` — not run (docs-build-only change)
- [x] `CHANGELOG.md` updated under `## [Unreleased] → Fixed`
- [x] Production-code diff is under ~400 lines (1 functional line + a guard + a WHY comment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRo5R2bufUpvkqyorfskHZ)_