### PR TITLE
Remove blue highlight from parameter name column in docs tables

### DIFF
--- a/docs/styles/_table.scss
+++ b/docs/styles/_table.scss
@@ -39,12 +39,11 @@ td {
 
 // Parameter name lives in the first column. The generator marks it with
 // .param-name; the porting page uses plain td (first child). Both should
-// render as the small monospaced blue identifier.
+// render as the small monospaced identifier.
 .param-name,
 tbody td:first-child {
   font-family: 'IBM Plex Mono', ui-monospace, Menlo, Consolas, monospace;
   font-size: 13px;
-  color: $colorBlue;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
The .param-name / tbody td:first-child rule applied $colorBlue to the
first column, making parameter names stand out in the same hue as type
pills. The name column needs no special colour — monospace font already
distinguishes it visually.

https://claude.ai/code/session_01HLg479ZC3c1Tgx16tyknfr