### PR TITLE
Add build artifact integrity check to CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,4 @@ jobs:
       - run: npm ci
         if: steps.node-cache.outputs.cache-hit != 'true'
       - run: npm run build
+      - run: test -f dist/ranjs.esm.js && test -f dist/ranjs.cjs.js && test -f dist/ranjs.min.js && test -f dist/index.d.ts


### PR DESCRIPTION
Closes #401

## Summary
- Adds a `test -f` shell check after `npm run build` in the CI `build` job to verify all four primary output bundles exist: `dist/ranjs.esm.js`, `dist/ranjs.cjs.js`, `dist/ranjs.min.js`, and `dist/index.d.ts`
- Mirrors the identical pattern already used in the `docs-build` job (line 101)
- Prevents silent Rollup or `tsc` configuration errors from producing a green CI build with missing artifacts

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`.github/workflows/ci.yml`**: One line added — `test -f` existence check for the four build artifacts, appended after `npm run build` in the `build` job.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbvuXnXFL94y6jmsE1BpM9)_