### PR TITLE
Enforce constructor JSDoc on distributions via jsdoclint

### DIFF
--- a/.eslintrc.jsdoc.js
+++ b/.eslintrc.jsdoc.js
@@ -17,7 +17,10 @@ module.exports = {
       // default preference for @function so existing docs tags aren't treated as violations.
       tagNamePreference: {
         // @method is used for documentation.js compatibility; keep it as-is.
-        method: 'method'
+        method: 'method',
+        // @constructor is used in all distribution class JSDoc blocks; keep it as-is.
+        // 'tag constructor' prefix avoids Object.prototype.constructor key conflict (eslint#13289).
+        'tag constructor': 'constructor'
       }
     }
   },
@@ -48,5 +51,31 @@ module.exports = {
     }],
     'jsdoc/require-param': 'error',
     'jsdoc/require-returns': 'error'
-  }
+  },
+  // Require JSDoc on distribution constructors — each constructor must carry @param tags so
+  // tsc can generate typed constructor signatures from JSDoc annotations.
+  overrides: [
+    {
+      files: ['src/dist/[!_]*.js'],
+      excludedFiles: ['src/dist/index.js'],
+      rules: {
+        'jsdoc/require-jsdoc': ['error', {
+          require: {
+            FunctionDeclaration: false,
+            MethodDefinition: false,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false
+          },
+          contexts: [
+            'ExportDefaultDeclaration > FunctionDeclaration',
+            'ExportNamedDeclaration > FunctionDeclaration',
+            'ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > ArrowFunctionExpression',
+            'MethodDefinition:not([key.name=/^_/]):not([kind=constructor])',
+            'MethodDefinition[kind=constructor]'
+          ],
+          checkConstructors: true
+        }]
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -448,7 +448,7 @@
   ],
   "scripts": {
     "lint": "./node_modules/.bin/standard src/**/*.js test/*.js",
-    "jsdoclint": "./node_modules/.bin/eslint --no-eslintrc --config .eslintrc.jsdoc.js src/dist/_distribution.js src/core/index.js src/location src/dispersion src/shape src/dependence src/test",
+    "jsdoclint": "./node_modules/.bin/eslint --no-eslintrc --config .eslintrc.jsdoc.js src/dist/_distribution.js 'src/dist/[!_]*.js' src/core/index.js src/location src/dispersion src/shape src/dependence src/test",
     "standard": "./node_modules/.bin/standard --fix src/**/*.js test/*.js",
     "test": "./node_modules/.bin/_mocha --require @babel/register",
     "docs": "node ./docs/index.js",

--- a/src/dist/beta-geometric.js
+++ b/src/dist/beta-geometric.js
@@ -17,6 +17,10 @@ import rBeta from './_beta'
  * @constructor
  */
 export default class extends PreComputed {
+  /**
+   * @param {number} alpha First shape parameter.
+   * @param {number} beta Second shape parameter.
+   */
   constructor (alpha, beta) {
     // TODO Use log PDF
     super()

--- a/src/dist/beta-negative-binomial.js
+++ b/src/dist/beta-negative-binomial.js
@@ -6,6 +6,11 @@ import gamma from './_gamma'
 import poisson from './_poisson'
 
 export default class extends PreComputed {
+  /**
+   * @param {number} r Number of successes (rounded to nearest integer).
+   * @param {number} alpha First shape parameter.
+   * @param {number} beta Second shape parameter.
+   */
   constructor (r, alpha, beta) {
     super()
     this.k = 3

--- a/src/dist/davis.js
+++ b/src/dist/davis.js
@@ -3,6 +3,11 @@ import Distribution from './_distribution'
 import { romberg } from '../algorithms'
 
 export default class Davis extends Distribution {
+  /**
+   * @param {number} mu Location parameter.
+   * @param {number} b Scale parameter.
+   * @param {number} n Shape parameter. Must not equal 1.
+   */
   constructor (mu, b, n) {
     super('continuous', 3)
 

--- a/src/dist/generalized-hermite.js
+++ b/src/dist/generalized-hermite.js
@@ -20,7 +20,7 @@ import PreComputed from './_pre-computed'
 export default class GeneralizedHermite extends PreComputed {
   /**
    * @param {number} a1 Mean of the first Poisson component.
-   * @param {number} am Mean of the second Poisson component.
+   * @param {number} a2 Mean of the second Poisson component.
    * @param {number} m Multiplier of the second Poisson. If not an integer, it is rounded to the nearest one.
    */
   constructor (a1, a2, m) {

--- a/src/dist/gilbrat.js
+++ b/src/dist/gilbrat.js
@@ -13,6 +13,7 @@ import LogNormal from './log-normal'
  */
 export default class Gilbrat extends LogNormal {
   // Special case of log-normal
+  /** */
   constructor () {
     super(0, 1)
   }

--- a/src/dist/gompertz.js
+++ b/src/dist/gompertz.js
@@ -14,7 +14,7 @@ import Distribution from './_distribution'
 export default class Gompertz extends Distribution {
   /**
    * @param {number} eta Shape parameter.
-   * @param {number} beta Scale parameter.
+   * @param {number} b Scale parameter.
    */
   constructor (eta, b) {
     super('continuous', 2)

--- a/src/dist/half-logistic.js
+++ b/src/dist/half-logistic.js
@@ -12,6 +12,7 @@ import Distribution from './_distribution'
  * @constructor
  */
 export default class HalfLogistic extends Distribution {
+  /** */
   constructor () {
     super('continuous', 0)
 

--- a/src/dist/hyperbolic-secant.js
+++ b/src/dist/hyperbolic-secant.js
@@ -12,6 +12,7 @@ import Distribution from './_distribution'
  * @constructor
  */
 export default class HyperbolicSecant extends Distribution {
+  /** */
   constructor () {
     super('continuous', 0)
     this.s = [{

--- a/src/dist/kolmogorov.js
+++ b/src/dist/kolmogorov.js
@@ -13,6 +13,7 @@ import { EPS, MAX_ITER } from '../core/constants'
  * @constructor
  */
 export default class Kolmogorov extends Distribution {
+  /** */
   constructor () {
     super('continuous', 0)
 

--- a/src/dist/kumaraswamy.js
+++ b/src/dist/kumaraswamy.js
@@ -14,8 +14,8 @@ import Distribution from './_distribution'
  */
 export default class Kumaraswamy extends Distribution {
   /**
-   * @param {number} alpha First shape parameter.
-   * @param {number} beta Second shape parameter.
+   * @param {number} a First shape parameter.
+   * @param {number} b Second shape parameter.
    */
   constructor (a, b) {
     super('continuous', 2)

--- a/src/dist/noncentral-t.js
+++ b/src/dist/noncentral-t.js
@@ -18,6 +18,10 @@ import Distribution from './_distribution'
  * @constructor
  */
 class NoncentralT extends Distribution {
+  /**
+   * @param {number} nu Degrees of freedom. If not an integer, it is rounded to the nearest one.
+   * @param {number} mu Non-centrality parameter.
+   */
   constructor (nu, mu) {
     super('continuous', 2)
 

--- a/src/dist/rademacher.js
+++ b/src/dist/rademacher.js
@@ -13,6 +13,7 @@ import Categorical from './categorical'
  */
 export default class Rademacher extends Categorical {
   // Special case of categorical
+  /** */
   constructor () {
     super([0.5, 0, 0.5], -1)
   }

--- a/src/dist/slash.js
+++ b/src/dist/slash.js
@@ -13,6 +13,7 @@ import Normal from './normal'
  * @constructor
  */
 export default class Slash extends Normal {
+  /** */
   constructor () {
     super(0, 1)
     this.s = [{

--- a/src/dist/uniform-ratio.js
+++ b/src/dist/uniform-ratio.js
@@ -13,6 +13,7 @@ import Distribution from './_distribution'
  * @constructor
  */
 export default class UniformRatio extends Distribution {
+  /** */
   constructor () {
     super('continuous', 0)
 


### PR DESCRIPTION
Closes #395

## Summary
- Adds a `jsdoc/require-jsdoc` override in `.eslintrc.jsdoc.js` scoped to `src/dist/[!_]*.js` that requires a JSDoc block on every distribution constructor, so missing constructor docs fail `npm run jsdoclint` immediately rather than silently producing `any`-typed TypeScript declarations.
- Expands the `jsdoclint` script in `package.json` to lint all public distribution files (previously only `_distribution.js` was covered).
- Backfills constructor JSDoc on the 11 distributions that lacked it, and corrects three `@param` name mismatches that would have generated wrong TypeScript constructor signatures.

## Design decisions
- [ADR-0010: JSDoc-Driven TypeScript Declaration Generation](decisions/0010-jsdoc-driven-declaration-generation.md) — mandates constructor-level `@param` blocks; this PR activates the linter enforcement that ADR-0010 called out as a required follow-up.

## Non-trivial changes
- **`.eslintrc.jsdoc.js`**: The override uses `checkConstructors: true` alongside `MethodDefinition[kind=constructor]` in `contexts`. This is load-bearing: `eslint-plugin-jsdoc`'s internal `exemptSpeciaMethods` function silently suppresses constructor reporting when `checkConstructors` is falsy, even when the constructor appears in `contexts`. Setting it `true` disables the exemption. Also adds `'tag constructor': 'constructor'` to `tagNamePreference` using the `tag ` prefix workaround for the `Object.prototype.constructor` key conflict (eslint#13289).
- **`generalized-hermite.js`, `gompertz.js`, `kumaraswamy.js`**: Three pre-existing `@param` name mismatches corrected (`am`→`a2`, `beta`→`b`, `alpha`/`beta`→`a`/`b`). These were generating wrong TypeScript declarations — `tsc` reads `@param` names literally for declaration output.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`package.json`**: `jsdoclint` script extended with `'src/dist/[!_]*.js'` glob.
- **`beta-geometric.js`, `beta-negative-binomial.js`, `davis.js`, `noncentral-t.js`**: Constructor `@param` blocks added (these had no prior constructor-level JSDoc).
- **`gilbrat.js`, `half-logistic.js`, `hyperbolic-secant.js`, `kolmogorov.js`, `rademacher.js`, `slash.js`, `uniform-ratio.js`**: Empty `/** */` constructor JSDoc blocks added for zero-parameter constructors to satisfy the linter.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjTaYkFQaqzjq6TUfRSAB1)_