### PR TITLE
Fix ConwayMaxwellPoisson Z overflow for large λ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gaussLegendre(f, a, b, n)` algorithm: fixed-order Gauss-Legendre quadrature with precomputed nodes and weights for n=5, 10, and 20; exact for polynomials of degree ≤ 2n−1 (#402).
 - `Distribution.fit(data)` static method for maximum-likelihood parameter estimation via Nelder-Mead simplex optimizer (#404)
 - `ConwayMaxwellPoisson` distribution: two-parameter count distribution generalizing Poisson (ν=1), supporting both overdispersion (ν<1) and underdispersion (ν>1).
+- `ConwayMaxwellPoisson`: normalizing constant Z computation refactored to log-space recurrence with running log-sum-exp; fixes silent overflow to `Infinity` (and therefore all-zero PDF/CDF) for λ ≥ ~710 (#420).
 - `ZipfMandelbrot` distribution: three-parameter finite discrete distribution with PMF `(k+q)^{-s} / H_{N,s,q}`, generalizing `Zipf` by the shift parameter `q ≥ 0` (#398).
 
 ## [1.25.0] - 2026-05-25

--- a/src/dist/conway-maxwell-poisson.js
+++ b/src/dist/conway-maxwell-poisson.js
@@ -19,7 +19,8 @@ export default class ConwayMaxwellPoisson extends PreComputed {
    * @param {number} nu Dispersion parameter (nu > 0). nu = 1 gives Poisson, nu > 1 gives underdispersion.
    */
   constructor (lambda, nu) {
-    super()
+    // logP=true: _pk returns log-probabilities; PreComputed.advance exponentiates before CDF accumulation
+    super(true)
     this.k = 2
 
     this.p = { lambda, nu }
@@ -36,28 +37,30 @@ export default class ConwayMaxwellPoisson extends PreComputed {
       closed: false
     }]
 
-    // Compute Z = sum_{j=0}^inf lambda^j / (j!)^nu iteratively until the next term is
-    // negligible relative to the accumulated sum. The series always converges for lambda>0,
-    // nu>0 because term ratio lambda/(j+1)^nu -> 0 as j -> inf.
-    let Z = 0
-    let term = 1
+    // Compute log(Z) via log-space recurrence and running log-sum-exp.
+    // Direct accumulation overflows to Infinity for lambda >= ~710 (term ~ lambda^j/j! peaks
+    // near j=lambda, exceeding Number.MAX_VALUE); log-space avoids this entirely.
+    const logLambda = Math.log(lambda)
+    const LOG_TOL = Math.log(1e-14)
+    let logTerm = 0
+    let logZ = 0
     let j = 0
     do {
-      Z += term
       j++
-      term *= lambda / Math.pow(j, nu)
-    } while (term > 1e-14 * Z)
-    Z += term
+      logTerm += logLambda - nu * Math.log(j)
+      const m = Math.max(logZ, logTerm)
+      logZ = m + Math.log(Math.exp(logZ - m) + Math.exp(logTerm - m))
+    } while (logTerm > logZ + LOG_TOL)
 
     this.c = {
-      p0: 1 / Z
+      logP0: -logZ
     }
   }
 
   _pk (k) {
     if (k === 0) {
-      return this.c.p0
+      return this.c.logP0
     }
-    return this.pdfTable[k - 1] * this.p.lambda / Math.pow(k, this.p.nu)
+    return this.pdfTable[k - 1] + Math.log(this.p.lambda) - this.p.nu * Math.log(k)
   }
 }

--- a/test/dist-cases-discrete.js
+++ b/test/dist-cases-discrete.js
@@ -286,6 +286,19 @@ export default [{
       { x: 5, pmf: 0.10081881344492456, cdf: 0.9160820579686972 },
       { x: 8, pmf: 0.008101511794681437, cdf: 0.9961970079383248 }
     ]
+  }, {
+    name: 'large lambda overflow check',
+    params: () => [800, 1],
+    // CMP(800, 1) = Poisson(800): logZ must converge to 800 (Z = e^lambda for nu=1).
+    // pmf(k) = e^(-800) * 800^k / k!; pmf(800) ≈ 1/sqrt(2*pi*800) ≈ 0.01412 (Stirling).
+    // pmf(0) = e^(-800) underflows to 0; cdf(800) ≈ 0.51 (slightly above 0.5, as expected for
+    // discrete Poisson). Primary purpose: verify no overflow/NaN for lambda > 710.
+    refVals: [
+      { x: 0, pmf: 0, cdf: 0 },
+      { x: 780, pmf: 0.0111000895525291, cdf: 0.246249019272150 },
+      { x: 800, pmf: 0.0141032704215892, cdf: 0.509401658000143 },
+      { x: 810, pmf: 0.0131701847329993, cdf: 0.646654547059622 }
+    ]
   }],
   // ConwayMaxwellPoisson(2, 1.5) — computed from Z(2,1.5) = 5.122675153816768
   refVals: [


### PR DESCRIPTION
Closes #420

## Summary
- `ConwayMaxwellPoisson` silently returned all-zero PDF/CDF for λ ≥ ~710 because the normalizing constant Z overflowed to `Infinity` during direct-space accumulation
- Replaced the accumulation loop with a log-space recurrence (`logTerm(j) = logTerm(j−1) + log(λ) − ν·log(j)`) and a running log-sum-exp to compute `log(Z)` without overflow
- `_pk` now returns log-probabilities (`logP=true` passed to `PreComputed`), keeping all arithmetic in log-space until `PreComputed._advance` exponentiates for CDF accumulation

## Non-trivial changes
- **`src/dist/conway-maxwell-poisson.js`**: Constructor Z computation changed from `Z += term; term *= lambda/j^nu` to a log-sum-exp recurrence; `this.c.p0` replaced with `this.c.logP0`; `_pk` returns log-probabilities via log-space recurrence instead of multiplying direct probabilities. Behavioral fix: correct PDF/CDF values for any finite λ.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Bug-fix entry added under `[Unreleased]`
- **`test/dist-cases-discrete.js`**: Test case added for `CMP(800, 1)` to verify no overflow/NaN for λ > 710; `x=0` reference point pins the modified `k===0` branch of `_pk`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNWuoMexYpbEvzG1nk2Ju5)_