### PR TITLE
Fix neumaier() NaN-on-infinity bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `neumaier()` now returns `±Infinity` (instead of `NaN`) when the input array contains `±Infinity`; fixes `lnL()`, `aic()`, and `bic()` silently returning `NaN` when any observation falls outside a distribution's support (#442)
+
 ### Added
 
 - `Distribution.fit(data)` static method for maximum-likelihood parameter estimation via Nelder-Mead simplex optimizer (#404)

--- a/src/algorithms/neumaier.js
+++ b/src/algorithms/neumaier.js
@@ -18,10 +18,13 @@ export default function (arr) {
   // Start summation.
   for (let i = 1; i < sorted.length; i++) {
     const t = s + sorted[i]
-    if (Math.abs(s) > Math.abs(sorted[i])) {
-      c += (s - t) + sorted[i]
-    } else {
-      c += (sorted[i] - t) + s
+    // Skip compensation when either operand is infinite: (±Inf - ±Inf) = NaN.
+    if (isFinite(s) && isFinite(t)) {
+      if (Math.abs(s) > Math.abs(sorted[i])) {
+        c += (s - t) + sorted[i]
+      } else {
+        c += (sorted[i] - t) + s
+      }
     }
     s = t
   }

--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -120,6 +120,18 @@ describe('algorithms', () => {
       assert.equal(algorithms.neumaier(arr), 6)
       assert.deepEqual(arr, [3, 1, 2])
     })
+
+    it('should return -Infinity when input contains -Infinity', () => {
+      assert.equal(algorithms.neumaier([-Infinity, 1, 2, 3]), -Infinity)
+    })
+
+    it('should return Infinity when input contains Infinity', () => {
+      assert.equal(algorithms.neumaier([Infinity, 1, 2, 3]), Infinity)
+    })
+
+    it('should return NaN for indeterminate -Infinity + Infinity', () => {
+      assert(Number.isNaN(algorithms.neumaier([-Infinity, Infinity])))
+    })
   })
 
   describe('romberg()', () => {


### PR DESCRIPTION
Closes #442

## Summary
- `neumaier()` returned `NaN` when the input contained `±Infinity` because the compensation step computed `±Infinity - ±Infinity = NaN` and poisoned the accumulator `c`
- Fixed by skipping the compensation update when either the running sum `s` or the new partial sum `t` is not finite — arithmetic on infinite values is exact and needs no error correction
- This restores correct `lnL()`, `aic()`, and `bic()` behaviour when any observation falls outside a distribution's support

## Non-trivial changes
- **`src/algorithms/neumaier.js:21-28`**: Added `isFinite(s) && isFinite(t)` guard around the compensation branch. When either operand is infinite, `Inf - Inf` is indeterminate; skipping compensation lets IEEE 754 infinity arithmetic propagate correctly without NaN contamination.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/algorithms.js`**: Three new regression tests for `-Infinity`, `+Infinity`, and indeterminate `±Infinity` inputs
- **`CHANGELOG.md`**: Bug fix entry added to `[Unreleased]`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_011pzdxJ2XGf4rSGjgxdNNC4)_