### PR TITLE
Add _fitInit overrides for Bernoulli, Poisson, Geometric, DiscreteUniform

### DIFF
--- a/src/dist/bernoulli.js
+++ b/src/dist/bernoulli.js
@@ -28,6 +28,7 @@ export default class Bernoulli extends Categorical {
   }
 
   static _fitInit (data) {
+    // MLE for p is the sample mean since E[X] = p.
     const mean = data.reduce((s, x) => s + x, 0) / data.length
     return [mean]
   }

--- a/src/dist/bernoulli.js
+++ b/src/dist/bernoulli.js
@@ -27,6 +27,11 @@ export default class Bernoulli extends Categorical {
     ])
   }
 
+  static _fitInit (data) {
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [mean]
+  }
+
   _q (p) {
     // this.p.weights[0] is the CDF at k=0; this.p.p is shadowed by the Categorical constructor.
     return p > this.p.weights[0] ? 1 : 0

--- a/src/dist/discrete-uniform.js
+++ b/src/dist/discrete-uniform.js
@@ -43,6 +43,10 @@ export default class DiscreteUniform extends Distribution {
     }
   }
 
+  static _fitInit (data) {
+    return [Math.min(...data), Math.max(...data)]
+  }
+
   _generator () {
     // Direct sampling
     return this._q(this.r.next())

--- a/src/dist/discrete-uniform.js
+++ b/src/dist/discrete-uniform.js
@@ -44,6 +44,7 @@ export default class DiscreteUniform extends Distribution {
   }
 
   static _fitInit (data) {
+    // MLEs for the support endpoints are the sample min and max.
     return [Math.min(...data), Math.max(...data)]
   }
 

--- a/src/dist/geometric.js
+++ b/src/dist/geometric.js
@@ -35,6 +35,11 @@ export default class Geometric extends Distribution {
     }]
   }
 
+  static _fitInit (data) {
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [1 / (1 + mean)]
+  }
+
   _generator () {
     // Inverse transform sampling
     return this._q(this.r.next())

--- a/src/dist/geometric.js
+++ b/src/dist/geometric.js
@@ -36,6 +36,8 @@ export default class Geometric extends Distribution {
   }
 
   static _fitInit (data) {
+    // MLE for p: E[X] = (1-p)/p under the failures-before-success parameterization,
+    // solved for p gives 1/(1+mean).
     const mean = data.reduce((s, x) => s + x, 0) / data.length
     return [1 / (1 + mean)]
   }

--- a/src/dist/poisson.js
+++ b/src/dist/poisson.js
@@ -37,6 +37,11 @@ export default class Poisson extends Distribution {
     }]
   }
 
+  static _fitInit (data) {
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [mean]
+  }
+
   _generator () {
     return poisson(this.r, this.p.lambda)
   }

--- a/src/dist/poisson.js
+++ b/src/dist/poisson.js
@@ -38,6 +38,7 @@ export default class Poisson extends Distribution {
   }
 
   static _fitInit (data) {
+    // MLE for lambda is the sample mean since E[X] = lambda.
     const mean = data.reduce((s, x) => s + x, 0) / data.length
     return [mean]
   }

--- a/test/dist.js
+++ b/test/dist.js
@@ -440,21 +440,21 @@ describe('dist', () => {
         const data = new dist.Bernoulli(0.7).seed(42).sample(1000)
         const result = dist.Bernoulli.fit(data)
         assert(result instanceof dist.Bernoulli)
-        assert(Math.abs(result.pdf(1) - 0.7) < 0.1)
+        assert(Math.abs(result.pdf(1) - 0.7) < 0.01)
       })
 
       it('Poisson.fit should recover lambda close to planted value', () => {
         const data = new dist.Poisson(3).seed(42).sample(1000)
         const result = dist.Poisson.fit(data)
         assert(result instanceof dist.Poisson)
-        assert(Math.abs(result.p.lambda - 3) < 0.1)
+        assert(Math.abs(result.p.lambda - 3) < 0.05)
       })
 
       it('Geometric.fit should recover p close to planted value', () => {
         const data = new dist.Geometric(0.4).seed(42).sample(1000)
         const result = dist.Geometric.fit(data)
         assert(result instanceof dist.Geometric)
-        assert(Math.abs(result.p.p - 0.4) < 0.05)
+        assert(Math.abs(result.p.p - 0.4) < 0.02)
       })
 
       it('DiscreteUniform.fit should recover xmin and xmax', () => {

--- a/test/dist.js
+++ b/test/dist.js
@@ -435,6 +435,35 @@ describe('dist', () => {
         const result = dist.Pareto.fit(data)
         assert(Math.abs(result.p.alpha - alphaExpected) < 0.05)
       })
+
+      it('Bernoulli.fit should recover p close to sample mean', () => {
+        const data = [1, 1, 1, 0, 1, 1, 1, 0]
+        const result = dist.Bernoulli.fit(data)
+        assert(result instanceof dist.Bernoulli)
+        assert(Math.abs(result.pdf(1) - 0.75) < 0.05)
+      })
+
+      it('Poisson.fit should recover lambda close to sample mean', () => {
+        const data = [2, 1, 3, 2, 2, 1, 3, 2]
+        const result = dist.Poisson.fit(data)
+        assert(result instanceof dist.Poisson)
+        assert(Math.abs(result.p.lambda - 2) < 0.1)
+      })
+
+      it('Geometric.fit should recover p close to closed-form MLE', () => {
+        const data = [1, 0, 2, 1, 0, 2, 1, 1]
+        const result = dist.Geometric.fit(data)
+        assert(result instanceof dist.Geometric)
+        assert(Math.abs(result.p.p - 0.5) < 0.05)
+      })
+
+      it('DiscreteUniform.fit should recover xmin and xmax', () => {
+        const data = [1, 2, 3, 4, 2, 3, 1, 4]
+        const result = dist.DiscreteUniform.fit(data)
+        assert(result instanceof dist.DiscreteUniform)
+        assert(result.p.xmin === 1)
+        assert(result.p.xmax === 4)
+      })
     })
   })
 

--- a/test/dist.js
+++ b/test/dist.js
@@ -436,33 +436,33 @@ describe('dist', () => {
         assert(Math.abs(result.p.alpha - alphaExpected) < 0.05)
       })
 
-      it('Bernoulli.fit should recover p close to sample mean', () => {
-        const data = [1, 1, 1, 0, 1, 1, 1, 0]
+      it('Bernoulli.fit should recover p close to planted value', () => {
+        const data = new dist.Bernoulli(0.7).seed(42).sample(1000)
         const result = dist.Bernoulli.fit(data)
         assert(result instanceof dist.Bernoulli)
-        assert(Math.abs(result.pdf(1) - 0.75) < 0.05)
+        assert(Math.abs(result.pdf(1) - 0.7) < 0.1)
       })
 
-      it('Poisson.fit should recover lambda close to sample mean', () => {
-        const data = [2, 1, 3, 2, 2, 1, 3, 2]
+      it('Poisson.fit should recover lambda close to planted value', () => {
+        const data = new dist.Poisson(3).seed(42).sample(1000)
         const result = dist.Poisson.fit(data)
         assert(result instanceof dist.Poisson)
-        assert(Math.abs(result.p.lambda - 2) < 0.1)
+        assert(Math.abs(result.p.lambda - 3) < 0.1)
       })
 
-      it('Geometric.fit should recover p close to closed-form MLE', () => {
-        const data = [1, 0, 2, 1, 0, 2, 1, 1]
+      it('Geometric.fit should recover p close to planted value', () => {
+        const data = new dist.Geometric(0.4).seed(42).sample(1000)
         const result = dist.Geometric.fit(data)
         assert(result instanceof dist.Geometric)
-        assert(Math.abs(result.p.p - 0.5) < 0.05)
+        assert(Math.abs(result.p.p - 0.4) < 0.05)
       })
 
       it('DiscreteUniform.fit should recover xmin and xmax', () => {
-        const data = [1, 2, 3, 4, 2, 3, 1, 4]
+        const data = new dist.DiscreteUniform(2, 8).seed(42).sample(1000)
         const result = dist.DiscreteUniform.fit(data)
         assert(result instanceof dist.DiscreteUniform)
-        assert(result.p.xmin === 1)
-        assert(result.p.xmax === 4)
+        assert(result.p.xmin === 2)
+        assert(result.p.xmax === 8)
       })
     })
   })

--- a/test/dist.js
+++ b/test/dist.js
@@ -437,28 +437,28 @@ describe('dist', () => {
       })
 
       it('Bernoulli.fit should recover p close to planted value', () => {
-        const data = new dist.Bernoulli(0.7).seed(42).sample(1000)
+        const data = new dist.Bernoulli(0.7).seed(42).sample(200)
         const result = dist.Bernoulli.fit(data)
         assert(result instanceof dist.Bernoulli)
-        assert(Math.abs(result.pdf(1) - 0.7) < 0.01)
+        assert(Math.abs(result.pdf(1) - 0.7) < 0.05)
       })
 
       it('Poisson.fit should recover lambda close to planted value', () => {
-        const data = new dist.Poisson(3).seed(42).sample(1000)
+        const data = new dist.Poisson(3).seed(42).sample(200)
         const result = dist.Poisson.fit(data)
         assert(result instanceof dist.Poisson)
-        assert(Math.abs(result.p.lambda - 3) < 0.05)
+        assert(Math.abs(result.p.lambda - 3) < 0.15)
       })
 
       it('Geometric.fit should recover p close to planted value', () => {
-        const data = new dist.Geometric(0.4).seed(42).sample(1000)
+        const data = new dist.Geometric(0.4).seed(42).sample(200)
         const result = dist.Geometric.fit(data)
         assert(result instanceof dist.Geometric)
-        assert(Math.abs(result.p.p - 0.4) < 0.02)
+        assert(Math.abs(result.p.p - 0.4) < 0.05)
       })
 
       it('DiscreteUniform.fit should recover xmin and xmax', () => {
-        const data = new dist.DiscreteUniform(2, 8).seed(42).sample(1000)
+        const data = new dist.DiscreteUniform(2, 8).seed(42).sample(200)
         const result = dist.DiscreteUniform.fit(data)
         assert(result instanceof dist.DiscreteUniform)
         assert(result.p.xmin === 2)


### PR DESCRIPTION
Closes #437

## Summary
- Adds closed-form MLE `static _fitInit(data)` overrides to Bernoulli, Poisson, Geometric, and DiscreteUniform so `Cls.fit(data)` starts Nelder-Mead at the exact MLE instead of relying on the base-class random-retry loop.
- Each override includes a one-line WHY comment explaining the statistical derivation.
- Four new fit tests using seeded 200-sample synthetic data verify parameter recovery within tolerance.

## Design decisions
- [ADR-0012: Distribution.fit() Static MLE Method via Nelder-Mead + _fitInit Hook](decisions/0012-distribution-fit-nelder-mead.md) — Nelder-Mead optimizer with `_fitInit` hook for data-aware starting points.

## Non-trivial changes
- **`src/dist/bernoulli.js`**: `_fitInit` returns `[mean(data)]` — the closed-form MLE for p since E[X] = p.
- **`src/dist/poisson.js`**: `_fitInit` returns `[mean(data)]` — the closed-form MLE for λ since E[X] = λ.
- **`src/dist/geometric.js`**: `_fitInit` returns `[1 / (1 + mean(data))]` — derived from the failures-before-success parameterization where E[X] = (1−p)/p, solved for p.
- **`src/dist/discrete-uniform.js`**: `_fitInit` returns `[min(data), max(data)]` — the closed-form MLEs for the support endpoints.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Four new `.fit()` tests using `seed(42).sample(200)` for deterministic, realistic data; tolerances set to ~2× the observed MLE error at n=200.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECEu3xJGnG7oPwjAsHk5hR)_