### PR TITLE
Fix IrwinHall and Bates to use named-object this.c

### DIFF
--- a/src/dist/bates.js
+++ b/src/dist/bates.js
@@ -40,23 +40,25 @@ export default class Bates extends IrwinHall {
       closed: true
     }]
 
-    // Extend speed-up constants. Note that c in IrwinHall has a length of n + 1
-    this.c = this.c.concat([
-      n / (b - a),
-      n * a / (b - a)
-    ])
+    // Extend speed-up constants with Bates affine transform coefficients
+    Object.assign(this.c, {
+      scale: n / (b - a),
+      shift: n * a / (b - a)
+    })
   }
 
   _generator () {
     // Direct sampling by transforming Irwin-Hall variate
-    return super._generator() / this.c[this.p.n + 1] + this.p.a
+    return super._generator() / this.c.scale + this.p.a
   }
 
   _pdf (x) {
-    return this.c[this.p.n + 1] * super._pdf(this.c[this.p.n + 1] * x - this.c[this.p.n + 2])
+    const { scale, shift } = this.c
+    return scale * super._pdf(scale * x - shift)
   }
 
   _cdf (x) {
-    return super._cdf(this.c[this.p.n + 1] * x - this.c[this.p.n + 2])
+    const { scale, shift } = this.c
+    return super._cdf(scale * x - shift)
   }
 }

--- a/src/dist/irwin-hall.js
+++ b/src/dist/irwin-hall.js
@@ -37,8 +37,8 @@ export default class IrwinHall extends Distribution {
       closed: true
     }]
 
-    // Speed-up constants
-    this.c = Array.from({ length: ni + 1 }, (d, k) => logGamma(k + 1) + logGamma(ni - k + 1))
+    // Speed-up constants — logGammaTerms is a runtime-indexed lookup table, see decisions/0008-this-c-named-object-convention.md
+    this.c = { logGammaTerms: Array.from({ length: ni + 1 }, (d, k) => logGamma(k + 1) + logGamma(ni - k + 1)) }
   }
 
   _generator () {
@@ -49,10 +49,11 @@ export default class IrwinHall extends Distribution {
   _pdf (x) {
     // Use symmetry property for large x values
     const y = x < this.p.n / 2 ? x : this.p.n - x
+    const { logGammaTerms } = this.c
 
     // Compute terms
     const terms = Array.from({ length: Math.floor(y) + 1 }, (d, k) => {
-      const z = (this.p.n - 1) * Math.log(y - k) - this.c[k]
+      const z = (this.p.n - 1) * Math.log(y - k) - logGammaTerms[k]
 
       return k % 2 === 0 ? Math.exp(z) : -Math.exp(z)
     })
@@ -67,10 +68,11 @@ export default class IrwinHall extends Distribution {
   _cdf (x) {
     // Use symmetry property for large x values
     const y = x < this.p.n / 2 ? x : this.p.n - x
+    const { logGammaTerms } = this.c
 
     // Compute terms
     const terms = Array.from({ length: Math.floor(y) + 1 }, (d, k) => {
-      const z = this.p.n * Math.log(y - k) - this.c[k]
+      const z = this.p.n * Math.log(y - k) - logGammaTerms[k]
 
       return k % 2 === 0 ? Math.exp(z) : -Math.exp(z)
     })


### PR DESCRIPTION
Closes #456

## Summary
- `IrwinHall` stored `this.c` as a positional numeric array, violating the named-object convention in ADR-0008 and CLAUDE.md. Replaced with `{ logGammaTerms: [...] }` and updated the two index accesses in `_pdf`/`_cdf` to destructure the array before the loop.
- `Bates` appended to `this.c` via `.concat()`, destroying the parent's named object and accessing the result by positional index. Replaced with `Object.assign(this.c, { scale, shift })` and named property access throughout `_generator`, `_pdf`, and `_cdf`.

## Design decisions
- [ADR-0008: this.c named-object convention](decisions/0008-this-c-named-object-convention.md) — pre-existing ADR this hotfix brings IrwinHall and Bates into compliance with.

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/irwin-hall.js`**: `this.c` converted from positional array to `{ logGammaTerms }` named object; `logGammaTerms` destructured before each loop to avoid repeated double-lookup in hot path.
- **`src/dist/bates.js`**: `this.c.concat([...])` replaced with `Object.assign(this.c, { scale, shift })`; positional index access replaced with named properties; `scale`/`shift` destructured at top of `_pdf` and `_cdf`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1pRuDdjPfuzQARSsGtKNK)_