### PR TITLE
Release v1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.25.0] - 2026-05-25
+
 ### Fixed
 
 - Docs build now locates the `ran` module entry in `documentation`'s output by

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ranjs",
-  "version": "1.24.6",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ranjs",
-      "version": "1.24.6",
+      "version": "1.25.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranjs",
-  "version": "1.24.6",
+  "version": "1.25.0",
   "description": "Library for generating various random variables.",
   "keywords": [
     "random",


### PR DESCRIPTION
## Release v1.25.0

### Changes since v1.24.5

eb2c0d1d Restore distribution parameters and paragraph layout in API docs
9c9f9f35 Add white favicon variant and vertical breathing room around equations
dcbef466 Drop the etymology paragraph from the API landing hero
544e90ce Restyle docs site to "clean docs + ink brand layer" design
a7e7dfa6 Rewrite README for publication readiness
f76fe2cb Deduplicate distribution `@see` tags that mirror the description link
b1860409 Teach scout agents to surface untracked todo.md entries as suggestions
77e65989 Docs build finds `ran` module by name, restoring API section
cf0dcc8c Porting guide page styling added, closes #209
325e91d1 Solution compounded for #209 — shared-stylesheet-cross-page-selector-leak
0a4bd6c6 A&S §26.2.17 rational approximation used as Wilson-Hilferty seed, closes #384
ba09d827 Normal._q erfinv loop replaced with A&S rational approximation, closes #385
d03151d5 Array.from replaced with pre-allocated loop in some(), closes #386
883bdcdd Add Student-t (nu=5) to benchmark suite, handle null stdlib entry
5ea8072f StudentT._q 4-term Cornish-Fisher seed + Halley refinement, closes #381
f51dc57c Solution compounded for #381 — halley-higher-period-oscillation-ibf-noise-floor
8430a833 Object.assign rule for this.c in subclasses documented in CLAUDE.md, closes #374
b8f39e54 Newton cycle detection added to StudentT._q to fix nu=10 infinite loop
941b31f5 StudentT Cornish-Fisher seed + Newton quantile added, closes #368
26a39e60 Solution compounded for #368 — erfinv-as-seed-negates-newton-speedup
e1dd7869 Rewrite Ziggurat sampler from paper notation, not stdlib reference
32070ab8 Replace for(;;) with while(true) in Ziggurat sampler for readability
05337304 Fix skewness() test spurious failure when sample skewness is near zero
61baa9b6 Replace Box-Muller with Improved Ziggurat in Normal variate generator, closes #369
97f39f0e Remove unused betaAlpha pre-computation from InverseGamma constructor, closes #373
5035a7d3 Gamma dedicated Wilson-Hilferty+Halley quantile added, gammaLowerIncompleteInv exported, closes #367
48231ab3 Solution compounded for #367 — gamma-subclass-q-inheritance-guard
b21befc8 super._q inlined in 10 derived distributions, V8 megamorphic deoptimization fixed, closes #366
309f3776 Solution compounded for #366 — super-q-v8-megamorphic-deoptimization
314c3cff feat: trim benchmark back to 5 cross-library distributions
5594a56a feat: expand benchmark to all 22 jStat distributions, move to scripts/
137d661c feat: add benchmark suite comparing ranjs vs jStat vs @stdlib (closes #114)
5c1b829c docs: add ADR-0011 for benchmark devDependencies (issue #114)
23f97ae0 HeadsMinusTails n = 0 constraint fixed, closes #363
bf06b7a6 HeadsMinusTails JSDoc corrected: support [0, 2n] and folded-variant description, closes #360
b5bae84f DoublyNoncentralT mu=0 case refVals added, closes #359
8c58c6cb Second parameter cases added to 105 single-case distributions, closes #135
3d07c8ce Solution compounded for #135 — second-param-cases-scipy-traps-and-stochastic-failures
7beb3ffd Generate declarations before typecheck in CI
ee7486ea Remove check-declarations.js from check-decl script
843a2823 Generate TypeScript declarations from JSDoc via tsc --allowJs (#170)
20b85559 ADR inline reference rationale added to _type field comment
3eabeafc Rename this.t to this._type on Distribution base class (issue #205 PR 1/6)
c64341ea Add ADR-0009: rename single-letter Distribution instance fields
b15563d7 NegativeBinomial boundary cases at p=0 and p=1 fixed, closes #145
a486f55b bounded() method added to Distribution base class, closes #119
4fe82e9c FlorySchulz._cdf cancellation fix added to changelog, closes #248
a837d475 Champernowne subpath export added to package.json
67b03521 Fix Champernowne stub: normalization constant, CDF, generator, export, closes #337
f6cf5910 JSDoc optional markers and default-value claims removed from distribution constructors, closes #306
c30a4a86 Replace FlorySchulz._generator with O(1) inverse-CDF method
2068fb2c Fix test timeout: UnitTests.test() now respects sampleParams
9c720dea Catastrophic cancellation in FlorySchulz._cdf fixed for small a
c314e548 Replace ranjs-sourced quantileVals with independently verified reference values, closes #341
39638da0 Skellam k=±1 refVals restored, closes #225
91985f43 NoncentralBeta alpha<1 lower-boundary CDF verified, stale TODO removed, closes #324
8d5100f1 Solution compounded for #324 — noncentral-beta-alpha-lt1-ad-noise-refvals-verification
1246529f Per-distribution GoF sample-size override added for Normal, Exponential and Uniform, closes #185
d56168a8 Solution compounded for #185 — per-distribution-gof-sample-size-override
0f66aeee Solution compounded for #295 — refvals-self-validation-cancellation-boundary
7ee65a6a Add boundary GoF tests (#270) and fix BenktanderII refVals provenance (#295)
60ef35d3 Vacuous extreme-tail quantile tolerance fixed with relative band
b2a86ac2 Scipy/ranjs quantile reference values added for all 26 discrete distributions
8f4566b9 Solution compounded for #279 — quantile-refvals-scipy-naming-traps-extreme-tail-tolerance
b4bb3f74 Scipy quantile reference values added for all remaining 95 continuous distributions
7c791f89 Add ADR-0008: this.c named-object convention, add inline reference
37e6d1a6 Migrate this.c from positional arrays to named objects in 21 distributions
a0806ffb this.c migrated to named object in bounded uniform-shape distributions
ef1495a8 this.c migrated to named object in location-scale distributions
c630bd3c this.c migrated to named object in simple continuous distributions
1bb78b62 Compound removed from fix and hotfix skills
438c19ba this.c migrated to named object in noncentral distributions
a8e96981 Compound step moved to after review in build, fix, and hotfix
e2f5d6c7 CODE_OF_CONDUCT.md and SECURITY.md added
a5ba16d7 NoncentralBeta _pdf NaN at x=0 for alpha <= 1 fixed
27428c30 NoncentralF invalidParams comments corrected to d1 and d2
4f134534 Lower-bound guard added to NoncentralBeta._cdf, stress tests and per-case refVals support added
7730c5da Romberg interpolation window start condition corrected
6d095bfe this.c migrated to named object in InverseGaussian, convention documented in CLAUDE.md
4621b5d1 Inline Marcum large-mu coefficients into marcum-q.js
e4ff7d62 Solution compounded for #315 — marcum-large-mu-asymptotic
7c170ce8 Large-mu asymptotic expansion added as the fifth Marcum branch, closes #315
6b0edeb4 Solution compounded for #316 — doubly-noncentral-chi2-inherit-noncentral-chi2
3656e5e0 DoublyNoncentralChi2 rewritten to extend NoncentralChi2, NoncentralChi2 validator relaxed to lambda >= 0, closes #316
33f09053 neumaier sorts a shallow copy to avoid mutating the caller's array, closes #313
1910dfbd romberg non-convergence sentinel 0 replaced with best extrapolate, Davis console.log removed, closes #312
ad77b89b Solution compounded for #253 — marcum-q-four-branches
92a72c0c marcumQ and marcumP four-branch implementation completed, closes #253
b1667101 DoublyNoncentralF lambda=0 regression tests added, closes #307
17e09b47 DoublyNoncentralBeta lambda=0 NaN fixed, regression tests added, closes #304
9f7745e1 Doubly non-central distribution references replaced with primary sources
367bdcb2 DoublyNoncentralChi2 subpath export added to package.json
be3d888f Solution compounded for #228 — doubly-noncentral-chi2-additivity-collapse
feee17c8 DoublyNoncentralChi2 distribution added, closes #228
11bbd2c8 NoncentralBeta lambda=0 NaN fixed, regression test added, closes #267
248ac646 Moyal._cdf catastrophic cancellation fixed, closes #247
b56c16c8 Pipeline continuation made explicit in hotfix/fix skills and CLAUDE.md
88bbbd2c besselI odd-symmetry regression tests for n >= 3 added, closes #297
3ad7dc37 besselI(n=1, x) low-precision polynomial replaced with Miller backward recurrence, VonMises CDF accuracy fixed, closes #255
f378d8a5 BenktanderII._cdf catastrophic cancellation near x=1 fixed, closes #242
c9ee7de5 arguments.length replaced with hardcoded k in all distribution constructors
455deda7 Lindley k hardcoded to 1 and AIC/BIC regression tests added, closes #291
79985e63 Lindley._cdf catastrophic cancellation near x=0 fixed, closes #241
95764291 Deprecation banner added to docs for deprecated entries
64b8296f Classical Hoyt (Nakagami-q) added to todo.md
a54bacf4 Hoyt deprecated as misnamed Nakagami alias, closes #226
616faaad _qEstimateWalk infinite-loop at p=0 and p=1 fixed, closes #285
8b164d3e Allow git diff, git log, and mkdir .claude/tmp without permission prompts
5accdf9b Skellam _q NaN-in-tails fixed via _qEstimateWalk, closes #283
b886e2ba Solution compounded for #284 — q-estimate-walk-infinite-support-discrete
bf443245 _qEstimateWalk base class helper added for deterministic discrete quantile estimation, closes #284
16625b07 Solution compounded for #212 — discrete-quantile-ceil-minus-one-pattern
9fb35c4c Quantile roundtrip property tests added and discrete _q off-by-ones fixed, closes #212
017d454b Sign error in Soliton JSDoc PMF formula fixed
9e40a086 Scipy quantile reference values added for 12 core continuous distributions
f67b1396 One-sided KS statistic fixed to two-sided D in ksTest and kolmogorovSmirnov
da0458b9 Solution compounded for #261 — r-distribution-mixed-beta-reductions
52311be5 R distribution asymmetry fixed via Beta(c/2, c/2) affine reduction, closes #261
4bf6d4f8 BenktanderII GoF coverage extended to b=1 and b≈1 branches
0f435789 Soliton support truncation fixed: k=N weight included
bc9ecf30 NegativeHypergeometric PMF typo fixed: Ki → k in logBinomial weight loop
4693cc2d Add WHY comments to all sampleParams exclusions in dist-cases files
ccbe2803 Separate sampleParams from cases in dist-cases files (#187)
7395edb9 Solutions compounded for #184 — AD test swap (errfix transcription + α calibration)
eb5b3c25 Replace KS with Anderson-Darling for distribution sampling assertions
72e07f76 Bug fixes excluded from major label definition
28b53909 @see references rendered as doc page citations
c8a141c4 @see citations added to all distribution JSDoc
15d09b29 Address review: tighten refVals comments and coverage
31698f78 Add refVals for 41 distributions from independent scipy/mpmath sources
186886b2 /release: infer major bump from closed major-labelled issues
6ba24d0a Add /release skill for end-to-end versioned npm releases
0e927cc8 Simplify to major-only semver label; drop minor and patch labels
150382e8 Add milestone enforcement: GitHub Actions + ops-issue + CLAUDE.md
b319a709 Enforce semver label (major/minor/patch) in ops-issue and CLAUDE.md
a9a34f36 Add ADR-0007: stay on ranjs, no npm rename
22047104 Build skill Stage 7 report order aligned with Stage 6 (compound before PR)
7ba139db Solution compounded for #202 — eslint-plugin-jsdoc-esm7-schema-incompatibility
a768502b eslint-plugin-jsdoc added as devDependency with jsdoclint CI job, closes #202
ba7ea150 ops-triage agent and Bug Triage stage added to fix/hotfix/build
c491e19c scipy/numpy refVals added to 8 core discrete distributions, closes #134
51e40842 Solution compounded for #132 — bounded-circular-special-shape-refvals-scipy-numpy
944cfeba scipy/R refVals added to 10 bounded, circular, and special-shape distributions, closes #132
ab7a579b Catastrophic cancellation in Rice._cdf fixed, closes #246
ebc67b89 Solution compounded for #245 — noncentral-chi2-cdf-complementary-marcum-q
a5f4628b Catastrophic cancellation in NoncentralChi2._cdf fixed, closes #245
3d220d1a Catastrophic cancellation in InverseGamma._cdf fixed, closes #244
29590a20 ci: disable Coveralls coverage-decrease failure on main
3cbaa146 Solution compounded for #243 — inverse-chi2-cdf-complementary-gamma
67de33ff Catastrophic cancellation in InverseChi2._cdf fixed, closes #243
f22c73ad fix: guard LogisticExponential._cdf against NaN for large x
80dd0b09 fix: eliminate catastrophic cancellation in _cdf for 13 distributions
f14096eb todo.md: add 14 missing distributions, besselK gap, multivariate note
444b8bad todo.md: rank distributions by breadth of use, fix section misclassifications
a91e442b todo.md: fix partial-implementation labels and add missing refs/refVals
fa044af3 Add todo.md: structured backlog from raw todo file
545261a0 NaN at x=0 in DoublyNoncentralT._pdf fixed, closes #229
d5a5c61f Add MCP fallback to ops-issue agent and require bug issue on fix/hotfix/build
c5c9ff77 NaN at x=0 in NoncentralBeta.{pdf,cdf} fixed, closes #230
229a5319 Solution compounded for #133 — noncentral-refvals-doubly-poisson-mixture-scaling
db7341aa scipy/R refVals added to 7 noncentral distributions, closes #133
a764cbc0 NaN at x=0 in NoncentralF.{pdf,cdf} fixed, closes #233
e7582b66 Allow edits to .claude/tmp without approval prompts
cd1cebf0 Solution compounded for #130 — fisher-z-double-halving-subclass-delegation
d00bd597 scipy refVals added to 12 remaining distributions, FisherZ constructor d.o.f. halving fixed, closes #130
efec9c7d InvertedWeibull refVals added including x=0 boundary point
ae132283 NaN at x=0 in InvertedWeibull._pdf fixed
f4e370c1 Checkout-main reset removed from session-start hook
b38c67ba Solution compounded for #129 — scipy-fisk-equivalence-muth-makeham-gammagompertz-numpy-verification
2a18ef57 test: add refVals for 9 Weibull/survival-model family distributions (#129)
538e31ac Solution compounded for #128 — scipy-burr-type-confusion-gev-sign-dagum-identity
da5c350d Near-boundary refVal points added to Burr, Dagum, Frechet
1b2b0fbe scipy refVals added to 9 extreme-value and heavy-tail distributions, closes #128
b560cac4 Build skill stage 6 made explicit about no-pause before push and PR
0ac49eca Stop hook with pipeline dir exclusions installed via session-start
cc61aeb1 Solution compounded for #127 — scipy-parameterization-mismatches-truncatednormal-rice
dbce779a scipy refVals added to 9 normal and logistic variant distributions, closes #127
13a2644f Zero-boundary refVal entries added to 7 half-line distributions
9451686a refVals expanded to 9 entries per distribution, tails and boundaries added
27e81433 scipy refVals added to 10 distributions, MaxwellBoltzmann constructor fixed, closes #126
c5827978 Inch CI docs badge replaced with GitHub Actions badge
503e7d1f erf/erfc hybrid Taylor/Laplace-CF implemented, closes #211
b453bfac Add publication-grade gap tracking to todo
4a8b860f Expand refVals to 8-10 points with boundary and tail coverage
1178b505 Solution compounded for #125 — closed-form-refvals-without-scipy
32774942 Reference values added for 12 core continuous distributions
040eb165 NegativeBinomial p-inversion callout added to porting guide
d9fac99a scipy.stats porting guide added to docs site
3bc808b6 Solution compounded for #109 — node-esm-subpath-exports-require-prebuilt-bundles
ba033ec7 Subpath regex hardened, sync-check script and README example added
850754df Add per-distribution subpath exports (#109)
87bfc058 ci: only upload coverage to Coveralls on main branch pushes
9aa882ed refactor(test): simplify and restructure distribution test architecture
33ee8924 Solution compounded for #50 — validate-rejects-missing-params
f0fc4504 Default parameter values removed from distribution constructors
a84c48eb Solution compounded for #196 — delaporte-poisson-compound-chi2
811e8ca6 [1.24.6] changelog section demoted back to [Unreleased]
f5cc88fc Solution compounded for #195 — skewnormal-box-muller-branch-waste
b980928c SkewNormal sampler PRNG consumption halved via both Box-Muller branches
331d4aea Chi-squared df corrected for alias-table sampler tests
1f64db49 Solution compounded for #193 — gamma-sampler-boundary-α=1
fe280100 Gamma sampler boundary fixed at shape α = 1
e4f0b5dc Sampling assertions strengthened with 3 fixed seeds
c35411f9 Solution compounded for #167 — docs-pages-deploy-artifact-action
f4377a8f Docs publishing moved to GitHub Actions
3df8b882 CONTRIBUTING.md and GitHub issue/PR templates added
1d589349 Automated npm publish workflow added on git tag
e04c7c73 docs-build job added to CI
6420bfd5 Matrix removed from lint job; Standard.js is Node-version-agnostic
28dd2f7f CI Node.js matrix expanded to 18, 20, and 22
d9173a28 Cache node_modules in CI keyed on package-lock.json hash
dc349635 Set fail-on-error: false on Coveralls upload step
386ae5ff Add check-decl script to catch missing/stale .d.ts declarations
ffde0786 Add typecheck job to CI; gate build on it
f3a467c5 Fix coin() overloads: split into scalar and array-returning forms
145f38e5 Add TypeScript type declarations for all public API (closes #108)
9fc69d70 Reference-value fixture helper and test runner wired in
4daa8e9b Solution compounded for #116 — docs-pages-array-build
0a0ebeee Docs build refactored around pages array with shared layout and external stylesheet
0999c13b Coverage folded into test job, separate coverage job removed
a60f9e11 Revert "Coverage job and Coveralls badge removed"
50255858 Coverage job and Coveralls badge removed
9e6b5b81 github-token added to Coveralls action to override stale CircleCI association
635037ca Coverage badge wired to Coveralls, orphan SVG generator removed
bf53e04d f11 asymptotic series truncated at minimum term to avoid diverging tail
7ba1ec26 Build job gated on lint and test passing
e80fd60f Generic CI badge removed in favour of scoped build badge
7707d37f Build job added to CI and build badge wired to README
966d3aff Solution compounded for #117 — badge-maker-svg-delegation
b46e9862 Badge generation delegated to badge-maker, CircleCI config removed
4eb8138b CodeScene badge and VS Code integration removed
4a537cdb CircleCI badge replaced with GitHub Actions badge
44c8613a NegativeBinomial parameter validation documented in changelog
cab191ad Solution compounded for #104 — galois-inequality-ulp-guard
fbc95d86 Math.random() removed from deterministic test helpers
dfb5ecf2 Solution compounded for #139 — ridders-error-estimate-kink-detection
2f2775f6 Ridders error estimate used to skip kink-crossing test points in cdf2pdf
28f1b160 fix(ci): explicit _mocha path and git push target in coverage job
63483448 Kink detection and relative tolerance added to cdf2pdf test
6a8229b9 CHANGELOG update added as mandatory step in /implement skill
55d07aed CHANGELOG update added as mandatory step in /implement skill
7811b665 Solution compounded for #137 — fisher-z-pdf-log-space-overflow
e47cab65 FisherZ pdf Infinity at large x fixed
53d42a45 NegativeBinomial p range restored to closed [0, 1]; fixture corrected
f5b8e1fe Solution compounded for #138 — negative-binomial-p-strict-bounds
4962b51e NegativeBinomial p constraint tightened to open interval (0, 1)
e81a68ca DoublyNoncentralT pdf NaN at mu=0 fixed
cdae4e9f Add missing rollup-linux-x64-musl lockfile entry
9c860aab Replace trials() with seeded deterministic sampling tests (#102)
ab96891f Dead smoke test removed
2a1d648c dist/ removed from git tracking; files field and prepublishOnly added
f882b54d Rollup 4 upgrade with ESM/CJS dual output and package exports field added
aa0a1f8c test(dist-cases): document why TruncatedNormal mu sits inside [a, b]
4c60bc4c Random test parameters in dist-cases.js replaced with fixed mid-range values
a33ec1b4 fix(session-start): force-create local main from origin/main
a21e2f9e Switch master to main and add session-start hook
dbe170ba ci: retarget workflows from master to main
253193f5 Kolmogorov boundary fixed: support corrected to open, cdf guarded at x <= 0
80fd14bf Solution compounded for #99 — esm-shim-node20-breakage
630d6510 esm replaced with @babel/register for Node 20+ compatibility
142e623e chore: ignore thoughts/ directory
d719b9bb Batched release model and per-PR changelog rule documented
2a55ad09 Versioning and changelog convention added to CLAUDE.md
86c0f73c Claude tmp directory added to gitignore
7499535a Audit vulnerabilities fixed and dead dependencies removed
b491ea41 Todos updated
1f9bc809 :arrow_up: Bump minimatch and mocha
eac08792 :arrow_up: Bump tar and npm
72dd7462 :arrow_up: Bump @tootallnate/once and npm
4e5472af Replace node-sass with sass and fix lint errors
1e740be9 Fix CI workflow branch name: main -> master
3d048e68 Add GitHub Actions CI: lint, test, and coverage badge
91068378 Claude Code configuration ported and tailored from trading repo
c4c40ecc :arrow_up: Bump postcss from 8.3.11 to 8.5.14
d52cf0b4 :arrow_up: Bump @babel/plugin-transform-modules-systemjs
3e62e347 :arrow_up: Bump picomatch from 2.2.2 to 2.3.2
285f2082 :arrow_up: Bump lodash from 4.17.21 to 4.18.1
e659b35a :arrow_up: Bump handlebars from 4.7.7 to 4.7.9
fbfa13a5 :arrow_up: Bump flatted from 3.2.4 to 3.4.2
6866853f Some improvements added
d708f1d7 :arrow_up: Bump json-schema and jsprim
01a1c97b :arrow_up: Bump semver from 5.7.1 to 5.7.2
c31d464a CodeScene badge updated
367da9aa Docs improved for some methods
16d451d0 Vector tests simplified
cfe0dc89 Test scripts follow standard JS
ddd7e83e :arrow_up: Bump http-cache-semantics from 4.1.0 to 4.1.1
1443735b :arrow_up: Bump json5 from 1.0.1 to 1.0.2
2c1e7344 :arrow_up: Bump minimatch from 3.0.4 to 3.0.8
80544312 :arrow_up: Bump ansi-regex
090fb9bc :arrow_up: Bump json-schema and jsprim
65d15323 :arrow_up: Bump nanoid and mocha
4eb492e8 :arrow_up: Bump parse-url from 7.0.2 to 8.1.0
4d3e50b6 :arrow_up: Bump qs from 6.5.2 to 6.5.3
41355065 :arrow_up: Bump parse-path and documentation
b31b35a0 :arrow_up: Bump decode-uri-component from 0.2.0 to 0.2.2
fd58eb6c :arrow_up: Bump scss-tokenizer from 0.2.3 to 0.4.3

---
*Automated release PR — do not add commits to this branch.*

https://claude.ai/code/session_01NNVzrusD7ynZgfa1ZEP2wC