### PR TITLE
Add nyc coverage thresholds to npm test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `neumaier()` now returns `±Infinity` (instead of `NaN`) when the input array contains `±Infinity`; fixes `lnL()`, `aic()`, and `bic()` silently returning `NaN` when any observation falls outside a distribution's support (#442)
 
+### Changed
+
+- `npm test` now runs under nyc with coverage thresholds enforced (`branches ≥ 92%`, `lines ≥ 98%`, `functions = 100%`, `statements ≥ 98%`); the suite exits non-zero if coverage drops below these baselines (#400)
+
 ### Added
 
 - `Distribution.fit(data)` static method for maximum-likelihood parameter estimation via Nelder-Mead simplex optimizer (#404)

--- a/package.json
+++ b/package.json
@@ -459,7 +459,7 @@
     "lint": "./node_modules/.bin/standard src/**/*.js test/*.js",
     "jsdoclint": "./node_modules/.bin/eslint --no-eslintrc --config .eslintrc.jsdoc.js src/dist/_distribution.js 'src/dist/[!_]*.js' src/core/index.js src/location src/dispersion src/shape src/dependence src/test",
     "standard": "./node_modules/.bin/standard --fix src/**/*.js test/*.js",
-    "test": "./node_modules/.bin/_mocha --require @babel/register",
+    "test": "./node_modules/.bin/cross-env NODE_ENV=test ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --require @babel/register",
     "docs": "node ./docs/index.js",
     "build": "./node_modules/.bin/rollup -c && ./node_modules/.bin/tsc -p tsconfig.build.json",
     "typecheck": "./node_modules/.bin/tsc --noEmit",
@@ -531,6 +531,11 @@
     "instrument": false,
     "require": [
       "@babel/register"
-    ]
+    ],
+    "check-coverage": true,
+    "branches": 92,
+    "lines": 98,
+    "functions": 100,
+    "statements": 98
   }
 }


### PR DESCRIPTION
Closes #400

## Summary
- `npm test` now instruments code with nyc and enforces minimum coverage thresholds (branches ≥ 92%, lines ≥ 98%, functions = 100%, statements ≥ 98%), exiting non-zero if any metric falls below its baseline
- Thresholds were measured against the current test suite and set just below the observed baseline to serve as a regression tripwire without being brittle

## Non-trivial changes
- **`package.json`**: `test` script now wraps mocha with `cross-env NODE_ENV=test nyc`; `nyc` block gains `check-coverage: true` and four threshold fields. `npm test` will now fail if tests are deleted or distributions removed without keeping coverage above these baselines.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `### Changed` entry documenting the new coverage enforcement in `[Unreleased]`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaqQqAxcGVTQZUrqecHy3S)_