### PR TITLE
Add _fitInit MOM overrides for log-transform distributions

### DIFF
--- a/src/dist/log-cauchy.js
+++ b/src/dist/log-cauchy.js
@@ -49,4 +49,14 @@ export default class LogCauchy extends Cauchy {
   _q (p) {
     return Math.exp(this.p.x0 + this.p.gamma * Math.tan(Math.PI * (p - 0.5)))
   }
+
+  static _fitInit (data) {
+    // log(Y) ~ Cauchy(x0, gamma): IQR on log scale avoids reliance on moments that don't exist
+    const logData = data.map(x => Math.log(x)).sort((a, b) => a - b)
+    const n = logData.length
+    const mid = n % 2 ? logData[(n - 1) / 2] : (logData[n / 2 - 1] + logData[n / 2]) / 2
+    const q1 = logData[Math.floor(n / 4)]
+    const q3 = logData[Math.floor(3 * n / 4)]
+    return [mid, Math.max((q3 - q1) / 2, 1e-3)]
+  }
 }

--- a/src/dist/log-laplace.js
+++ b/src/dist/log-laplace.js
@@ -48,4 +48,15 @@ export default class LogLaplace extends Laplace {
       ? Math.exp(this.p.mu + this.p.b * Math.log(2 * p))
       : Math.exp(this.p.mu - this.p.b * Math.log(2 - 2 * p))
   }
+
+  static _fitInit (data) {
+    // log(Y) ~ Laplace(mu, b): median is MOM for location; median absolute deviation / ln(2) for scale
+    // because median(|X-mu|) = b*ln(2) for Laplace, so b = MAD / ln(2)
+    const logData = data.map(x => Math.log(x)).sort((a, b) => a - b)
+    const n = logData.length
+    const mu = n % 2 ? logData[(n - 1) / 2] : (logData[n / 2 - 1] + logData[n / 2]) / 2
+    const devs = logData.map(x => Math.abs(x - mu)).sort((a, b) => a - b)
+    const mad = n % 2 ? devs[(n - 1) / 2] : (devs[n / 2 - 1] + devs[n / 2]) / 2
+    return [mu, Math.max(mad / Math.LN2, 1e-3)]
+  }
 }

--- a/src/dist/log-logistic.js
+++ b/src/dist/log-logistic.js
@@ -59,4 +59,13 @@ export default class LogLogistic extends Distribution {
   _q (p) {
     return this.p.alpha * Math.pow(1 / p - 1, -1 / this.p.beta)
   }
+
+  static _fitInit (data) {
+    // log(Y) ~ Logistic(log(alpha), 1/beta): MOM on log scale exploits the log-logistic/logistic link
+    const n = data.length
+    const logData = data.map(x => Math.log(x))
+    const meanLog = logData.reduce((s, x) => s + x, 0) / n
+    const stdLog = Math.sqrt(logData.reduce((s, x) => s + (x - meanLog) ** 2, 0) / n) || 1
+    return [Math.exp(meanLog), Math.PI / (stdLog * Math.sqrt(3))]
+  }
 }

--- a/src/dist/log-normal.js
+++ b/src/dist/log-normal.js
@@ -48,4 +48,13 @@ export default class LogNormal extends Normal {
   _q (p) {
     return Math.exp(this.p.mu + this.c.sigmaRoot2 * erfinv(2 * p - 1))
   }
+
+  static _fitInit (data) {
+    // log(Y) ~ Normal(mu, sigma): MOM on log scale gives the natural parameterization
+    const n = data.length
+    const logData = data.map(x => Math.log(x))
+    const mu = logData.reduce((s, x) => s + x, 0) / n
+    const sigma = Math.sqrt(logData.reduce((s, x) => s + (x - mu) ** 2, 0) / n) || 1
+    return [mu, sigma]
+  }
 }

--- a/src/dist/logistic-exponential.js
+++ b/src/dist/logistic-exponential.js
@@ -61,4 +61,17 @@ export default class LogisticExponential extends Distribution {
       ? z / this.p.lambda
       : Math.log(1 + z) / this.p.lambda
   }
+
+  static _fitInit (data) {
+    // Median pins lambda via F^{-1}(0.5)=log(2)/lambda; 75th pctile solves kappa using the quantile inverse
+    const sorted = [...data].sort((a, b) => a - b)
+    const n = sorted.length
+    const median = n % 2 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    const q75 = sorted[Math.floor(0.75 * n)]
+    const lambda = Math.log(2) / median
+    // expm1(lambda*q75) > 1 iff q75 > median, which holds for non-degenerate data; fall back to 1
+    const raw = Math.expm1(lambda * q75)
+    const kappa = raw > 1 ? Math.log(3) / Math.log(raw) : 1
+    return [lambda, kappa]
+  }
 }

--- a/src/dist/logit-normal.js
+++ b/src/dist/logit-normal.js
@@ -47,4 +47,13 @@ export default class LogitNormal extends Normal {
   _q (p) {
     return 1 / (1 + Math.exp(-(this.p.mu + this.c.sigmaRoot2 * erfinv(2 * p - 1))))
   }
+
+  static _fitInit (data) {
+    // logit(Y) ~ Normal(mu, sigma): MOM on logit scale gives the natural parameterization
+    const n = data.length
+    const logitData = data.map(x => Math.log(x / (1 - x)))
+    const mu = logitData.reduce((s, x) => s + x, 0) / n
+    const sigma = Math.sqrt(logitData.reduce((s, x) => s + (x - mu) ** 2, 0) / n) || 1
+    return [mu, sigma]
+  }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -464,6 +464,54 @@ describe('dist', () => {
         assert(result.p.xmin === 2)
         assert(result.p.xmax === 8)
       })
+
+      it('LogNormal.fit should recover mu and sigma close to planted values', () => {
+        const data = new dist.LogNormal(1, 0.5).seed(42).sample(200)
+        const result = dist.LogNormal.fit(data)
+        assert(result instanceof dist.LogNormal)
+        assert(Math.abs(result.p.mu - 1) < 0.15)
+        assert(Math.abs(result.p.sigma - 0.5) < 0.15)
+      })
+
+      it('LogCauchy.fit should recover x0 and gamma close to planted values', () => {
+        const data = new dist.LogCauchy(0, 1).seed(42).sample(200)
+        const result = dist.LogCauchy.fit(data)
+        assert(result instanceof dist.LogCauchy)
+        assert(Math.abs(result.p.x0 - 0) < 0.5)
+        assert(Math.abs(result.p.gamma - 1) < 0.5)
+      })
+
+      it('LogLogistic.fit should recover alpha and beta close to planted values', () => {
+        const data = new dist.LogLogistic(2, 3).seed(42).sample(200)
+        const result = dist.LogLogistic.fit(data)
+        assert(result instanceof dist.LogLogistic)
+        assert(Math.abs(result.p.alpha - 2) < 0.3)
+        assert(Math.abs(result.p.beta - 3) < 0.5)
+      })
+
+      it('LogLaplace.fit should recover mu and b close to planted values', () => {
+        const data = new dist.LogLaplace(0, 1).seed(42).sample(200)
+        const result = dist.LogLaplace.fit(data)
+        assert(result instanceof dist.LogLaplace)
+        assert(Math.abs(result.p.mu - 0) < 0.2)
+        assert(Math.abs(result.p.b - 1) < 0.2)
+      })
+
+      it('LogisticExponential.fit should recover lambda and kappa close to planted values', () => {
+        const data = new dist.LogisticExponential(1, 2).seed(42).sample(200)
+        const result = dist.LogisticExponential.fit(data)
+        assert(result instanceof dist.LogisticExponential)
+        assert(Math.abs(result.p.lambda - 1) < 0.3)
+        assert(Math.abs(result.p.kappa - 2) < 0.5)
+      })
+
+      it('LogitNormal.fit should recover mu and sigma close to planted values', () => {
+        const data = new dist.LogitNormal(0, 1).seed(42).sample(200)
+        const result = dist.LogitNormal.fit(data)
+        assert(result instanceof dist.LogitNormal)
+        assert(Math.abs(result.p.mu - 0) < 0.2)
+        assert(Math.abs(result.p.sigma - 1) < 0.2)
+      })
     })
   })
 

--- a/test/dist.js
+++ b/test/dist.js
@@ -512,6 +512,48 @@ describe('dist', () => {
         assert(Math.abs(result.p.mu - 0) < 0.2)
         assert(Math.abs(result.p.sigma - 1) < 0.2)
       })
+
+      it('LogNormal._fitInit should return sigma=1 for constant data', () => {
+        const init = dist.LogNormal._fitInit([2, 2, 2])
+        assert(Number.isFinite(init[0]))
+        assert(init[1] === 1)
+      })
+
+      it('LogCauchy._fitInit should return valid params for odd-n data', () => {
+        const init = dist.LogCauchy._fitInit(new dist.LogCauchy(0, 1).seed(1).sample(101))
+        assert(Number.isFinite(init[0]))
+        assert(init[1] > 0)
+      })
+
+      it('LogLogistic._fitInit should return positive params for constant data', () => {
+        const init = dist.LogLogistic._fitInit([2, 2, 2])
+        assert(init[0] > 0)
+        assert(init[1] > 0)
+      })
+
+      it('LogLaplace._fitInit should return valid params for odd-n data', () => {
+        const init = dist.LogLaplace._fitInit(new dist.LogLaplace(0, 1).seed(1).sample(101))
+        assert(Number.isFinite(init[0]))
+        assert(init[1] > 0)
+      })
+
+      it('LogisticExponential._fitInit should return valid params for odd-n data', () => {
+        const init = dist.LogisticExponential._fitInit(new dist.LogisticExponential(1, 2).seed(1).sample(101))
+        assert(init[0] > 0)
+        assert(init[1] > 0)
+      })
+
+      it('LogisticExponential._fitInit should fall back to kappa=1 for degenerate data', () => {
+        const init = dist.LogisticExponential._fitInit([5, 5, 5, 5])
+        assert(init[0] > 0)
+        assert(init[1] === 1)
+      })
+
+      it('LogitNormal._fitInit should return sigma=1 for constant data', () => {
+        const init = dist.LogitNormal._fitInit([0.5, 0.5, 0.5])
+        assert(Number.isFinite(init[0]))
+        assert(init[1] === 1)
+      })
     })
   })
 


### PR DESCRIPTION
Closes #436

## Summary
- Adds `static _fitInit(data)` overrides for 6 log-transform distributions: LogNormal, LogCauchy, LogLogistic, LogLaplace, LogisticExponential, LogitNormal.
- Each override computes method-of-moments estimates on the transformed scale (log or logit), replacing the base-class random-restart seed with a data-aware starting point for Nelder-Mead.
- One seeded fit-recovery test added per distribution, asserting planted parameters are recovered within tolerance.

## Design decisions
- [ADR-0012: Distribution fit via Nelder-Mead](decisions/0012-distribution-fit-nelder-mead.md) — establishes the `_fitInit` hook that these overrides implement.

## Non-trivial changes
- **`src/dist/log-normal.js`**: MOM on log scale — mean and biased std of `log(data)` map directly to `(mu, sigma)`.
- **`src/dist/log-cauchy.js`**: IQR-based init on log scale — Cauchy has no finite moments, so median and half-IQR of `log(data)` give robust `(x0, gamma)` estimates.
- **`src/dist/log-logistic.js`**: Exploits the log-logistic/logistic link — `log(Y) ~ Logistic(log(alpha), 1/beta)`, so mean/std of `log(data)` yield `alpha = exp(mean)` and `beta = π / (std * √3)`.
- **`src/dist/log-laplace.js`**: Median and median-absolute-deviation on log scale — for Laplace(μ, b), `median(|X−μ|) = b·ln(2)`, so scale init is `MAD / ln(2)` (not MAD directly).
- **`src/dist/logistic-exponential.js`**: Closed-form quantile inversion — median pins `lambda = ln(2)/median`; 75th percentile solves `kappa = ln(3)/ln(expm1(lambda·q75))`. Guard added: falls back to `kappa = 1` when `expm1(lambda·q75) ≤ 1` (degenerate/single-point data) to avoid `Infinity` propagating into Nelder-Mead.
- **`src/dist/logit-normal.js`**: MOM on logit scale — mean and biased std of `logit(data)` map directly to `(mu, sigma)`.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Six `it` blocks added inside the existing `.fit()` describe block, one per distribution, each seeding 200-sample synthetic data and asserting parameters recover within stated tolerance.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_014QXpskkxeHfRjM413hN5Wz)_