### PR TITLE
Restore distribution parameters and paragraph layout in API docs

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -37,8 +37,21 @@ function getSortedEntries (entries, priority) {
 
 function parseEntry (entry) {
   const name = entry.name
-  const params = entry.params.map(ParamParser)
-  const throws = entry.throws.map(ThrowsParser)
+  // Distribution classes carry @param/@throws on the constructor's own
+  // JSDoc (the post-#306 layout: class block has no @param so tsc can
+  // pick the constructor signature). documentation.js v14 surfaces that
+  // block as entry.constructorComment. Fall back to it when the class
+  // entry itself has no params/throws, otherwise the rendered cards
+  // show "Name()" with no Parameters table.
+  const ctor = entry.constructorComment
+  const sourceParams = entry.params.length > 0
+    ? entry.params
+    : (ctor ? ctor.params : [])
+  const sourceThrows = entry.throws.length > 0
+    ? entry.throws
+    : (ctor ? ctor.throws : [])
+  const params = sourceParams.map(ParamParser)
+  const throws = sourceThrows.map(ThrowsParser)
 
   return {
     name,

--- a/docs/src/desc-parser.js
+++ b/docs/src/desc-parser.js
@@ -1,5 +1,16 @@
+// Renders a documentation.js description AST into HTML.
+//
+// Markdown descriptions in the source JSDoc carry paragraph breaks (blank
+// lines between blocks like prose → formula → prose), but the old parser
+// flattened the whole tree into a single inline string, which both
+// collapsed paragraphs visually and stripped breathing room around
+// standalone math. We now emit one <p> per markdown paragraph and let
+// the page CSS handle spacing. {@link …} fragments (which arrive in the
+// AST as adjacent [text, link] pairs) are stitched back into a single
+// <a> per pair via assembleLinks.
+
 function extractLinkText (node) {
-  const re = /\[(.*?)\]/;
+  const re = /\[(.*?)\]/
   return re.exec(node.value)[1]
 }
 
@@ -28,12 +39,31 @@ const assembleLinks = children => {
 
 const simplify = str => str.replace(/\s+/g, ' ')
 
-const dfs = (obj, key, map) => {
-  if (Array.isArray(obj.children)) {
-    return map(assembleLinks(obj.children).map(d => dfs(d, key, map)))
-  } else {
-    return obj[key]
+const renderNode = node => {
+  if (Array.isArray(node.children)) {
+    return assembleLinks(node.children).map(renderNode).join('')
   }
+  return node.value || ''
 }
 
-module.exports = obj => dfs(obj.description, 'value', d => simplify(d.join('')))
+module.exports = obj => {
+  const root = obj.description
+  if (!root || !Array.isArray(root.children)) {
+    return ''
+  }
+  // Each top-level child of a markdown description is typically a
+  // paragraph node. Wrap each in <p> so multi-paragraph descriptions
+  // ("Generator for X:" → "$f(...)$" → "with μ ∈ ℝ …") keep their
+  // semantic breaks; this is what gives standalone formulas vertical
+  // breathing room in the rendered card.
+  const paragraphs = root.children
+    .filter(c => c.type === 'paragraph')
+    .map(p => `<p>${simplify(renderNode(p)).trim()}</p>`)
+
+  // Fallback for descriptions with no paragraph nodes (rare — e.g. a
+  // single bare text root): render the whole subtree inline.
+  if (paragraphs.length === 0) {
+    return simplify(renderNode(root)).trim()
+  }
+  return paragraphs.join('')
+}

--- a/docs/styles/_table.scss
+++ b/docs/styles/_table.scss
@@ -58,3 +58,21 @@ tbody td:first-child {
   display: inline-block;
   margin: 0 4px 4px 0;
 }
+
+// DescParser now wraps every description (incl. one-liner param descs)
+// in <p>. Reset the default paragraph margins inside table cells and
+// inline desc holders so a single-paragraph param row doesn't grow a
+// 16px gap above/below its content. Multi-paragraph param descs are
+// rare but still get an in-cell visual break via the gap rule below.
+td p,
+.return-desc p,
+.throws-desc p,
+.deprecated-message p {
+  margin: 0;
+}
+
+td p + p,
+.return-desc p + p,
+.throws-desc p + p {
+  margin-top: 0.4em;
+}

--- a/docs/styles/card.scss
+++ b/docs/styles/card.scss
@@ -66,14 +66,23 @@
     }
   }
 
-  // Descriptions frequently contain inline MathJax SVG (6+ ex tall); a
-  // generous line-height keeps neighbouring text from colliding with
-  // fractions and exponents.
+  // Descriptions are emitted as one <p> per markdown paragraph by
+  // DescParser. Block-level <p> margins inside .desc give standalone
+  // formulas natural vertical breathing room without per-element math
+  // hacks. line-height stays slightly looser than body to keep tall
+  // inline math from crowding adjacent text within a mixed paragraph.
   .desc {
     margin: 6px 0 14px;
     color: $colorInk;
-    line-height: 1.9;
+    line-height: 1.75;
   }
+
+  .desc p {
+    margin: 0.9em 0;
+  }
+
+  .desc p:first-child { margin-top: 0; }
+  .desc p:last-child { margin-bottom: 0; }
 
   // Section labels inside a card (Parameters / Returns / Throws / Examples /
   // References). These are emitted as <h3> by the template; here we override

--- a/docs/styles/equation.scss
+++ b/docs/styles/equation.scss
@@ -1,26 +1,37 @@
 // Server-rendered MathJax SVG. mjpage wraps each formula in a span:
 //   .mjpage         inline math ($a$ inside prose)
 //   .mjpage__block  display math (centered, on its own line)
-// The base CSS that mjpage injects sets .mjpage to display:inline, but
-// inline elements ignore vertical padding when sizing line boxes — so
-// tall fractions and exponents render flush against the line below.
-// Promoting .mjpage to inline-block with vertical padding extends the
-// line box vertically, giving every formula real breathing room while
-// short symbols (μ ∈ ℝ) still flow naturally with the text. Display math
-// gets a larger explicit block margin on top of that.
+//
+// mjpage injects its own <style> block AFTER our stylesheet in <head>,
+// and that block sets max-width: none / padding: 0 / display: inline on
+// .mjpage. So every property we need to win against it has to be
+// !important — otherwise wide formulas overflow the column on mobile
+// and tall ones collide with the line below.
+//
+// Both selectors clamp width to the content column and turn on
+// overflow-x: auto, so a wide formula (e.g. Beta-Rectangular's
+// piecewise PDF) becomes a horizontally scrollable strip on narrow
+// viewports instead of being cut off. inline-block on .mjpage lets
+// vertical padding actually grow the line box, giving tall inline math
+// breathing room in mixed-text paragraphs. Standalone formulas live in
+// their own <p> (via DescParser) and get extra room from paragraph
+// margins.
 
 .mjpage {
   display: inline-block !important;
   vertical-align: middle;
-  padding: 0.45em 0.2em;
+  max-width: 100% !important;
+  overflow-x: auto !important;
+  overflow-y: hidden !important;
+  padding: 0.25em 0.15em !important;
 }
 
 .mjpage__block {
   display: block !important;
   max-width: 100% !important;
-  overflow-x: auto;
-  overflow-y: hidden;
-  margin: 1.8em auto !important;
-  padding: 8px 0 10px !important;
+  overflow-x: auto !important;
+  overflow-y: hidden !important;
+  margin: 1.2em auto !important;
+  padding: 6px 0 8px !important;
   text-align: center;
 }


### PR DESCRIPTION
## Summary

Three coupled fixes to the restyled API doc cards:

1. **Distribution parameters were missing.** Every `dist.*` card rendered as `ran.dist.Name()` with no `Parameters` table. Root cause: when JSDoc `@param` tags were moved from the class block onto the constructor (#306, May 23, to satisfy `tsc`'s constructor typing), documentation.js v14 started emitting them on `entry.constructorComment.params` instead of `entry.params`. `docs/index.js`'s `parseEntry` kept reading `entry.params` and got an empty array. Now it falls back to `constructorComment.params` / `.throws` when the class entry's own arrays are empty.
2. **No vertical space around equations.** `DescParser` was joining the whole description AST into one inline string, collapsing markdown paragraph breaks. Standalone formulas (`Generator for X:` / `$f(...)$` / `with μ ∈ ℝ …`) ended up on one visual line with the surrounding prose. Each top-level paragraph node is now emitted as its own `<p>`, and the new `.desc p` margins give standalone math natural breathing room.
3. **Wide formulas overflowed on mobile.** mjpage injects its own `<style>` block AFTER the project stylesheet and sets `max-width: none` on `.mjpage`, defeating my width clamp. The fix is mechanical — add `!important` to the override. `.mjpage` / `.mjpage__block` now both clamp to 100% of the content column with `overflow-x: auto`, so a wide piecewise PDF (Polya-Aeppli, Beta-Rectangular) becomes a horizontally scrollable strip on a 420 px viewport instead of being clipped.

References were not actually missing — they render for every distribution that has `@see` tags. The user's uncertainty there was likely from #392's deduplication, which removed `@see` entries that duplicated the description's Wikipedia link.

Doc-only change — no `CHANGELOG.md` entry per the project's docs/refactor exemption.

## Files changed

- `docs/index.js` — `parseEntry` falls back to `constructorComment.params` / `.throws`.
- `docs/src/desc-parser.js` — rewritten to emit one `<p>` per markdown paragraph; single-paragraph fallback preserved.
- `docs/styles/card.scss` — `.desc p` margins (top/bottom), reset on first/last child; `line-height` relaxed (1.9 → 1.75) since paragraphs now do the spacing work.
- `docs/styles/equation.scss` — `!important` on `.mjpage` / `.mjpage__block` width/overflow/padding so the mjpage-injected styles can't undo them. inline-block + `max-width: 100%` + `overflow-x: auto` makes wide formulas scrollable on mobile.
- `docs/styles/_table.scss` — zero `<p>` margins inside `td`, `.return-desc`, `.throws-desc`, `.deprecated-message`; sibling-paragraph gap rule for the rare multi-paragraph param desc.

## Test plan

- [x] `npm run docs` builds without errors
- [x] `ran.dist.Normal(mu, sigma)` (was `Normal()`) — full signature + Parameters table back
- [x] Normal description renders as 3 paragraphs with the formula on its own line, breathing room above and below
- [x] PERT, Pareto, Poisson, PolyaAeppli all show their full constructor signatures and parameter tables
- [x] References section still renders for distributions with `@see` tags (Normal: "Improved Ziggurat algorithm")
- [x] Mobile (420 px) — PolyaAeppli's wide piecewise PDF clamps to the viewport and is horizontally scrollable (`clientW: 388`, `scrollW: 546`, `overflow-x: auto`)
- [x] Mobile — small inline math (`μ ∈ ℝ`, `λ > 0`) still flows inline with prose, no awkward scrollbars
- [x] Porting page (`porting-scipy.html`) unchanged — tables and sidebar still render

## Checklist

- [x] `npm run standard` — N/A (doc-only)
- [x] `npm test` — N/A (doc-only)
- [x] `npm run typecheck` — N/A (doc-only)
- [x] `CHANGELOG.md` updated — skipped per the docs/refactor exemption
- [x] Production-code diff under ~400 lines — no production code touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01QjAmB5w21ZDr1aZsQH98zZ)_