### PR TITLE
Fix Slash: replace this.c1 positional array with named this.c property

### DIFF
--- a/src/dist/slash.js
+++ b/src/dist/slash.js
@@ -23,9 +23,7 @@ export default class Slash extends Normal {
       value: Infinity,
       closed: false
     }]
-    this.c1 = [
-      0.5 / Math.sqrt(2 * Math.PI)
-    ]
+    Object.assign(this.c, { halfOverRoot2Pi: 0.5 / Math.sqrt(2 * Math.PI) })
   }
 
   _generator () {
@@ -35,7 +33,7 @@ export default class Slash extends Normal {
 
   _pdf (x) {
     return x === 0
-      ? this.c1[0]
+      ? this.c.halfOverRoot2Pi
       : (super._pdf(0) - super._pdf(x)) / (x * x)
   }
 


### PR DESCRIPTION
Closes #470

## Summary
- Replaces the non-standard `this.c1` positional array in `Slash` with a named property on `this.c` via `Object.assign`, conforming to ADR-0008.
- Updates the single `this.c1[0]` reference in `_pdf` to `this.c.halfOverRoot2Pi`.
- No mathematical changes — the constant value and all formula logic are unchanged.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/slash.js`**: `this.c1 = [0.5 / Math.sqrt(2 * Math.PI)]` replaced with `Object.assign(this.c, { halfOverRoot2Pi: 0.5 / Math.sqrt(2 * Math.PI) })` in constructor; `this.c1[0]` updated to `this.c.halfOverRoot2Pi` in `_pdf`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCwSTqy99X4iUhKooAk2B2)_