### PR TITLE
Add class name and JSDoc to BetaNegativeBinomial

### DIFF
--- a/src/dist/beta-negative-binomial.js
+++ b/src/dist/beta-negative-binomial.js
@@ -5,7 +5,18 @@ import rBeta from './_beta'
 import gamma from './_gamma'
 import poisson from './_poisson'
 
-export default class extends PreComputed {
+/**
+ * Generator for the [beta-negative-binomial distribution]{@link https://en.wikipedia.org/wiki/Beta_negative_binomial_distribution}:
+ *
+ * $f(k; r, \alpha, \beta) = \frac{\Gamma(r + k)}{\Gamma(k + 1)\,\Gamma(r)} \frac{\mathrm{B}(\alpha + r,\, \beta + k)}{\mathrm{B}(\alpha,\, \beta)},$
+ *
+ * with $r \in \mathbb{N}^+$ and $\alpha, \beta > 0$. Support: $k \in \mathbb{N}_0$.
+ *
+ * @class BetaNegativeBinomial
+ * @memberof ran.dist
+ * @constructor
+ */
+export default class BetaNegativeBinomial extends PreComputed {
   /**
    * @param {number} r Number of successes (rounded to nearest integer).
    * @param {number} alpha First shape parameter.


### PR DESCRIPTION
Closes #414

## Summary
- Changed anonymous `export default class extends PreComputed` to named `export default class BetaNegativeBinomial extends PreComputed`, satisfying the CLAUDE.md convention and enabling TypeScript declaration generation
- Added class-level JSDoc block with `@class BetaNegativeBinomial`, `@memberof ran.dist`, `@constructor`, PMF formula, parameter constraints, and support — following the pattern in `src/dist/generalized-hermite.js`

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/beta-negative-binomial.js`**: Class declaration named and class-level JSDoc block added; no logic changes

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_012i2oHtdBuz8UwuaYnrmpxB)_