### PR TITLE
Add _fitInit and fit overrides for Categorical and Hyperexponential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gaussLegendre(f, a, b, n)` algorithm: fixed-order Gauss-Legendre quadrature with precomputed nodes and weights for n=5, 10, and 20; exact for polynomials of degree ≤ 2n−1 (#402).
 - `Distribution.fit(data)` static method for maximum-likelihood parameter estimation via Nelder-Mead simplex optimizer (#404)
 - `fit()` now works on zero-parameter distributions (`Gilbrat`, `HalfLogistic`, `HyperbolicSecant`, `Kolmogorov`, `Rademacher`, `Slash`, `UniformRatio`): calling `Cls.fit(data)` returns a fresh instance without optimization (#427)
+- `Categorical.fit(data)` and `Hyperexponential.fit(data)` now return fitted instances instead of throwing from the base-class scalar-constructor probe; `Categorical` uses closed-form empirical frequencies, `Hyperexponential` defaults to a two-component mixture initialised by a median split (#428)
 - `ConwayMaxwellPoisson` distribution: two-parameter count distribution generalizing Poisson (ν=1), supporting both overdispersion (ν<1) and underdispersion (ν>1).
 - `ConwayMaxwellPoisson`: normalizing constant Z computation refactored to log-space recurrence with running log-sum-exp; fixes silent overflow to `Infinity` (and therefore all-zero PDF/CDF) for λ ≥ ~710 (#420).
 - `ZipfMandelbrot` distribution: three-parameter finite discrete distribution with PMF `(k+q)^{-s} / H_{N,s,q}`, generalizing `Zipf` by the shift parameter `q ≥ 0` (#398).

--- a/src/dist/categorical.js
+++ b/src/dist/categorical.js
@@ -71,4 +71,41 @@ export default class Categorical extends Distribution {
   _cdf (x) {
     return Math.min(1, this.cdfTable[x - this.p.min])
   }
+
+  static _fitInit (data) {
+    // Subclasses (Bernoulli, Binomial, Zipf, ...) reuse Categorical's storage but have scalar
+    // constructors of their own; only override for Categorical itself so the base-class random
+    // retry still services the rest of the hierarchy.
+    if (this !== Categorical) {
+      return super._fitInit(data)
+    }
+    // Empirical frequencies are the unconstrained MLE for the categorical PMF, so this hook
+    // returns the closed-form optimum itself; fit() below skips Nelder-Mead because there is
+    // nothing left to optimise.
+    const min = Math.min(...data)
+    const max = Math.max(...data)
+    const counts = new Array(max - min + 1).fill(0)
+    for (const x of data) counts[x - min]++
+    return counts.map(c => c / data.length)
+  }
+
+  /**
+   * Estimates the categorical distribution from data via maximum likelihood. The MLE is
+   * closed-form (empirical frequencies of the observed integer categories) so this override
+   * skips Nelder-Mead. See [decisions/0012-distribution-fit-nelder-mead.md]{@link ../../decisions/0012-distribution-fit-nelder-mead.md}.
+   *
+   * @method fit
+   * @memberof ran.dist.Categorical
+   * @param {number[]} data Array of integer observations to fit.
+   * @returns {Categorical} A new Categorical instance with MLE parameters.
+   */
+  static fit (data) {
+    // Subclasses (Bernoulli, Binomial, etc.) have scalar constructors, so the (weights, min)
+    // construction here only applies to Categorical itself — delegate everything else to the
+    // base-class implementation, which still wires the subclass's own _fitInit into Nelder-Mead.
+    if (this !== Categorical) {
+      return super.fit(data)
+    }
+    return new this(this._fitInit(data), Math.min(...data))
+  }
 }

--- a/src/dist/hyperexponential.js
+++ b/src/dist/hyperexponential.js
@@ -2,6 +2,7 @@ import exponential from './_exponential'
 import AliasTable from './_alias-table'
 import Distribution from './_distribution'
 import neumaier from '../algorithms/neumaier'
+import nelderMead from '../algorithms/nelder-mead'
 
 /**
  * Probability density function for the [hyperexponential distribution]{@link https://en.wikipedia.org/wiki/Hyperexponential_distribution}:
@@ -64,5 +65,57 @@ export default class Hyperexponential extends Distribution {
   _cdf (x) {
     // -expm1(-d*x) per component avoids cancellation when d*x is near 0
     return Math.min(neumaier(this.p.rates.map((d, i) => this.p.weights[i] * -Math.expm1(-d * x))), 1)
+  }
+
+  static _fitInit (data) {
+    // k=2 is the smallest non-trivial mixture and avoids over-fitting on default fit() calls; users
+    // who need more components must construct the distribution manually. Splitting the sorted data
+    // at the median and taking 1/mean per bucket as a rate seeds Nelder-Mead with two distinct
+    // time-scales, well separated from the degenerate optimum where both rates collapse to 1/mean.
+    const sorted = data.slice().sort((a, b) => a - b)
+    const mid = Math.max(1, Math.floor(sorted.length / 2))
+    const low = sorted.slice(0, mid)
+    const high = sorted.slice(mid).length > 0 ? sorted.slice(mid) : low
+    const meanLow = low.reduce((s, x) => s + x, 0) / low.length || 1
+    const meanHigh = high.reduce((s, x) => s + x, 0) / high.length || meanLow
+    return [0.5, 0.5, 1 / meanLow, 1 / meanHigh]
+  }
+
+  /**
+   * Estimates the hyperexponential distribution from data via maximum likelihood, using a fixed
+   * two-component default mixture. Overrides the base-class fit() to pack and unpack the
+   * Nelder-Mead flat vector around the (Object[]) constructor signature. See
+   * [decisions/0012-distribution-fit-nelder-mead.md]{@link ../../decisions/0012-distribution-fit-nelder-mead.md}.
+   *
+   * @method fit
+   * @memberof ran.dist.Hyperexponential
+   * @param {number[]} data Array of non-negative observations to fit.
+   * @returns {Hyperexponential} A new Hyperexponential instance with MLE parameters.
+   */
+  static fit (data) {
+    // The constructor takes an Object[] of {weight, rate}, so the base-class fit() spread cannot
+    // reconstruct it from Nelder-Mead's flat numeric vector. Override to pack the optimiser's
+    // [w_0..w_{k-1}, r_0..r_{k-1}] vector back into the required object-array shape on every
+    // evaluation, then return the best fit.
+    const Cls = this
+    const x0 = Cls._fitInit(data)
+    const k = x0.length / 2
+    const toParams = v => {
+      const params = new Array(k)
+      for (let i = 0; i < k; i++) params[i] = { weight: v[i], rate: v[i + k] }
+      return params
+    }
+    const best = nelderMead(
+      v => {
+        try {
+          const l = -new Cls(toParams(v)).lnL(data)
+          return isNaN(l) ? Infinity : l
+        } catch (_) {
+          return Infinity
+        }
+      },
+      x0
+    )
+    return new Cls(toParams(best))
   }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -654,6 +654,29 @@ describe('dist', () => {
         assert(result instanceof dist.Chi)
         assert(Math.abs(result.p.k - 4) <= 1)
       })
+
+      it('Categorical.fit should recover category probabilities close to planted values', () => {
+        const data = new dist.Categorical([0.2, 0.3, 0.5], 0).seed(42).sample(500)
+        const result = dist.Categorical.fit(data)
+        assert(result instanceof dist.Categorical)
+        assert(Math.abs(result.pdf(0) - 0.2) < 0.1)
+        assert(Math.abs(result.pdf(1) - 0.3) < 0.1)
+        assert(Math.abs(result.pdf(2) - 0.5) < 0.1)
+      })
+
+      it('Hyperexponential.fit should recover a mixture whose mean matches the data', () => {
+        const data = new dist.Hyperexponential([
+          { weight: 0.5, rate: 1 },
+          { weight: 0.5, rate: 5 }
+        ]).seed(42).sample(500)
+        const result = dist.Hyperexponential.fit(data)
+        assert(result instanceof dist.Hyperexponential)
+        // Component label-switching makes (weight, rate) pairs non-identifiable; use the mixture
+        // mean E[X] = Σ w_i / λ_i — a sufficient statistic invariant under that permutation.
+        const sampleMean = data.reduce((s, x) => s + x, 0) / data.length
+        const fittedMean = result.p.weights.reduce((s, w, i) => s + w / result.p.rates[i], 0)
+        assert(Math.abs(fittedMean - sampleMean) < 0.2)
+      })
     })
   })
 


### PR DESCRIPTION
Closes #428

## Summary
- `Categorical.fit(data)` now returns a fitted instance via closed-form empirical frequencies (the MLE is the empirical PMF), skipping Nelder-Mead because the optimum is already known.
- `Hyperexponential.fit(data)` returns a fitted two-component mixture; `_fitInit` seeds Nelder-Mead with a median split (`1/mean` per bucket as the rate) so the optimizer starts from two distinct time-scales rather than a degenerate point.
- Both distributions previously threw from the base-class random-scalar probe because their constructors take array arguments.

## Design decisions
- ADR reference: [decisions/0012-distribution-fit-nelder-mead.md](decisions/0012-distribution-fit-nelder-mead.md) — anticipated this exact override pattern for non-scalar-constructor distributions.
- **Signature adjustment**: per the issue's "small signature adjustment" allowance, neither `_fitInit` changes its `number[]` return contract — Categorical's returns the closed-form weight vector (length `max-min+1`), and Hyperexponential's returns a flat `[w_0, w_1, r_0, r_1]` packed vector that the overridden `fit()` repacks into the constructor's `{weight, rate}[]` shape on every Nelder-Mead evaluation.
- **k=2 default for Hyperexponential**: the smallest non-trivial mixture; documented in the WHY comment. Users wanting more components construct manually. The issue called this out as "k from a sensible default".
- **Categorical subclass guard**: nine classes extend `Categorical` (Bernoulli, Binomial, Zipf, Rademacher, Hypergeometric, Soliton, NegativeHypergeometric, BetaBinomial, ZipfMandelbrot) but all have scalar constructors. The `if (this !== Categorical) return super._fitInit/fit(data)` guard on both overrides keeps the inherited fit pipeline intact for them (Bernoulli has its own `_fitInit`; the others fall back to `Distribution._fitInit`'s random retry).

## Non-trivial changes
- **`src/dist/categorical.js`**: new `static _fitInit` returning empirical frequencies and new `static fit` constructing `new this(weights, min)` directly. Both methods guard `this !== Categorical` so subclasses keep using the base-class pipeline.
- **`src/dist/hyperexponential.js`**: new `static _fitInit` (median-split rate seed, k=2) and new `static fit` that flattens/repacks the Nelder-Mead vector around the `{weight, rate}[]` constructor signature. Adds `nelderMead` import.
- **`test/dist.js`**: one fit recovery test per distribution. Categorical asserts PMF values within 0.1 of planted; Hyperexponential asserts the mixture mean `Σ w_i / λ_i` matches the sample mean within 0.2 (a label-switching-invariant statistic).

## Triage follow-up
Filed as a separate bug surfaced during this work: **#473** — Hyperexponential constructor does not validate weights are non-negative; the `invalidParams` test entries for negative-weight cases are passing for the wrong reason (argument-shape `TypeError` rather than weight constraint). Out of scope for this PR.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: one bullet added under `[Unreleased] > Added`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWiZs1zhwfJ5y26NjKz6Hu)_