### PR TITLE
Add class-level JSDoc block to Davis distribution

### DIFF
--- a/src/dist/davis.js
+++ b/src/dist/davis.js
@@ -2,6 +2,17 @@ import { riemannZeta, gamma } from '../special'
 import Distribution from './_distribution'
 import { romberg } from '../algorithms'
 
+/**
+ * Generator for the [Davis distribution]{@link https://en.wikipedia.org/wiki/Davis_distribution}:
+ *
+ * $f(x; \mu, b, n) = \frac{b^n (x - \mu)^{-1-n}}{\Gamma(n)\, \zeta(n)\, \left(e^{b/(x-\mu)} - 1\right)},$
+ *
+ * with $\mu > 0$, $b > 0$, and $n > 0, n \neq 1$. Support: $x \in (\mu, \infty)$.
+ *
+ * @class Davis
+ * @memberof ran.dist
+ * @constructor
+ */
 export default class Davis extends Distribution {
   /**
    * @param {number} mu Location parameter.


### PR DESCRIPTION
Closes #415

## Summary
- Added missing class-level JSDoc block (`@class`, `@memberof ran.dist`, `@constructor`) to `src/dist/davis.js` so Davis appears in the generated `ran.dist` namespace documentation and passes `jsdoclint` member checks.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/davis.js`**: Class-level JSDoc block added above the class declaration, matching the convention used by every other distribution in `src/dist/`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxRkJpNWNs5SX8uYCj1c2v)_