### PR TITLE
Add Tests.symmetryDiscrete helper and wire into 4 symmetric discrete distributions

### DIFF
--- a/test/dist-cases-discrete.js
+++ b/test/dist-cases-discrete.js
@@ -86,7 +86,8 @@ export default [{
     [100, -1], [100, 2] // 0 <= p <= 1
   ],
   cases: [{
-    params: () => [25, 0.5]
+    params: () => [25, 0.5],
+    symmetryDiscrete: 12.5
   }, {
     name: 'small n, low p',
     params: () => [10, 0.1],
@@ -362,10 +363,12 @@ export default [{
     params: s => [s.reduce((sum, d) => d + sum, 0) / s.length]
   },
   cases: [{
-    params: () => [5, 50]
+    params: () => [5, 50],
+    symmetryDiscrete: 27.5
   }, {
     name: 'small range',
     params: () => [0, 9],
+    symmetryDiscrete: 4.5,
     refVals: [
       { x: 0, pmf: 0.1, cdf: 0.1 },
       { x: 1.0, pmf: 0.1, cdf: 0.2 },
@@ -886,7 +889,8 @@ export default [{
   name: 'Rademacher',
   invalidParams: [],
   cases: [{
-    params: () => []
+    params: () => [],
+    symmetryDiscrete: 0
   }],
   // Rademacher: P(X=-1) = P(X=1) = 0.5
   refVals: [
@@ -911,7 +915,8 @@ export default [{
     [1, -1], [1, 0] // mu2 > 0
   ],
   cases: [{
-    params: () => [5, 5]
+    params: () => [5, 5],
+    symmetryDiscrete: 0
   }, {
     name: 'asymmetric rates',
     params: () => [1, 4],

--- a/test/dist.js
+++ b/test/dist.js
@@ -106,7 +106,8 @@ const UnitTests = {
       generate: () => new dist[tc.name](...c.params()),
       refVals: c.refVals,
       quantileVals: c.quantileVals,
-      symmetry: c.symmetry
+      symmetry: c.symmetry,
+      symmetryDiscrete: c.symmetryDiscrete
     }))
 
     cases.forEach(c => {
@@ -158,6 +159,12 @@ const UnitTests = {
         if (c.symmetry !== undefined) {
           it('pdf and cdf should be symmetric around the center', () => {
             Tests.symmetry(c.generate(), c.symmetry)
+          })
+        }
+
+        if (c.symmetryDiscrete !== undefined) {
+          it('pmf and cdf should be symmetric around the center (discrete)', () => {
+            Tests.symmetryDiscrete(c.generate(), c.symmetryDiscrete)
           })
         }
       })

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -471,5 +471,21 @@ export const Tests = {
       const cdfMinus = dist.cdf(center - x)
       assert(almostEqual(cdfPlus + cdfMinus, 1), `cdf(${center}+${x}) + cdf(${center}-${x}) = ${cdfPlus + cdfMinus} != 1`)
     }
+  },
+
+  // For discrete distributions: pmf(center+k) = pmf(center-k) and cdf(center+k) + cdf(center-k-1) = 1.
+  // Integer centers start at k=1 to avoid the trivial pmf(c)=pmf(c) at k=0.
+  // Half-integer centers (e.g. Binomial n/2 with odd n) use 0.5-spaced offsets so test points land on integers.
+  symmetryDiscrete (dist, center) {
+    const start = Number.isInteger(center) ? 1 : 0.5
+    for (let i = 0; i < 5; i++) {
+      const k = start + i
+      const pmfPlus = dist.pdf(center + k)
+      const pmfMinus = dist.pdf(center - k)
+      assert(almostEqual(pmfPlus, pmfMinus), `pmf(${center}+${k}) = ${pmfPlus} != pmf(${center}-${k}) = ${pmfMinus}`)
+      const cdfPlus = dist.cdf(center + k)
+      const cdfMinusLow = dist.cdf(center - k - 1)
+      assert(almostEqual(cdfPlus + cdfMinusLow, 1), `cdf(${center}+${k}) + cdf(${center}-${k}-1) = ${cdfPlus + cdfMinusLow} != 1`)
+    }
   }
 }


### PR DESCRIPTION
Closes #412

## Summary
- Adds `Tests.symmetryDiscrete(dist, center)` to `test/test-utils.js` — checks `pmf(c+k) = pmf(c-k)` and `cdf(c+k) + cdf(c-k-1) = 1` for 5 offsets, handling both integer centers (start k=1) and half-integer centers (start k=0.5, so test points land on integers).
- Wires the helper into `Binomial(25, 0.5)`, `DiscreteUniform` (both cases), `Rademacher`, and `Skellam(5, 5)`.
- `HeadsMinusTails` was intentionally omitted: the ranjs implementation is the **folded** |H−T| variant on [0, 2n], which is not symmetric around 0. A separate issue (#459) tracks changing it to the signed variant.

## Non-trivial changes
- **`test/test-utils.js`**: The CDF identity used is `cdf(c+k) + cdf(c-k-1) = 1` (i.e. `P(X ≤ c+k) = P(X ≥ c-k) = 1 − P(X ≤ c-k-1)`). The issue stated `cdf(c+k) + sf(c-k+1) = 1` — these are mathematically equivalent given the library's `survival(x) = 1 − cdf(x)`, but the form used here is more direct. Integer centers start the loop at k=1 to avoid the trivially-true `pmf(c) = pmf(c)` assertion at k=0.
- **`test/dist-cases-discrete.js`**: `HeadsMinusTails` is absent despite being listed in the issue — see Summary above.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: `symmetryDiscrete` forwarded through the `cases.map()` object and wired with an `if` block matching the existing `symmetry` pattern.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_014NYtZLKhnqz9KLoye1JauU)_