### PR TITLE
Activate and export digamma special function

### DIFF
--- a/src/special/digamma.js
+++ b/src/special/digamma.js
@@ -1,14 +1,14 @@
-/* const coeffs = [
+const coeffs = [
   1 / 12,
   1 / 120,
   1 / 252,
   1 / 240,
   1 / 132,
-  1 / 12
-] */
+  691 / 32760
+]
 
 /**
- * Evaluates the digamma function using the series expanson.
+ * Evaluates the digamma function using the Stirling series expansion.
  *
  * @method _psiSeries
  * @memberof ran.special
@@ -16,17 +16,17 @@
  * @returns {number} The estimated value.
  * @private
  */
-/* function _psiSeries (z) {
-  let z2 = z * z
+function _psiSeries (z) {
+  const z2 = z * z
   let s = 0
   for (let i = coeffs.length - 1; i >= 0; i--) {
     s = (coeffs[i] - s) / z2
   }
   return Math.log(z) - 0.5 / z - s
-} */
+}
 
 /**
- * Computes the digamma function for arbitrary arguments.
+ * Computes the digamma function ψ(z) = d/dz ln Γ(z) for arbitrary arguments.
  * Source: https://www.jstor.org/stable/2347257
  *
  * @method digamma
@@ -35,10 +35,10 @@
  * @returns {number} The digamma function at the specified value.
  * @private
  */
-/* function _digamma (z) {
+function digamma (z) {
   // Reflection for z < 0
   if (z < 0) {
-    return _digamma(1 - z) - Math.PI / Math.tan(Math.PI * z)
+    return digamma(1 - z) - Math.PI / Math.tan(Math.PI * z)
   }
 
   // Shift z
@@ -50,4 +50,4 @@
   return _psiSeries(z) + s
 }
 
-export default _digamma */
+export default digamma

--- a/src/special/index.js
+++ b/src/special/index.js
@@ -8,6 +8,7 @@
 export { besselI, besselInu, besselISpherical } from './bessel'
 export { default as beta } from './beta'
 export { betaIncomplete, regularizedBetaIncomplete } from './beta-incomplete'
+export { default as digamma } from './digamma'
 export { erf, erfc, erfinv } from './error'
 export { default as gamma } from './gamma'
 export { gammaLowerIncomplete, gammaUpperIncomplete, gammaLowerIncompleteInv } from './gamma-incomplete'

--- a/test/special.js
+++ b/test/special.js
@@ -6,6 +6,34 @@ import * as special from '../src/special/index.js'
 const LAPS = 100
 
 describe('special', () => {
+  const EM = 0.5772156649015329
+
+  describe('digamma(z)', () => {
+    it('should return reference values', () => {
+      assert(equal(special.digamma(1), -EM))
+      assert(equal(special.digamma(2), 1 - EM))
+      assert(equal(special.digamma(0.5), -EM - 2 * Math.log(2)))
+      assert(equal(special.digamma(0.25), -Math.PI / 2 - 3 * Math.log(2) - EM))
+      // z >= 10: direct Stirling path
+      assert(equal(special.digamma(10), 2.251752589066721))
+    })
+
+    it('should return reference values for negative non-integer arguments', () => {
+      // Exercises the reflection formula: ψ(z) = ψ(1-z) - π·cot(πz)
+      // ψ(-0.5) = ψ(1.5) = ψ(0.5) + 2 = 2 - EM - 2·ln2
+      assert(equal(special.digamma(-0.5), 2 - EM - 2 * Math.log(2)))
+      // ψ(-1.5) = ψ(2.5) = ψ(1.5) + 2/3
+      assert(equal(special.digamma(-1.5), 2 - EM - 2 * Math.log(2) + 2 / 3))
+    })
+
+    it('should satisfy the recurrence ψ(z+1) = ψ(z) + 1/z', () => {
+      repeat(() => {
+        const z = Math.random() * 100 + 0.1
+        assert(equal(special.digamma(z + 1), special.digamma(z) + 1 / z))
+      }, LAPS)
+    })
+  })
+
   /*
   describe('digamma(z)', () => {
     it('should return reference values', () => {


### PR DESCRIPTION
Closes #399

## Summary
- Uncomments the pre-written digamma (ψ) implementation in `src/special/digamma.js` and exports it as `ran.special.digamma`
- Fixes the 6th Bernoulli series coefficient from `1/12` (copy-paste bug in the original draft) to the correct value `691/32760`
- Adds tests covering reference values across all three code paths: shift-accumulation, direct Stirling series (z ≥ 10), and reflection formula (z < 0)

## Non-trivial changes
- **`src/special/digamma.js`**: New public special function. The implementation uses Bernardo (1976) AS 103: upward argument shifting to z ≥ 10, then Horner-evaluated Stirling asymptotic series, with the reflection identity `ψ(z) = ψ(1−z) − π·cot(πz)` for negative arguments. The 6th coefficient was corrected from `1/12` to `691/32760 = |B₁₂|/12`.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/special/index.js`**: One-line export added in alphabetical order.
- **`test/special.js`**: Test block added for the new function.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFCSF8Ng1jHQdrHEuBUWjD)_