### PR TITLE
Add symmetry-property tests for 8 symmetric distributions

### DIFF
--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -49,10 +49,12 @@ export default [{
     [0, -1], [0, 0] // beta > 0
   ],
   cases: [{
-    params: () => [0, 2]
+    params: () => [0, 2],
+    symmetry: 0
   }, {
     name: 'shifted location',
     params: () => [3, 0.5],
+    symmetry: 3,
     refVals: [
       { x: 2.6, pdf: 0, cdf: 0 },
       { x: 2.8, pdf: 1.39341341869433, cdf: 0.141321954550238 },
@@ -600,10 +602,12 @@ export default [{
     [0, -1], [0, 0] // gamma > 0
   ],
   cases: [{
-    params: () => [0, 2]
+    params: () => [0, 2],
+    symmetry: 0
   }, {
     name: 'shifted location, small scale',
     params: () => [3, 0.5],
+    symmetry: 3,
     refVals: [
       { x: 0, pdf: 0.0172059397937184, cdf: 0.0525684567112534 },
       { x: 1.0, pdf: 0.0374482219039754, cdf: 0.0779791303773693 },
@@ -805,10 +809,12 @@ export default [{
     [1, -1], [1, 0] // beta > 0
   ],
   cases: [{
-    params: () => [2, 2]
+    params: () => [2, 2],
+    symmetry: 0
   }, {
     name: 'near-zero alpha',
     params: () => [0.5, 2],
+    symmetry: 0,
     refVals: [
       { x: -3.0, pdf: 0.00057092958335171, cdf: 0.000266002752569605 },
       { x: -1.0, pdf: 0.0539909665131881, cdf: 0.0227501319481793 },
@@ -849,10 +855,12 @@ export default [{
     [1, -1], [1, 0] // k > 0
   ],
   cases: [{
-    params: () => [2, 2]
+    params: () => [2, 2],
+    symmetry: 0
   }, {
     name: 'near-zero k',
     params: () => [2, 0.5],
+    symmetry: 0,
     refVals: [
       { x: -4.0, pdf: 0.0214886864422952, cdf: 0.121558367217107 },
       { x: -2.0, pdf: 0.0459849301464303, cdf: 0.183939720585721 },
@@ -2789,10 +2797,12 @@ export default [{
     [0, -1], [0, 0] // s > 0
   ],
   cases: [{
-    params: () => [0, 2]
+    params: () => [0, 2],
+    symmetry: 0
   }, {
     name: 'shifted location, small scale',
     params: () => [3, 0.5],
+    symmetry: 3,
     refVals: [
       { x: 0, pdf: 0.00493301858272009, cdf: 0.00247262315663477 },
       { x: 1.0, pdf: 0.0353254124265822, cdf: 0.0179862099620916 },
@@ -3491,10 +3501,12 @@ export default [{
     [0, -1], [0, 0] // sigma > 0
   ],
   cases: [{
-    params: () => [0, 2]
+    params: () => [0, 2],
+    symmetry: 0
   }, {
     name: 'shifted location, small sigma',
     params: () => [3, 0.5],
+    symmetry: 3,
     refVals: [
       { x: 1.5, pdf: 0.00886369682387602, cdf: 0.00134989803163009 },
       { x: 2.0, pdf: 0.107981933026376, cdf: 0.0227501319481792 },
@@ -3721,10 +3733,12 @@ export default [{
   cases: [{
     // c=4 instead of 2 — at c=2 the sample distribution is too uniform-shaped
     // for the foreign-rejection test (vs Uniform) to reject reliably
-    params: () => [4]
+    params: () => [4],
+    symmetry: 0
   }, {
     name: 'near-zero c (U-shaped)',
     params: () => [0.5],
+    symmetry: 0,
     refVals: [
       { x: -0.9, pdf: 0.66261701448848, cdf: 0.257004951825697 },
       { x: -0.5, pdf: 0.236609314080785, cdf: 0.397756778317356 },
@@ -4083,10 +4097,12 @@ export default [{
     [-1], [0] // nu > 0
   ],
   cases: [{
-    params: () => [2]
+    params: () => [2],
+    symmetry: 0
   }, {
     name: 'near-zero nu (heavy tail)',
     params: () => [0.5],
+    symmetry: 0,
     refVals: [
       { x: -5.0, pdf: 0.0141307479465662, cdf: 0.142995701579429 },
       { x: -2.0, pdf: 0.0518992282473726, cdf: 0.222757445091566 },
@@ -4100,6 +4116,7 @@ export default [{
     // scipy.stats.t(df=5).ppf(p); acceptance criterion: q(0.975) ≈ 2.5706
     name: 'nu=5',
     params: () => [5],
+    symmetry: 0,
     quantileVals: [
       { p: 0.025, x: -2.5705818366147395 },
       { p: 0.5, x: 0.0 },

--- a/test/dist.js
+++ b/test/dist.js
@@ -105,7 +105,8 @@ const UnitTests = {
       name: c.name || 'random parameters',
       generate: () => new dist[tc.name](...c.params()),
       refVals: c.refVals,
-      quantileVals: c.quantileVals
+      quantileVals: c.quantileVals,
+      symmetry: c.symmetry
     }))
 
     cases.forEach(c => {
@@ -151,6 +152,12 @@ const UnitTests = {
         if (c.quantileVals) {
           it('quantile should match per-case reference values', () => {
             checkQuantileVals(c.generate(), c.quantileVals)
+          })
+        }
+
+        if (c.symmetry !== undefined) {
+          it('pdf and cdf should be symmetric around the center', () => {
+            Tests.symmetry(c.generate(), c.symmetry)
           })
         }
       })

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -455,5 +455,21 @@ export const Tests = {
           `|cdf(q(${p}); ${getParamList(dist)}) - ${p}| = ${Math.abs(c - p)} >= 1e-6`)
       }
     }
+  },
+
+  symmetry (dist, center) {
+    const supp = dist.support()
+    const lo = Number.isFinite(supp[0].value) ? supp[0].value : -Infinity
+    const hi = Number.isFinite(supp[1].value) ? supp[1].value : Infinity
+    const hw = Math.min(Math.min(hi - center, center - lo) * 0.9, 10)
+    for (const f of [0.1, 0.3, 0.5, 0.7, 0.9]) {
+      const x = f * hw
+      const pdfPlus = dist.pdf(center + x)
+      const pdfMinus = dist.pdf(center - x)
+      assert(almostEqual(pdfPlus, pdfMinus), `pdf(${center}+${x}) = ${pdfPlus} != pdf(${center}-${x}) = ${pdfMinus}`)
+      const cdfPlus = dist.cdf(center + x)
+      const cdfMinus = dist.cdf(center - x)
+      assert(almostEqual(cdfPlus + cdfMinus, 1), `cdf(${center}+${x}) + cdf(${center}-${x}) = ${cdfPlus + cdfMinus} != 1`)
+    }
   }
 }


### PR DESCRIPTION
Closes #394

## Summary
- Adds `Tests.symmetry(dist, center)` helper to `test/test-utils.js` that asserts `pdf(center+x) === pdf(center-x)` and `cdf(center+x) + cdf(center-x) === 1` across 5 support-adaptive probe points
- Wires the helper into all 8 required distributions: `Normal`, `StudentT`, `Logistic`, `Cauchy`, `DoubleGamma`, `DoubleWeibull`, `Anglit`, `R`
- Adds 17 new passing test assertions (2 cases × 6 distributions + 3 cases × 1 distribution + 2 cases × 1 distribution)

## Non-trivial changes
- **`test/test-utils.js`**: New `Tests.symmetry` helper. The probe half-width is computed as `min(0.9 × min(hi−center, center−lo), 10)` so the helper works correctly for both bounded-support distributions (Anglit, R) and unbounded ones (Normal, Cauchy, etc.) without needing per-distribution configuration.
- **`test/dist.js`**: `symmetry` property threaded through the `analytical()` case mapper and a new conditional `it` block added to invoke `Tests.symmetry` when present.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: `symmetry: <center>` metadata field added to each case object for the 8 affected distributions (17 case objects total). The center value is the location parameter for location-family distributions, and `0` for distributions always symmetric around the origin.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5AABGTXrfYiWR4J5WWik7)_