### PR TITLE
Fix PreComputed._cdf cache-hit path returning values above 1

### DIFF
--- a/src/dist/_pre-computed.js
+++ b/src/dist/_pre-computed.js
@@ -130,7 +130,7 @@ export default class PreComputed extends Distribution {
   _cdf (x) {
     // If already in table, return value
     if (x < this.cdfTable.length) {
-      return this.cdfTable[x]
+      return Math.min(1, this.cdfTable[x])
     }
 
     // Otherwise, advance to current index and return F(x)

--- a/src/dist/conway-maxwell-poisson.js
+++ b/src/dist/conway-maxwell-poisson.js
@@ -60,15 +60,4 @@ export default class ConwayMaxwellPoisson extends PreComputed {
     }
     return this.pdfTable[k - 1] * this.p.lambda / Math.pow(k, this.p.nu)
   }
-
-  // The running-sum CDF can accumulate to 1 + 1 ULP due to floating-point rounding.
-  // Clamping here prevents the monotonicity invariant from being violated for large k.
-  // See solutions/correctness/2026-05-26-1210-precomputed-cdf-asymmetric-clamping.md
-  _cdf (x) {
-    if (x < this.cdfTable.length) {
-      return Math.min(1, this.cdfTable[x])
-    }
-    this._advance(x)
-    return Math.min(1, this.cdfTable[x])
-  }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -403,6 +403,19 @@ describe('dist', () => {
         preComputed._pk()
       }, 'PreComputed._pk() is not implemented')
     })
+
+    it('should clamp _cdf to 1 on cache-hit path when PMFs sum to 1+epsilon', () => {
+      // Subclass whose PMFs sum to slightly above 1 (simulating floating-point rounding)
+      class OverflowPMF extends PreComputed {
+        _pk () { return 0.5 + 1e-15 }
+      }
+      const d = new OverflowPMF()
+      // Warm up cache by accessing index 1 (fills cdfTable[0] and cdfTable[1])
+      d._cdf(1)
+      // cdfTable[0] = 0.5+eps, cdfTable[1] ≈ 1 + 2eps > 1; re-reading from cache must still return ≤ 1
+      assert.isAtMost(d._cdf(0), 1)
+      assert.isAtMost(d._cdf(1), 1)
+    })
   })
 
   // Ordinary distributions.


### PR DESCRIPTION
Closes #419

## Summary
- `PreComputed._cdf` had an asymmetric clamping bug: the freshly-computed branch applied `Math.min(1, ...)` but the cache-hit branch returned the raw stored value, which can exceed 1 by 1 ULP when PMFs accumulate to 1+ε due to floating-point rounding.
- Fixed by adding `Math.min(1, ...)` to the cache-hit branch, making both paths symmetric.
- `ConwayMaxwellPoisson._cdf` override was a workaround for this base-class bug — removed now that the base class is fixed.

## Non-trivial changes
- **`src/dist/_pre-computed.js`**: Cache-hit branch of `_cdf` now clamps to `Math.min(1, this.cdfTable[x])`, preventing CDF > 1 from being returned on repeated calls for the same index.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/conway-maxwell-poisson.js`**: Removed `_cdf` override — it duplicated the base-class fix that now lives in `PreComputed._cdf`.
- **`test/dist.js`**: Added regression test for cache-hit clamping using a synthetic `OverflowPMF` subclass whose PMFs deliberately sum to 1+ε.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFa8LqzyFQkPTiuWe9PTRe)_