### PR TITLE
Fix Pareto.fit() via closed-form MLE init and lnPdf support check

### DIFF
--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -633,7 +633,7 @@ class Distribution {
    *
    */
   lnPdf (x) {
-    return Math.log(this._pdf(x))
+    return Math.log(this.pdf(x))
   }
 
   /**
@@ -804,7 +804,9 @@ class Distribution {
     const best = nelderMead(
       params => {
         try {
-          return -new Cls(...params).lnL(data)
+          const v = -new Cls(...params).lnL(data)
+          // neumaier(-Infinity, ...) returns NaN; treat as invalid params
+          return isNaN(v) ? Infinity : v
         } catch (_) {
           return Infinity
         }

--- a/src/dist/pareto.js
+++ b/src/dist/pareto.js
@@ -53,4 +53,11 @@ export default class Pareto extends Distribution {
   _q (p) {
     return this.p.xmin / Math.pow(1 - p, 1 / this.p.alpha)
   }
+
+  static _fitInit (data) {
+    const xmin = Math.min(...data)
+    const n = data.length
+    const alpha = n / data.reduce((s, x) => s + Math.log(x / xmin), 0)
+    return [xmin, alpha]
+  }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -414,6 +414,20 @@ describe('dist', () => {
         const result = dist.Exponential.fit(data)
         assert(result instanceof dist.Exponential)
       })
+
+      it('Pareto.fit should recover xmin close to min(data)', () => {
+        const data = [1.5, 2.0, 3.1, 1.8, 2.5]
+        const result = dist.Pareto.fit(data)
+        assert(Math.abs(result.p.xmin - 1.5) < 1e-3)
+      })
+
+      it('Pareto.fit should recover alpha close to closed-form MLE', () => {
+        const data = [1.5, 2.0, 3.1, 1.8, 2.5]
+        const xmin = Math.min(...data)
+        const alphaExpected = data.length / data.reduce((s, x) => s + Math.log(x / xmin), 0)
+        const result = dist.Pareto.fit(data)
+        assert(Math.abs(result.p.alpha - alphaExpected) < 0.05)
+      })
     })
   })
 


### PR DESCRIPTION
Closes #423

## Summary
- `Pareto._fitInit(data)` added: seeds Nelder-Mead at the closed-form Pareto MLE (`xmin = min(data)`, `alpha = n / Σ log(xᵢ / xmin)`), replacing the random-retry base class default that couldn't find boundary-achieved MLEs
- `lnPdf(x)` fixed to call `this.pdf(x)` instead of `this._pdf(x)`: `pdf()` applies support bounds so out-of-support inputs return 0, making `lnPdf` correctly return `-Infinity` rather than a spuriously finite value that caused the optimizer to drift toward wrong parameters
- `fit()` NaN guard added: `neumaier([-Infinity, ...])` returns `NaN` (filed as #442); the guard converts `NaN` to `Infinity` so Nelder-Mead treats out-of-support parameter vectors as invalid

## Design decisions
- [ADR-0012: Distribution.fit() via Nelder-Mead MLE](decisions/0012-distribution-fit-nelder-mead.md) — establishes the `_fitInit` override hook that this PR exercises

## Non-trivial changes
- **`src/dist/_distribution.js:636`**: `lnPdf` behavioral change — before, `Math.log(_pdf(x))` returned a wrong finite value for `x` outside the support (e.g. `Pareto(1.575, 2.93).lnPdf(1.5) = 0.81`); after, `Math.log(pdf(x)) = Math.log(0) = -Infinity`. This makes `lnL(data)` correctly signal that parameter vectors placing data outside the support are invalid.
- **`src/dist/_distribution.js:807–809`**: NaN guard in `fit()` — without this, `neumaier([-Infinity,...]) = NaN` corrupts the Nelder-Mead simplex sort (NaN comparisons are undefined), causing the optimizer to diverge. Converts NaN to Infinity so the vertex is treated as worst in the simplex.
- **`src/dist/pareto.js:57–61`**: `Pareto._fitInit` — returns the closed-form Pareto MLE as the initial simplex center. Without this, the base-class random-retry default started at `[1, 1]`, which placed `xmin = 1 < min(data)` with no gradient signal toward the boundary MLE.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Two Pareto fit tests asserting `xmin` within `1e-3` of `min(data)` and `alpha` within `0.05` of the closed-form estimate

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtiq7RRvseoBsd4oDm8fDJ)_