### PR TITLE
Dedup duplicate `@see` tags across distribution JSDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Distribution JSDoc references de-duplicated: removed 135 `@see <url>` tags
+  whose URL was identical to the inline `{@link <url>}` already present in
+  the distribution's description. The rendered "References" section now
+  appears only when it carries non-trivial information (papers, books,
+  algorithm citations) rather than repeating the distribution-name link.
+  Four `// Source:` code comments (Alpha, Anglit, Arcsine, BaldingNichols)
+  were promoted to class-level `@see` entries so the cited works show up in
+  the rendered docs.
+
 - `Gamma.q(p)` (and `Chi2.q(p)`, `InverseGamma.q(p)`) Wilson-Hilferty seed now uses
   an A&S §26.2.17 rational approximation instead of `erfinv`, eliminating nested
   Newton iteration inside the outer Halley loop and accelerating quantile throughput.

--- a/src/dist/alpha.js
+++ b/src/dist/alpha.js
@@ -12,7 +12,7 @@ import { erf, erfinv } from '../special'
  *
  * @class Alpha
  * @memberof ran.dist
- * @see https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/alppdf.htm
+ * @see Johnson, Kotz, and Balakrishnan, Continuous Univariate Distributions Vol. 1, 2nd ed., John Wiley and Sons, 1994, p. 173.
  * @constructor
  */
 export default class Alpha extends Distribution {

--- a/src/dist/anglit.js
+++ b/src/dist/anglit.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class Anglit
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy-1.0.0/reference/tutorial/stats/continuous_anglit.html
+ * @see M. King, Statistics for Process Control Engineers, John Wiley and Sons, 2017, p. 472.
  * @constructor
  */
 export default class Anglit extends Distribution {

--- a/src/dist/arcsine.js
+++ b/src/dist/arcsine.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * @class Arcsine
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Arcsine_distribution#Arbitrary_bounded_support
+ * @see W. Feller, An Introduction to Probability Theory and Its Applications Vol. 2, 2nd ed., John Wiley and Sons, 1991, p. 79.
  * @constructor
  */
 export default class Arcsine extends Distribution {

--- a/src/dist/balding-nichols.js
+++ b/src/dist/balding-nichols.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * @class BaldingNichols
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Balding%E2%80%93Nichols_model
+ * @see D.J. Balding and R.A. Nichols, "A method for quantifying differentiation between populations at multi-allelic loci and its implications for investigating identity and paternity", Genetica 96, 3–12, 1995.
  * @constructor
  */
 export default class BaldingNichols extends Beta {

--- a/src/dist/bates.js
+++ b/src/dist/bates.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Bates
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Bates_distribution
  * @constructor
  */
 export default class Bates extends IrwinHall {

--- a/src/dist/benini.js
+++ b/src/dist/benini.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Benini
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Benini_distribution
  * @constructor
  */
 export default class Benini extends Distribution {

--- a/src/dist/benktander-ii.js
+++ b/src/dist/benktander-ii.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class BenktanderII
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Benktander_type_II_distribution
  * @constructor
  */
 export default class BenktanderII extends Distribution {

--- a/src/dist/bernoulli.js
+++ b/src/dist/bernoulli.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Bernoulli
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Bernoulli_distribution
  * @constructor
  */
 export default class Bernoulli extends Categorical {

--- a/src/dist/beta-binomial.js
+++ b/src/dist/beta-binomial.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class BetaBinomial
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Beta-binomial_distribution
  * @constructor
  */
 export default class BetaBinomial extends Categorical {

--- a/src/dist/beta-geometric.js
+++ b/src/dist/beta-geometric.js
@@ -14,7 +14,6 @@ import rBeta from './_beta'
  * @memberof ran.dist
  * @param {number} alpha First shape parameter.
  * @param {number} beta Second shape parameter.
- * @see https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/bgepdf.htm
  * @constructor
  */
 export default class extends PreComputed {

--- a/src/dist/beta-prime.js
+++ b/src/dist/beta-prime.js
@@ -12,7 +12,6 @@ import Beta from './beta'
  *
  * @class BetaPrime
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Beta_prime_distribution
  * @constructor
  */
 export default class BetaPrime extends Beta {

--- a/src/dist/beta-rectangular.js
+++ b/src/dist/beta-rectangular.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class BetaRectangular
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Beta_rectangular_distribution
  * @constructor
  */
 export default class BetaRectangular extends Beta {

--- a/src/dist/beta.js
+++ b/src/dist/beta.js
@@ -12,7 +12,6 @@ import Distribution from './_distribution'
  *
  * @class Beta
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Beta_distribution
  * @constructor
  */
 export default class Beta extends Distribution {

--- a/src/dist/binomial.js
+++ b/src/dist/binomial.js
@@ -11,7 +11,6 @@ import Categorical from './categorical'
  *
  * @class Binomial
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Binomial_distribution
  * @constructor
  */
 export default class Binomial extends Categorical {

--- a/src/dist/birnbaum-saunders.js
+++ b/src/dist/birnbaum-saunders.js
@@ -11,7 +11,6 @@ import { erfinv } from '../special'
  *
  * @class BirnbaumSaunders
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Birnbaum%E2%80%93Saunders_distribution
  * @constructor
  */
 export default class BirnbaumSaunders extends Normal {

--- a/src/dist/borel-tanner.js
+++ b/src/dist/borel-tanner.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class BorelTanner
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Borel_distribution#Borel%E2%80%93Tanner_distribution
  * @constructor
  */
 export default class BorelTanner extends PreComputed {

--- a/src/dist/borel.js
+++ b/src/dist/borel.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Borel
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Borel_distribution
  * @constructor
  */
 export default class Borel extends PreComputed {

--- a/src/dist/bounded-pareto.js
+++ b/src/dist/bounded-pareto.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class BoundedPareto
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Pareto_distribution#Bounded_Pareto_distribution
  * @constructor
  */
 export default class BoundedPareto extends Distribution {

--- a/src/dist/bradford.js
+++ b/src/dist/bradford.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Bradford
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bradford.html
  * @constructor
  */
 export default class Bradford extends Distribution {

--- a/src/dist/burr.js
+++ b/src/dist/burr.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Burr
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Burr_distribution
  * @constructor
  */
 export default class Burr extends Distribution {

--- a/src/dist/categorical.js
+++ b/src/dist/categorical.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Categorical
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Categorical_distribution
  * @constructor
  */
 export default class Categorical extends Distribution {

--- a/src/dist/cauchy.js
+++ b/src/dist/cauchy.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Cauchy
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Cauchy_distribution
  * @constructor
  */
 export default class Cauchy extends Distribution {

--- a/src/dist/champernowne.js
+++ b/src/dist/champernowne.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Champernowne
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Champernowne_distribution
  * @constructor
  */
 export default class Champernowne extends Distribution {

--- a/src/dist/chi.js
+++ b/src/dist/chi.js
@@ -10,7 +10,6 @@ import Chi2 from './chi2'
  *
  * @class Chi
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Chi_distribution
  * @constructor
  */
 export default class Chi extends Chi2 {

--- a/src/dist/chi2.js
+++ b/src/dist/chi2.js
@@ -10,7 +10,6 @@ import Gamma from './gamma'
  *
  * @class Chi2
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Chi-squared_distribution
  * @constructor
  */
 export default class Chi2 extends Gamma {

--- a/src/dist/dagum.js
+++ b/src/dist/dagum.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Dagum
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Dagum_distribution
  * @constructor
  */
 export default class Dagum extends Distribution {

--- a/src/dist/degenerate.js
+++ b/src/dist/degenerate.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Degenerate
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Degenerate_distribution
  * @constructor
  */
 export default class Degenerate extends Distribution {

--- a/src/dist/delaporte.js
+++ b/src/dist/delaporte.js
@@ -13,7 +13,6 @@ import PreComputed from './_pre-computed'
  *
  * @class Delaporte
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Delaporte_distribution
  * @constructor
  */
 export default class Delaporte extends PreComputed {

--- a/src/dist/discrete-uniform.js
+++ b/src/dist/discrete-uniform.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class DiscreteUniform
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Discrete_uniform_distribution
  * @constructor
  */
 export default class DiscreteUniform extends Distribution {

--- a/src/dist/discrete-weibull.js
+++ b/src/dist/discrete-weibull.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class DiscreteWeibull
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Discrete_Weibull_distribution
  * @constructor
  */
 export default class DiscreteWeibull extends Distribution {

--- a/src/dist/double-gamma.js
+++ b/src/dist/double-gamma.js
@@ -10,7 +10,6 @@ import Gamma from './gamma'
  *
  * @class DoubleGamma
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/tutorial/stats/continuous_dgamma.html
  * @constructor
  */
 export default class DoubleGamma extends Gamma {

--- a/src/dist/double-weibull.js
+++ b/src/dist/double-weibull.js
@@ -9,7 +9,6 @@ import Weibull from './weibull'
  *
  * @class DoubleWeibull
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/tutorial/stats/continuous_dweibull.html
  * @constructor
  */
 export default class DoubleWeibull extends Weibull {

--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -16,7 +16,6 @@ import Distribution from './_distribution'
  *
  * @class DoublyNoncentralBeta
  * @memberof ran.dist
- * @see https://arxiv.org/abs/1706.08557
  * @constructor
  */
 export default class DoublyNoncentralBeta extends Distribution {

--- a/src/dist/doubly-noncentral-chi2.js
+++ b/src/dist/doubly-noncentral-chi2.js
@@ -11,7 +11,6 @@ import NoncentralChi2 from './noncentral-chi2'
  *
  * @class DoublyNoncentralChi2
  * @memberof ran.dist
- * @see https://doi.org/10.1093/biomet/36.1-2.202
  * @constructor
  */
 export default class DoublyNoncentralChi2 extends NoncentralChi2 {

--- a/src/dist/doubly-noncentral-f.js
+++ b/src/dist/doubly-noncentral-f.js
@@ -10,7 +10,6 @@ import DoublyNoncentralBeta from './doubly-noncentral-beta'
  *
  * @class DoublyNoncentralF
  * @memberof ran.dist
- * @see https://doi.org/10.1111/j.1467-842X.1965.tb00036.x
  * @constructor
  */
 export default class DoublyNoncentralF extends DoublyNoncentralBeta {

--- a/src/dist/doubly-noncentral-t.js
+++ b/src/dist/doubly-noncentral-t.js
@@ -16,7 +16,6 @@ import NoncentralT from './noncentral-t'
  *
  * @class DoublyNoncentralT
  * @memberof ran.dist
- * @see https://www.wiley.com/en-us/Intermediate+Probability%3A+A+Computational+Approach-p-9780470026373
  * @constructor
  */
 export default class DoublyNoncentralT extends Distribution {

--- a/src/dist/erlang.js
+++ b/src/dist/erlang.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Erlang
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Erlang_distribution
  * @constructor
  */
 export default class Erlang extends Gamma {

--- a/src/dist/exponential-logarithmic.js
+++ b/src/dist/exponential-logarithmic.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class ExponentialLogarithmic
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Exponential-logarithmic_distribution#Related_distribution
  * @constructor
  */
 export default class ExponentialLogarithmic extends Distribution {

--- a/src/dist/exponential.js
+++ b/src/dist/exponential.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Exponential
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Exponential_distribution
  * @constructor
  */
 export default class Exponential extends Distribution {

--- a/src/dist/exponentiated-weibull.js
+++ b/src/dist/exponentiated-weibull.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class ExponentiatedWeibull
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Exponentiated_Weibull_distribution
  * @constructor
  */
 export default class ExponentiatedWeibull extends Weibull {

--- a/src/dist/f.js
+++ b/src/dist/f.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class F
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/F-distribution
  * @constructor
  */
 export default class F extends Beta {

--- a/src/dist/fisher-z.js
+++ b/src/dist/fisher-z.js
@@ -9,7 +9,6 @@ import F from './f'
  *
  * @class FisherZ
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Fisher%27s_z-distribution
  * @constructor
  */
 export default class FisherZ extends F {

--- a/src/dist/flory-schulz.js
+++ b/src/dist/flory-schulz.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class FlorySchulz
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Flory%E2%80%93Schulz_distribution
  * @constructor
  */
 export default class FlorySchulz extends Distribution {

--- a/src/dist/frechet.js
+++ b/src/dist/frechet.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Frechet
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Frechet_distribution
  * @constructor
  */
 export default class Frechet extends Distribution {

--- a/src/dist/gamma-gompertz.js
+++ b/src/dist/gamma-gompertz.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class GammaGompertz
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Gamma/Gompertz_distribution
  * @constructor
  */
 export default class GammaGompertz extends Distribution {

--- a/src/dist/gamma.js
+++ b/src/dist/gamma.js
@@ -12,7 +12,6 @@ import Distribution from './_distribution'
  *
  * @class Gamma
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Gamma_distribution
  * @see G. Marsaglia and W. W. Tsang, "A Simple Method for Generating Gamma Variables", ACM Trans. Math. Softw. 26(3), 363–372, 2000.
  * @constructor
  */

--- a/src/dist/generalized-exponential.js
+++ b/src/dist/generalized-exponential.js
@@ -10,7 +10,6 @@ import { lambertW0 } from '../special'
  *
  * @class GeneralizedExponential
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/tutorial/stats/continuous_genexpon.html
  * @constructor
  */
 export default class GeneralizedExponential extends Distribution {

--- a/src/dist/generalized-extreme-value.js
+++ b/src/dist/generalized-extreme-value.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedExtremeValue
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Generalized_extreme_value_distribution
  * @constructor
  */
 export default class GeneralizedExtremeValue extends Distribution {

--- a/src/dist/generalized-gamma.js
+++ b/src/dist/generalized-gamma.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedGamma
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Generalized_gamma_distribution
  * @constructor
  */
 export default class GeneralizedGamma extends Gamma {

--- a/src/dist/generalized-hermite.js
+++ b/src/dist/generalized-hermite.js
@@ -15,7 +15,6 @@ import PreComputed from './_pre-computed'
  *
  * @class GeneralizedHermite
  * @memberof ran.dist
- * @see https://journal.r-project.org/archive/2015/RJ-2015-035/RJ-2015-035.pdf
  * @constructor
  */
 export default class GeneralizedHermite extends PreComputed {

--- a/src/dist/generalized-logistic.js
+++ b/src/dist/generalized-logistic.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedLogistic
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Generalized_logistic_distribution
  * @constructor
  */
 export default class GeneralizedLogistic extends Distribution {

--- a/src/dist/generalized-normal.js
+++ b/src/dist/generalized-normal.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedNormal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Generalized_normal_distribution
  * @constructor
  */
 export default class GeneralizedNormal extends GeneralizedGamma {

--- a/src/dist/generalized-pareto.js
+++ b/src/dist/generalized-pareto.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class GeneralizedPareto
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Generalized_Pareto_distribution
  * @constructor
  */
 export default class GeneralizedPareto extends Distribution {

--- a/src/dist/geometric.js
+++ b/src/dist/geometric.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Geometric
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Geometric_distribution
  * @constructor
  */
 export default class Geometric extends Distribution {

--- a/src/dist/gilbrat.js
+++ b/src/dist/gilbrat.js
@@ -9,7 +9,6 @@ import LogNormal from './log-normal'
  *
  * @class Gilbrat
  * @memberof ran.dist
- * @see http://mathworld.wolfram.com/GibratsDistribution.html
  * @constructor
  */
 export default class Gilbrat extends LogNormal {

--- a/src/dist/gompertz.js
+++ b/src/dist/gompertz.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Gompertz
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Gompertz_distribution
  * @constructor
  */
 export default class Gompertz extends Distribution {

--- a/src/dist/gumbel.js
+++ b/src/dist/gumbel.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Gumbel
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Gumbel_distribution
  * @constructor
  */
 export default class Gumbel extends Distribution {

--- a/src/dist/half-generalized-normal.js
+++ b/src/dist/half-generalized-normal.js
@@ -9,7 +9,6 @@ import GeneralizedNormal from './generalized-normal'
  *
  * @class HalfGeneralizedNormal
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.halfgennorm.html
  * @constructor
  */
 export default class HalfGeneralizedNormal extends GeneralizedNormal {

--- a/src/dist/half-logistic.js
+++ b/src/dist/half-logistic.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class HalfLogistic
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Half-logistic_distribution
  * @constructor
  */
 export default class HalfLogistic extends Distribution {

--- a/src/dist/half-normal.js
+++ b/src/dist/half-normal.js
@@ -10,7 +10,6 @@ import { erfinv } from '../special'
  *
  * @class HalfNormal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Half-normal_distribution
  * @constructor
  */
 export default class HalfNormal extends Normal {

--- a/src/dist/hyperbolic-secant.js
+++ b/src/dist/hyperbolic-secant.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class HyperbolicSecant
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Hyperbolic_secant_distribution
  * @constructor
  */
 export default class HyperbolicSecant extends Distribution {

--- a/src/dist/hyperexponential.js
+++ b/src/dist/hyperexponential.js
@@ -13,7 +13,6 @@ import neumaier from '../algorithms/neumaier'
  * @class Hyperexponential
  * @memberof ran.dist
  * object with two properties: weight and rate.
- * @see https://en.wikipedia.org/wiki/Hyperexponential_distribution
  * @constructor
  */
 export default class Hyperexponential extends Distribution {

--- a/src/dist/hypergeometric.js
+++ b/src/dist/hypergeometric.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Hypergeometric
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Hypergeometric_distribution
  * @constructor
  */
 export default class Hypergeometric extends Categorical {

--- a/src/dist/inverse-chi2.js
+++ b/src/dist/inverse-chi2.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class InverseChi2
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Inverse-chi-squared_distribution
  * @constructor
  */
 export default class InverseChi2 extends Distribution {

--- a/src/dist/inverse-gamma.js
+++ b/src/dist/inverse-gamma.js
@@ -10,7 +10,6 @@ import Gamma from './gamma'
  *
  * @class InverseGamma
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Inverse-gamma_distribution
  * @constructor
  */
 export default class InverseGamma extends Gamma {

--- a/src/dist/inverse-gaussian.js
+++ b/src/dist/inverse-gaussian.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class InverseGaussian
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution
  * @see J. R. Michael, W. R. Schucany and R. W. Haas, "Generating Random Variates Using Transformations with Multiple Roots", Am. Stat. 30(2), 88–90, 1976.
  * @constructor
  */

--- a/src/dist/inverted-weibull.js
+++ b/src/dist/inverted-weibull.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class InvertedWeibull
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/tutorial/stats/continuous_invweibull.html
  * @constructor
  */
 export default class InvertedWeibull extends Distribution {

--- a/src/dist/irwin-hall.js
+++ b/src/dist/irwin-hall.js
@@ -12,7 +12,6 @@ import Distribution from './_distribution'
  * @class IrwinHall
  * @memberof ran.dist
  * value is 1.
- * @see https://en.wikipedia.org/wiki/Irwin%E2%80%93Hall_distribution
  * @constructor
  */
 export default class IrwinHall extends Distribution {

--- a/src/dist/johnson-sb.js
+++ b/src/dist/johnson-sb.js
@@ -11,7 +11,6 @@ import { erfinv } from '../special'
  *
  * @class JohnsonSB
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Johnson%27s_SU-distribution#Johnson's_SB-distribution
  * @constructor
  */
 export default class JohnsonSB extends Normal {

--- a/src/dist/johnson-su.js
+++ b/src/dist/johnson-su.js
@@ -11,7 +11,6 @@ import { erfinv } from '../special'
  *
  * @class JohnsonSU
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Johnson%27s_SU-distribution
  * @constructor
  */
 export default class JohnsonSU extends Normal {

--- a/src/dist/kolmogorov.js
+++ b/src/dist/kolmogorov.js
@@ -10,7 +10,6 @@ import { EPS, MAX_ITER } from '../core/constants'
  *
  * @class Kolmogorov
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test#Kolmogorov_distribution
  * @constructor
  */
 export default class Kolmogorov extends Distribution {

--- a/src/dist/kumaraswamy.js
+++ b/src/dist/kumaraswamy.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Kumaraswamy
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Kumaraswamy_distribution
  * @constructor
  */
 export default class Kumaraswamy extends Distribution {

--- a/src/dist/laplace.js
+++ b/src/dist/laplace.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Laplace
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Laplace_distribution
  * @constructor
  */
 export default class Laplace extends Distribution {

--- a/src/dist/levy.js
+++ b/src/dist/levy.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Levy
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Lévy_distribution
  * @constructor
  */
 export default class Levy extends Distribution {

--- a/src/dist/lindley.js
+++ b/src/dist/lindley.js
@@ -10,7 +10,6 @@ import { lambertW1m } from '../special'
  *
  * @class Lindley
  * @memberof ran.dist
- * @see http://www.hjms.hacettepe.edu.tr/uploads/b35d591c-22f6-4136-8735-20c82936cd64.pdf
  * @constructor
  */
 export default class Lindley extends Distribution {

--- a/src/dist/log-cauchy.js
+++ b/src/dist/log-cauchy.js
@@ -9,7 +9,6 @@ import Cauchy from './cauchy'
  *
  * @class LogCauchy
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Log-Cauchy_distribution
  * @constructor
  */
 export default class LogCauchy extends Cauchy {

--- a/src/dist/log-gamma.js
+++ b/src/dist/log-gamma.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class LogGamma
  * @memberof ran.dist
- * @see https://reference.wolfram.com/language/ref/LogGammaDistribution.html
  * @constructor
  */
 export default class LogGamma extends Gamma {

--- a/src/dist/log-laplace.js
+++ b/src/dist/log-laplace.js
@@ -9,7 +9,6 @@ import Laplace from './laplace'
  *
  * @class LogLaplace
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Log-Laplace_distribution
  * @constructor
  */
 export default class LogLaplace extends Laplace {

--- a/src/dist/log-logistic.js
+++ b/src/dist/log-logistic.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class LogLogistic
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Log-logistic_distribution
  * @constructor
  */
 export default class LogLogistic extends Distribution {

--- a/src/dist/log-normal.js
+++ b/src/dist/log-normal.js
@@ -10,7 +10,6 @@ import { erfinv } from '../special'
  *
  * @class LogNormal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Log-normal_distribution
  * @constructor
  */
 export default class LogNormal extends Normal {

--- a/src/dist/log-series.js
+++ b/src/dist/log-series.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class LogSeries
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Logarithmic_distribution
  * @see A. Kemp, "Efficient generation of logarithmically distributed pseudo-random variables", Appl. Stat. 30(3), 249–253, 1981.
  * @constructor
  */

--- a/src/dist/logarithmic.js
+++ b/src/dist/logarithmic.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Logarithmic
  * @memberof ran.dist
- * @see http://mathworld.wolfram.com/LogarithmicDistribution.html
  * @constructor
  */
 export default class Logarithmic extends Distribution {

--- a/src/dist/logistic-exponential.js
+++ b/src/dist/logistic-exponential.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class LogisticExponential
  * @memberof ran.dist
- * @see http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.295.8653&rep=rep1&type=pdf
  * @constructor
  */
 export default class LogisticExponential extends Distribution {

--- a/src/dist/logistic.js
+++ b/src/dist/logistic.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Logistic
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Logistic_distribution
  * @constructor
  */
 export default class Logistic extends Distribution {

--- a/src/dist/logit-normal.js
+++ b/src/dist/logit-normal.js
@@ -10,7 +10,6 @@ import { erfinv } from '../special'
  *
  * @class LogitNormal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Logit-normal_distribution
  * @constructor
  */
 export default class LogitNormal extends Normal {

--- a/src/dist/lomax.js
+++ b/src/dist/lomax.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Lomax
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Lomax_distribution
  * @constructor
  */
 export default class Lomax extends Distribution {

--- a/src/dist/makeham.js
+++ b/src/dist/makeham.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Makeham
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Gompertz%E2%80%93Makeham_law_of_mortality
  * @constructor
  */
 export default class Makeham extends Distribution {

--- a/src/dist/maxwell-boltzmann.js
+++ b/src/dist/maxwell-boltzmann.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class MaxwellBoltzmann
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Maxwell%E2%80%93Boltzmann_distribution
  * @constructor
  */
 export default class MaxwellBoltzmann extends Gamma {

--- a/src/dist/mielke.js
+++ b/src/dist/mielke.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Mielke
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mielke.html#r7049b665a02e-2
  * @constructor
  */
 export default class Mielke extends Dagum {

--- a/src/dist/moyal.js
+++ b/src/dist/moyal.js
@@ -11,7 +11,6 @@ import { gammaUpperIncomplete } from '../special'
  *
  * @class Moyal
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.moyal.html#r7049b665a02e-2
  * @constructor
  */
 export default class Moyal extends Distribution {

--- a/src/dist/muth.js
+++ b/src/dist/muth.js
@@ -12,7 +12,6 @@ import { lambertW1m } from '../special'
  *
  * @class Muth
  * @memberof ran.dist
- * @see https://www.tandfonline.com/doi/abs/10.3846/13926292.2015.1048540
  * @constructor
  */
 export default class Muth extends Distribution {

--- a/src/dist/nakagami.js
+++ b/src/dist/nakagami.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Nakagami
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Nakagami_distribution
  * @constructor
  */
 export default class Nakagami extends Distribution {

--- a/src/dist/negative-binomial.js
+++ b/src/dist/negative-binomial.js
@@ -14,7 +14,6 @@ import Distribution from './_distribution'
  * @class NegativeBinomial
  * @memberof ran.dist
  * integer.
- * @see https://en.wikipedia.org/wiki/Negative_binomial_distribution
  * @constructor
  */
 export default class NegativeBinomial extends Distribution {

--- a/src/dist/negative-hypergeometric.js
+++ b/src/dist/negative-hypergeometric.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class NegativeHypergeometric
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution
  * @constructor
  */
 export default class NegativeHypergeometric extends Categorical {

--- a/src/dist/neyman-a.js
+++ b/src/dist/neyman-a.js
@@ -11,7 +11,6 @@ import PreComputed from './_pre-computed'
  *
  * @class NeymanA
  * @memberof ran.dist
- * @see http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.527.574&rep=rep1&type=pdf
  * @constructor
  */
 export default class NeymanA extends PreComputed {

--- a/src/dist/noncentral-beta.js
+++ b/src/dist/noncentral-beta.js
@@ -13,7 +13,6 @@ import Distribution from './_distribution'
  *
  * @class NoncentralBeta
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Noncentral_beta_distribution
  * @constructor
  */
 export default class NoncentralBeta extends Distribution {

--- a/src/dist/noncentral-chi.js
+++ b/src/dist/noncentral-chi.js
@@ -10,7 +10,6 @@ import NoncentralChi2 from './noncentral-chi2'
  *
  * @class NoncentralChi
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Noncentral_chi_distribution
  * @constructor
  */
 export default class NoncentralChi extends NoncentralChi2 {

--- a/src/dist/noncentral-chi2.js
+++ b/src/dist/noncentral-chi2.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class NoncentralChi2
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Noncentral_chi-squared_distribution
  * @constructor
  */
 export default class NoncentralChi2 extends Distribution {

--- a/src/dist/noncentral-f.js
+++ b/src/dist/noncentral-f.js
@@ -10,7 +10,6 @@ import NoncentralBeta from './noncentral-beta'
  *
  * @class NoncentralF
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Noncentral_F-distribution
  * @constructor
  */
 export default class NoncentralF extends NoncentralBeta {

--- a/src/dist/noncentral-t.js
+++ b/src/dist/noncentral-t.js
@@ -15,7 +15,6 @@ import Distribution from './_distribution'
  * @memberof ran.dist
  * @param {number} nu Degrees of freedom. If not an integer, it is rounded to the nearest one.
  * @param {number} mu Non-centrality parameter.
- * @see https://en.wikipedia.org/wiki/Noncentral_t-distribution
  * @constructor
  */
 class NoncentralT extends Distribution {

--- a/src/dist/normal.js
+++ b/src/dist/normal.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Normal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Normal_distribution
  * @see https://en.wikipedia.org/wiki/Ziggurat_algorithm Improved Ziggurat algorithm (sampling algorithm)
  * @constructor
  */

--- a/src/dist/pareto.js
+++ b/src/dist/pareto.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Pareto
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Pareto_distribution
  * @constructor
  */
 export default class Pareto extends Distribution {

--- a/src/dist/pert.js
+++ b/src/dist/pert.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class PERT
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/PERT_distribution
  * @constructor
  */
 export default class PERT extends Beta {

--- a/src/dist/poisson.js
+++ b/src/dist/poisson.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Poisson
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Poisson_distribution
  * @see D. E. Knuth, "Seminumerical Algorithms", The Art of Computer Programming vol. 2, 1969 (small λ). A. C. Atkinson, "The Computer Generation of Poisson Random Variables", Appl. Stat. 28(1), 29–35, 1979 (large λ).
  * @constructor
  */

--- a/src/dist/polya-aeppli.js
+++ b/src/dist/polya-aeppli.js
@@ -11,7 +11,6 @@ import poisson from './_poisson'
  *
  * @class PolyaAeppli
  * @memberof ran.dist
- * @see https://arxiv.org/abs/1406.2780
  * @constructor
  */
 export default class PolyaAeppli extends PreComputed {

--- a/src/dist/power-law.js
+++ b/src/dist/power-law.js
@@ -9,7 +9,6 @@ import Kumaraswamy from './kumaraswamy'
  *
  * @class PowerLaw
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.powerlaw.html
  * @constructor
  */
 export default class PowerLaw extends Kumaraswamy {

--- a/src/dist/q-exponential.js
+++ b/src/dist/q-exponential.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class QExponential
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Q-exponential_distribution
  * @constructor
  */
 export default class QExponential extends GeneralizedPareto {

--- a/src/dist/r.js
+++ b/src/dist/r.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class R
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy-1.5.4/reference/tutorial/stats/continuous_rdist.html
  * @constructor
  */
 export default class R extends Beta {

--- a/src/dist/rademacher.js
+++ b/src/dist/rademacher.js
@@ -9,7 +9,6 @@ import Categorical from './categorical'
  *
  * @class Rademacher
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Rademacher_distribution
  * @constructor
  */
 export default class Rademacher extends Categorical {

--- a/src/dist/raised-cosine.js
+++ b/src/dist/raised-cosine.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class RaisedCosine
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Raised_cosine_distribution
  * @constructor
  */
 export default class RaisedCosine extends Distribution {

--- a/src/dist/rayleigh.js
+++ b/src/dist/rayleigh.js
@@ -9,7 +9,6 @@ import Weibull from './weibull'
  *
  * @class Rayleigh
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Rayleigh_distribution
  * @constructor
  */
 export default class Rayleigh extends Weibull {

--- a/src/dist/reciprocal-inverse-gaussian.js
+++ b/src/dist/reciprocal-inverse-gaussian.js
@@ -9,7 +9,6 @@ import InverseGaussian from './inverse-gaussian'
  *
  * @class ReciprocalInverseGaussian
  * @memberof ran.dist
- * @see https://docs.scipy.org/doc/scipy-1.7.0/reference/tutorial/stats/continuous_recipinvgauss.html
  * @constructor
  */
 export default class ReciprocalInverseGaussian extends InverseGaussian {

--- a/src/dist/reciprocal.js
+++ b/src/dist/reciprocal.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Reciprocal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Reciprocal_distribution
  * @constructor
  */
 export default class Reciprocal extends Distribution {

--- a/src/dist/rice.js
+++ b/src/dist/rice.js
@@ -12,7 +12,6 @@ import Distribution from './_distribution'
  *
  * @class Rice
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Rice_distribution
  * @constructor
  */
 export default class Rice extends Distribution {

--- a/src/dist/shifted-log-logistic.js
+++ b/src/dist/shifted-log-logistic.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class ShiftedLogLogistic
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Shifted_log-logistic_distribution
  * @constructor
  */
 export default class ShiftedLogLogistic extends Distribution {

--- a/src/dist/skellam.js
+++ b/src/dist/skellam.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Skellam
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Skellam_distribution
  * @constructor
  */
 export default class Skellam extends Distribution {

--- a/src/dist/skew-normal.js
+++ b/src/dist/skew-normal.js
@@ -13,7 +13,6 @@ import Normal from './normal'
  *
  * @class SkewNormal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Skew_normal_distribution
  * @see A. Azzalini, "SN package FAQ", https://azzalini.stat.unipd.it/SN/faq-r.html (sampling algorithm)
  * @constructor
  */

--- a/src/dist/slash.js
+++ b/src/dist/slash.js
@@ -10,7 +10,6 @@ import Normal from './normal'
  *
  * @class Slash
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Slash_distribution
  * @constructor
  */
 export default class Slash extends Normal {

--- a/src/dist/soliton.js
+++ b/src/dist/soliton.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Soliton
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Soliton_distribution
  * @constructor
  */
 export default class Soliton extends Categorical {

--- a/src/dist/student-t.js
+++ b/src/dist/student-t.js
@@ -13,7 +13,6 @@ import Distribution from './_distribution'
  *
  * @class StudentT
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Student%27s_t-distribution
  * @constructor
  */
 export default class StudentT extends Distribution {

--- a/src/dist/student-z.js
+++ b/src/dist/student-z.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class StudentZ
  * @memberof ran.dist
- * @see http://mathworld.wolfram.com/Studentsz-Distribution.html
  * @constructor
  */
 export default class StudentZ extends StudentT {

--- a/src/dist/trapezoidal.js
+++ b/src/dist/trapezoidal.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Trapezoidal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Trapezoidal_distribution
  * @constructor
  */
 export default class Trapezoidal extends Distribution {

--- a/src/dist/triangular.js
+++ b/src/dist/triangular.js
@@ -9,7 +9,6 @@ import Distribution from './_distribution'
  *
  * @class Triangular
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Triangular_distribution
  * @constructor
  */
 export default class Triangular extends Distribution {

--- a/src/dist/truncated-normal.js
+++ b/src/dist/truncated-normal.js
@@ -13,7 +13,6 @@ import { erfinv } from '../special'
  *
  * @class TruncatedNormal
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Truncated_normal_distribution
  * @constructor
  */
 export default class TruncatedNormal extends Normal {

--- a/src/dist/tukey-lambda.js
+++ b/src/dist/tukey-lambda.js
@@ -10,7 +10,6 @@ import brent from '../algorithms/brent'
  *
  * @class TukeyLambda
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Tukey_lambda_distribution
  * @constructor
  */
 export default class TukeyLambda extends Distribution {

--- a/src/dist/u-quadratic.js
+++ b/src/dist/u-quadratic.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class UQuadratic
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/U-quadratic_distribution
  * @constructor
  */
 export default class UQuadratic extends Distribution {

--- a/src/dist/uniform-product.js
+++ b/src/dist/uniform-product.js
@@ -11,7 +11,6 @@ import { gamma, gammaUpperIncomplete } from '../special'
  *
  * @class UniformProduct
  * @memberof ran.dist
- * @see https://mathworld.wolfram.com/UniformProductDistribution.html
  * @constructor
  */
 export default class UniformProduct extends Distribution {

--- a/src/dist/uniform-ratio.js
+++ b/src/dist/uniform-ratio.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class UniformRatio
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Ratio_distribution#Uniform_ratio_distribution
  * @constructor
  */
 export default class UniformRatio extends Distribution {

--- a/src/dist/uniform.js
+++ b/src/dist/uniform.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Uniform
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)
  * @constructor
  */
 export default class Uniform extends Distribution {

--- a/src/dist/von-mises.js
+++ b/src/dist/von-mises.js
@@ -12,7 +12,6 @@ import { MAX_ITER } from '../core/constants'
  *
  * @class VonMises
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Von_Mises_distribution
  * @see L. Barabesi, "Generating von Mises variates by the ratio-of-uniforms method", Statistica Applicata 7(4), 417–426, 1995.
  * @constructor
  */

--- a/src/dist/weibull.js
+++ b/src/dist/weibull.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Weibull
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Weibull_distribution
  * @constructor
  */
 export default class Weibull extends Exponential {

--- a/src/dist/wigner.js
+++ b/src/dist/wigner.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Wigner
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Wigner_semicircle_distribution
  * @constructor
  */
 export default class Wigner extends Distribution {

--- a/src/dist/yule-simon.js
+++ b/src/dist/yule-simon.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class YuleSimon
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Yule%E2%80%93Simon_distribution
  * @constructor
  */
 export default class YuleSimon extends Distribution {

--- a/src/dist/zeta.js
+++ b/src/dist/zeta.js
@@ -11,7 +11,6 @@ import Distribution from './_distribution'
  *
  * @class Zeta
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Zeta_distribution
  * @see L. Devroye, "Non-Uniform Random Variate Generation", Springer-Verlag, 1986, ch. 10.
  * @constructor
  */

--- a/src/dist/zipf.js
+++ b/src/dist/zipf.js
@@ -10,7 +10,6 @@ import Distribution from './_distribution'
  *
  * @class Zipf
  * @memberof ran.dist
- * @see https://en.wikipedia.org/wiki/Zipf%27s_law
  * @constructor
  */
 export default class Zipf extends Categorical {


### PR DESCRIPTION
## Summary

In 134 of 139 distributions, the class-level `@see <url>` tag pointed at the **exact same URL** already linked inline as `[distribution name]{@link <url>}` in the description. The rendered "References" section was therefore a copy of the distribution-name hyperlink on every card — pure visual noise, no added information.

This PR:

1. **Removes 135 duplicate `@see` lines** across 134 distributions plus the duplicate half of `normal.js` (which keeps its distinct Ziggurat-algorithm reference).
2. **Promotes 4 `// Source:` code comments** to class-level `@see` so the cited works show up in the rendered docs:
   - `Alpha` → Johnson, Kotz & Balakrishnan (1994)
   - `Anglit` → King (2017)
   - `Arcsine` → Feller (1991)
   - `BaldingNichols` → Balding & Nichols (1995)

`VonMises` and `DoublyNoncentralT` were left alone — their additional references were already surfaced (an existing `@see` with a label survived dedup; Paolella is already credited in the description prose, respectively).

## Result

| Bucket | Before | After |
|---|---|---|
| Distributions with a "References" section in the rendered docs | 139 | 14 |
| of which carry genuine scholarly content (papers/books/algorithms) | ~10 | 14 |
| of which were just a Wikipedia link duplicate | ~129 | 0 |

The 14 remaining References sections are all substantive: Alpha, Anglit, Arcsine, BaldingNichols, Gamma (Marsaglia-Tsang), HeadsMinusTails (MathWorld), Hoyt (cross-ref to Nakagami), InverseGaussian (Michael-Schucany-Haas), LogSeries (Kemp), Normal (Ziggurat), Poisson (Knuth/Atkinson), SkewNormal (Azzalini), VonMises (Barabesi), Zeta (Devroye).

## Verification

- `npm run standard` ✅
- `npm run jsdoclint` ✅
- `npm test` ✅ — 4650 passing
- `npm run docs` ✅ — rebuilt cleanly; verified References sections render correctly on the 14 expected cards and are absent from the rest.

## Checklist

- [x] `npm run standard` passes
- [x] `npm test` passes (4650 passing)
- [x] `npm run typecheck` — not run (JSDoc text-only changes; no signatures touched)
- [x] `CHANGELOG.md` updated under `## [Unreleased] → Changed`
- [x] Production-code diff is well under ~400 lines (136 files: 13 insertions, 135 deletions)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRo5R2bufUpvkqyorfskHZ)_