### PR TITLE
Add _fitInit MOM overrides for 22 compound discrete distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `_fitInit` data-aware method-of-moments initializers added to 22 discrete distributions (`Binomial`, `NegativeBinomial`, `Skellam`, `DiscreteWeibull`, `Zeta`, `YuleSimon`, `LogSeries`, `FlorySchulz`, `Borel`, `BorelTanner`, `HeadsMinus Tails`, `ConwayMaxwellPoisson`, `PolyaAeppli`, `NeymanA`, `GeneralizedHermite`, `Delaporte`, `Zipf`, `Hypergeometric`, `NegativeHypergeometric`, `BetaBinomial`, `Logarithmic`, `ExponentialLogarithmic`); `Cls.fit(data)` now starts Nelder-Mead from a moment-matched seed instead of a random draw (#438).
 - `gaussLegendre(f, a, b, n)` algorithm: fixed-order Gauss-Legendre quadrature with precomputed nodes and weights for n=5, 10, and 20; exact for polynomials of degree ≤ 2n−1 (#402).
 - `Distribution.fit(data)` static method for maximum-likelihood parameter estimation via Nelder-Mead simplex optimizer (#404)
 - `fit()` now works on zero-parameter distributions (`Gilbrat`, `HalfLogistic`, `HyperbolicSecant`, `Kolmogorov`, `Rademacher`, `Slash`, `UniformRatio`): calling `Cls.fit(data)` returns a fresh instance without optimization (#427)

--- a/solutions/distribution/2026-05-28-1120-log-series-fitinit-asymptotic-inversion.md
+++ b/solutions/distribution/2026-05-28-1120-log-series-fitinit-asymptotic-inversion.md
@@ -1,0 +1,59 @@
+---
+date: 2026-05-28T11:20:00Z
+category: "distribution"
+problem: "LogSeries._fitInit used wrong asymptotic inversion: p ≈ 1 - 1/mean instead of 1 - 1/sqrt(mean)"
+status: complete
+related_issue: "#438"
+related_plan: "thoughts/plans/2026-05-28-1106-fitinit-discrete-438.md"
+tags: [fitInit, log-series, moment-of-moments, asymptotic, Hill-estimator, power-law]
+---
+
+# Solution: LogSeries _fitInit Asymptotic Inversion Error
+
+**Date**: 2026-05-28
+**Category**: distribution
+**Related Issue**: #438
+
+## Problem
+
+The first-draft `_fitInit` for `LogSeries` used `p ≈ 1 - 1/mean` to seed the Nelder-Mead optimizer. For any dataset with mean > 2, this formula produces a starting point severely below the true `p`, causing the optimizer to waste iterations or converge to a poor local optimum. For example, at p=0.9 (true E[X] ≈ 4.34), the formula yields p≈0.77 instead of 0.9.
+
+## Root Cause
+
+The log-series distribution has E[X] = -p / ((1-p) ln(1-p)). Near p → 1, both (1-p) and -ln(1-p) vanish, so the asymptotic behavior is:
+
+E[X] ≈ 1 / (1-p)²
+
+not the linear E[X] ≈ 1/(1-p) found in geometric/Borel-family distributions. The plan conflated log-series with the geometric family and inverted the wrong relation.
+
+The correct inversion of E[X] ≈ 1/(1-p)² gives:
+- (1-p) ≈ 1/sqrt(mean)
+- p ≈ 1 - 1/sqrt(mean)
+
+## Fix
+
+`src/dist/log-series.js`: changed the `_fitInit` seed from `1 - 1/mean` to `1 - 1/Math.sqrt(mean)`, with a WHY comment making the asymptotic explicit.
+
+```js
+// E[X] ≈ 1/(1-p)^2 for p near 1; inverting gives p ≈ 1 - 1/sqrt(mean).
+const mean = data.reduce((s, x) => s + x, 0) / data.length
+return [Math.max(0.01, Math.min(0.99, 1 - 1 / Math.sqrt(mean)))]
+```
+
+Additionally, `Zeta._fitInit` and `Zipf._fitInit` received a guard for `sumLog <= 0` (all data equal to 1), which would otherwise produce `s = Infinity` via `n/sumLog` and trap the optimizer at a boundary cliff.
+
+## Prevention Strategy
+
+When writing `_fitInit` for any distribution whose mean is not linear in its natural parameter (log-series, Borel, Yule-Simon, Polya-Aeppli, etc.):
+
+1. Write out the full asymptotic expansion of E[X] near the boundary parameter value.
+2. Verify the inversion at a concrete test point: compute `E[X]` at a known `p`, run `_fitInit([E[X], E[X], ...])`, and confirm it returns back the original `p` (within MoM tolerance).
+3. For Hill estimators and other log-sum denominators, always guard against `sumLog <= 0` before computing `n / sumLog`.
+
+## Related Solutions
+
+- See `solutions/distribution/` for other distribution-fitting patterns.
+
+## Key Insight
+
+For the log-series distribution, E[X] grows as 1/(1-p)² near p → 1 (not as 1/(1-p)), so the moment-of-moments initializer must invert using `p ≈ 1 - 1/sqrt(mean)` — using the linear inversion `1 - 1/mean` silently produces a severe underestimate of p for any heavy-tailed sample.

--- a/src/dist/beta-binomial.js
+++ b/src/dist/beta-binomial.js
@@ -20,6 +20,18 @@ export default class BetaBinomial extends Categorical {
    * @param {number} alpha First shape parameter.
    * @param {number} beta Second shape parameter.
    */
+  static _fitInit (data) {
+    // n = max(data); moment-match alpha, beta from mean proportion and overdispersion.
+    const n = Math.max(1, data.reduce((m, x) => x > m ? x : m, 0))
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const variance = data.reduce((s, x) => s + x * x, 0) / data.length - mean * mean
+    const m1 = mean / n
+    const binVar = n * m1 * (1 - m1)
+    const v = binVar > 0 ? Math.max(1.01, variance / binVar) : 2
+    const phi = Math.max(0.1, (n - v) / (v - 1))
+    return [n, Math.max(0.1, m1 * phi), Math.max(0.1, (1 - m1) * phi)]
+  }
+
   constructor (n, alpha, beta) {
     const ni = Math.round(n)
     super(Array.from({ length: ni + 1 }, (d, i) => Math.exp(logBinomial(ni, i) + logBeta(i + alpha, ni - i + beta) - logBeta(alpha, beta))), 0)

--- a/src/dist/binomial.js
+++ b/src/dist/binomial.js
@@ -19,6 +19,13 @@ export default class Binomial extends Categorical {
    * @param {number} n Number of trials.
    * @param {number} p Probability of success.
    */
+  static _fitInit (data) {
+    // E[X] = np; n ≈ max(data) as the support upper bound, p = mean/n.
+    const n = Math.max(1, data.reduce((m, x) => x > m ? x : m, 0))
+    const p = Math.min(0.99, data.reduce((s, x) => s + x, 0) / (data.length * n))
+    return [n, Math.max(0.01, p)]
+  }
+
   constructor (n, p) {
     const ni = Math.round(n)
     super(Array.from({ length: ni + 1 }, (d, k) => Math.exp(logBinomial(n, k) + k * Math.log(p) + (n - k) * Math.log(1 - p))), 0)

--- a/src/dist/borel-tanner.js
+++ b/src/dist/borel-tanner.js
@@ -40,6 +40,14 @@ export default class BorelTanner extends PreComputed {
     }]
   }
 
+  static _fitInit (data) {
+    // Support starts at n; E[X] = n/(1-mu). Use min(data) for n and solve for mu.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const n = Math.max(1, data.reduce((m, x) => x < m ? x : m, data[0]))
+    const mu = mean > n ? 1 - n / mean : 0
+    return [Math.max(0, Math.min(0.99, mu)), n]
+  }
+
   _pk (k) {
     if (k < this.p.n) {
       return 0

--- a/src/dist/borel.js
+++ b/src/dist/borel.js
@@ -37,6 +37,12 @@ export default class Borel extends PreComputed {
     }]
   }
 
+  static _fitInit (data) {
+    // E[X] = 1/(1-mu); solving gives mu = 1 - 1/mean.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [Math.max(0, Math.min(0.99, mean > 1 ? 1 - 1 / mean : 0))]
+  }
+
   _pk (k) {
     if (k < 1) {
       return -Infinity

--- a/src/dist/conway-maxwell-poisson.js
+++ b/src/dist/conway-maxwell-poisson.js
@@ -57,6 +57,13 @@ export default class ConwayMaxwellPoisson extends PreComputed {
     }
   }
 
+  static _fitInit (data) {
+    // Var[X] ≈ lambda/nu; E[X] ≈ lambda. Ratio mean/variance seeds the dispersion nu.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const variance = data.reduce((s, x) => s + x * x, 0) / data.length - mean * mean
+    return [Math.max(0.01, mean), Math.max(0.01, mean / Math.max(variance, 0.01))]
+  }
+
   _pk (k) {
     if (k === 0) {
       return this.c.logP0

--- a/src/dist/delaporte.js
+++ b/src/dist/delaporte.js
@@ -51,6 +51,14 @@ export default class Delaporte extends PreComputed {
     }
   }
 
+  static _fitInit (data) {
+    // Fixing beta=1: E = alpha+lambda, Var-E = alpha (overdispersion); lambda = E-alpha.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const variance = data.reduce((s, x) => s + x * x, 0) / data.length - mean * mean
+    const alpha = Math.max(0.1, variance - mean)
+    return [alpha, 1, Math.max(0.1, mean - alpha)]
+  }
+
   _pk (k) {
     // Set i = 0 term
     let ki = k

--- a/src/dist/discrete-weibull.js
+++ b/src/dist/discrete-weibull.js
@@ -36,6 +36,12 @@ export default class DiscreteWeibull extends Distribution {
     }]
   }
 
+  static _fitInit (data) {
+    // PMF(0) = 1-q, so q ≈ fraction of nonzero observations; beta = 1 as neutral shape seed.
+    const zeroFraction = data.filter(x => x === 0).length / data.length
+    return [Math.max(0.01, Math.min(0.99, 1 - zeroFraction)), 1]
+  }
+
   _generator () {
     // Inverse transform sampling
     return this._q(this.r.next())

--- a/src/dist/exponential-logarithmic.js
+++ b/src/dist/exponential-logarithmic.js
@@ -36,6 +36,12 @@ export default class ExponentialLogarithmic extends Distribution {
     }]
   }
 
+  static _fitInit (data) {
+    // beta ≈ 1/mean (exponential rate MLE); p = 0.5 as neutral shape seed for Nelder-Mead.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [0.5, Math.max(0.01, 1 / mean)]
+  }
+
   _generator () {
     // Inverse transform sampling
     return this._q(this.r.next())

--- a/src/dist/flory-schulz.js
+++ b/src/dist/flory-schulz.js
@@ -40,6 +40,12 @@ export default class FlorySchulz extends Distribution {
     }
   }
 
+  static _fitInit (data) {
+    // E[X] = 2/a; solving gives a = 2/mean.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [Math.max(0.01, Math.min(0.99, 2 / mean))]
+  }
+
   _generator () {
     // FlorySchulz(a) = G1 + G2 + 1, G_i ~ Geom(a) (failures before success).
     // Geom(a) inverse-CDF: floor(log(U) / log(1-a)), O(1) regardless of a.

--- a/src/dist/generalized-hermite.js
+++ b/src/dist/generalized-hermite.js
@@ -54,6 +54,15 @@ export default class GeneralizedHermite extends PreComputed {
     }
   }
 
+  static _fitInit (data) {
+    // X = X1 + 2*X2 with m fixed at 2; E = a1+2*a2, Var = a1+4*a2 gives a2 = (V-E)/2.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const variance = data.reduce((s, x) => s + x * x, 0) / data.length - mean * mean
+    const a2 = Math.max(0.01, (variance - mean) / 2)
+    const a1 = Math.max(0.01, mean - 2 * a2)
+    return [a1, a2, 2]
+  }
+
   _pk (k) {
     if (k === 0) {
       return this.c.baseLogProb

--- a/src/dist/heads-minus-tails.js
+++ b/src/dist/heads-minus-tails.js
@@ -47,6 +47,12 @@ export default class HeadsMinusTails extends PreComputed {
     }
   }
 
+  static _fitInit (data) {
+    // Support upper bound is 2n, so max(data) ≈ 2n for large samples.
+    const maxVal = data.reduce((m, x) => x > m ? x : m, 0)
+    return [Math.max(1, Math.round(maxVal / 2))]
+  }
+
   _pk (k) {
     if (k === 0) {
       return this.c.baseLogProb + logBinomial(2 * this.p.n, this.p.n)

--- a/src/dist/hypergeometric.js
+++ b/src/dist/hypergeometric.js
@@ -20,6 +20,16 @@ export default class Hypergeometric extends Categorical {
    * @param {number} K Total number of successes. If not an integer, it is rounded to the nearest one.
    * @param {number} n If not an integer, it is rounded to the nearest one. Number of draws.
    */
+  static _fitInit (data) {
+    // Rough seed: N = 2*max+2 ensures max(data) ≤ min(n, K); E[X] = nK/N seeds K.
+    const maxVal = data.reduce((m, x) => x > m ? x : m, 0)
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const N = 2 * maxVal + 2
+    const n = Math.max(1, Math.round(N / 2))
+    const K = Math.max(1, Math.min(N - 1, Math.round(mean * N / n)))
+    return [N, K, n]
+  }
+
   constructor (N, K, n) {
     const Ni = Math.round(N)
     const Ki = Math.round(K)

--- a/src/dist/log-series.js
+++ b/src/dist/log-series.js
@@ -36,6 +36,13 @@ export default class LogSeries extends Distribution {
     }]
   }
 
+  static _fitInit (data) {
+    // E[X] ≈ 1/(1-p)^2 for p near 1; inverting gives p ≈ 1 - 1/sqrt(mean).
+    // See solutions/distribution/2026-05-28-1120-log-series-fitinit-asymptotic-inversion.md
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [Math.max(0.01, Math.min(0.99, 1 - 1 / Math.sqrt(mean)))]
+  }
+
   _generator () {
     // Direct sampling
     return Math.floor(1 + Math.log(this.r.next()) / Math.log(1 - Math.pow(1 - this.p.p, this.r.next())))

--- a/src/dist/logarithmic.js
+++ b/src/dist/logarithmic.js
@@ -44,6 +44,15 @@ export default class Logarithmic extends Distribution {
     }
   }
 
+  static _fitInit (data) {
+    // Support is [a, b]; sample min/max are the natural boundary estimators for bounded support.
+    const minVal = data.reduce((m, x) => x < m ? x : m, data[0])
+    const maxVal = data.reduce((m, x) => x > m ? x : m, data[0])
+    const a = Math.max(1, minVal)
+    const b = Math.max(a + 0.01, maxVal)
+    return [a, b]
+  }
+
   _generator () {
     // Inverse transform sampling
     return this._q(this.r.next())

--- a/src/dist/negative-binomial.js
+++ b/src/dist/negative-binomial.js
@@ -42,6 +42,17 @@ export default class NegativeBinomial extends Distribution {
     }]
   }
 
+  static _fitInit (data) {
+    // Method-of-moments: Var/E = 1/(1-p) gives p = 1 - E/V; r = E*(1-p)/p.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const variance = data.reduce((s, x) => s + x * x, 0) / data.length - mean * mean
+    if (variance <= mean) {
+      return [Math.max(1, Math.round(mean)), 0.5]
+    }
+    const p = 1 - mean / variance
+    return [Math.max(1, Math.round(mean * (1 - p) / p)), Math.min(0.99, p)]
+  }
+
   _generator () {
     // p=0 is degenerate: all mass at 0
     if (this.p.p === 0) return 0

--- a/src/dist/negative-hypergeometric.js
+++ b/src/dist/negative-hypergeometric.js
@@ -19,6 +19,14 @@ export default class NegativeHypergeometric extends Categorical {
    * @param {number} K Total number of successes. If not an integer, it is rounded to the nearest one.
    * @param {number} r Total number of failures to stop at. If not an integer, it is rounded to the nearest one.
    */
+  static _fitInit (data) {
+    // Rough seed: N = 2*max+2, K = N/2, r = 1; Nelder-Mead refines from this.
+    const maxVal = data.reduce((m, x) => x > m ? x : m, 0)
+    const N = 2 * maxVal + 2
+    const K = Math.max(1, Math.round(N / 2))
+    return [N, K, 1]
+  }
+
   constructor (N, K, r) {
     // Validate parameters
     const Ni = Math.round(N)

--- a/src/dist/neyman-a.js
+++ b/src/dist/neyman-a.js
@@ -46,6 +46,14 @@ export default class NeymanA extends PreComputed {
     }
   }
 
+  static _fitInit (data) {
+    // E[X] = lambda*phi, Var[X] = lambda*phi*(1+phi); solving gives phi = V/E - 1.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const variance = data.reduce((s, x) => s + x * x, 0) / data.length - mean * mean
+    const phi = Math.max(0.01, variance / mean - 1)
+    return [Math.max(0.01, mean / phi), phi]
+  }
+
   // Using Eq. (131) in Johnson, Kotz, Kemp: Univariate Discrete Distributions.
   _pk (k) {
     if (k === 0) {

--- a/src/dist/polya-aeppli.js
+++ b/src/dist/polya-aeppli.js
@@ -45,6 +45,18 @@ export default class PolyaAeppli extends PreComputed {
     }
   }
 
+  static _fitInit (data) {
+    // Var/E = (1+theta)/(1-theta); solving gives theta = (ratio-1)/(ratio+1), lambda = E*(1-theta).
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const variance = data.reduce((s, x) => s + x * x, 0) / data.length - mean * mean
+    if (variance <= mean) {
+      return [Math.max(0.01, mean / 2), 0.5]
+    }
+    const ratio = variance / mean
+    const theta = Math.max(0.01, Math.min(0.99, (ratio - 1) / (ratio + 1)))
+    return [Math.max(0.01, mean * (1 - theta)), theta]
+  }
+
   _pk (k) {
     if (k === 0) {
       return -this.p.lambda

--- a/src/dist/skellam.js
+++ b/src/dist/skellam.js
@@ -46,6 +46,13 @@ export default class Skellam extends Distribution {
     }
   }
 
+  static _fitInit (data) {
+    // E[X] = mu1-mu2, Var[X] = mu1+mu2; solving gives mu1 = (E+V)/2, mu2 = (V-E)/2.
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    const variance = data.reduce((s, x) => s + x * x, 0) / data.length - mean * mean
+    return [Math.max(0.01, (mean + variance) / 2), Math.max(0.01, (variance - mean) / 2)]
+  }
+
   _generator () {
     // Direct sampling
     return poisson(this.r, this.p.mu1) - poisson(this.r, this.p.mu2)

--- a/src/dist/yule-simon.js
+++ b/src/dist/yule-simon.js
@@ -40,6 +40,12 @@ export default class YuleSimon extends Distribution {
     }
   }
 
+  static _fitInit (data) {
+    // E[X] = rho/(rho-1) for rho>1; solving gives rho = mean/(mean-1).
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [mean > 1 ? mean / (mean - 1) : 2]
+  }
+
   _generator () {
     // Direct sampling by compounding exponential and geometric
     const e1 = -Math.log(this.r.next())

--- a/src/dist/zeta.js
+++ b/src/dist/zeta.js
@@ -43,6 +43,12 @@ export default class Zeta extends Distribution {
     }
   }
 
+  static _fitInit (data) {
+    // Hill estimator gives MLE for the power-law exponent on integer support starting at 1.
+    const sumLog = data.reduce((s, x) => s + Math.log(x), 0)
+    return [sumLog <= 0 ? 2 : Math.max(1.01, Math.min(100, 1 + data.length / sumLog))]
+  }
+
   _generator () {
     // Rejection sampling
     return zeta(this.r, this.p.s)

--- a/src/dist/zipf.js
+++ b/src/dist/zipf.js
@@ -18,6 +18,13 @@ export default class Zipf extends Categorical {
    * @param {number} s Exponent of the distribution.
    * @param {number} N Number of words. If not an integer, it is rounded to the nearest integer. Default is 100.
    */
+  static _fitInit (data) {
+    // N ≈ max(data) as support size; Hill estimator gives MLE for power-law exponent s.
+    const N = data.reduce((m, x) => x > m ? x : m, 1)
+    const sumLog = data.reduce((s, x) => s + Math.log(x), 0)
+    return [sumLog <= 0 ? 1 : Math.max(0.01, Math.min(100, 1 + data.length / sumLog)), N]
+  }
+
   constructor (s, N) {
     const Ni = Math.round(N)
     super(Array.from({ length: Ni }, (d, i) => Math.pow(i + 1, -s)), 1)

--- a/test/dist.js
+++ b/test/dist.js
@@ -677,6 +677,136 @@ describe('dist', () => {
         const fittedMean = result.p.weights.reduce((s, w, i) => s + w / result.p.rates[i], 0)
         assert(Math.abs(fittedMean - sampleMean) < 0.2)
       })
+
+      it('Zeta.fit should recover s close to planted value', () => {
+        const data = new dist.Zeta(2.5).seed(42).sample(500)
+        const result = dist.Zeta.fit(data)
+        assert(result instanceof dist.Zeta)
+        assert(Math.abs(result.p.s - 2.5) < 0.3)
+      })
+
+      it('YuleSimon.fit should recover rho close to planted value', () => {
+        const data = new dist.YuleSimon(3).seed(42).sample(200)
+        const result = dist.YuleSimon.fit(data)
+        assert(result instanceof dist.YuleSimon)
+        assert(Math.abs(result.p.rho - 3) < 0.5)
+      })
+
+      it('LogSeries.fit should recover p close to planted value', () => {
+        const data = new dist.LogSeries(0.7).seed(42).sample(200)
+        const result = dist.LogSeries.fit(data)
+        assert(result instanceof dist.LogSeries)
+        assert(Math.abs(result.p.p - 0.7) < 0.05)
+      })
+
+      it('FlorySchulz.fit should recover a close to planted value', () => {
+        const data = new dist.FlorySchulz(0.4).seed(42).sample(200)
+        const result = dist.FlorySchulz.fit(data)
+        assert(result instanceof dist.FlorySchulz)
+        assert(Math.abs(result.p.a - 0.4) < 0.05)
+      })
+
+      it('NegativeBinomial.fit should return a usable NegativeBinomial instance', () => {
+        const data = new dist.NegativeBinomial(5, 0.4).seed(42).sample(200)
+        const result = dist.NegativeBinomial.fit(data)
+        assert(result instanceof dist.NegativeBinomial)
+        assert(result.p.r > 0 && result.p.p > 0 && result.p.p < 1)
+        assert(Number.isFinite(result.pdf(Math.round(5 * 0.4 / 0.6))) && result.pdf(Math.round(5 * 0.4 / 0.6)) > 0)
+      })
+
+      it('Skellam.fit should return a usable Skellam instance', () => {
+        const data = new dist.Skellam(4, 2).seed(42).sample(200)
+        const result = dist.Skellam.fit(data)
+        assert(result instanceof dist.Skellam)
+        assert(result.p.mu1 > 0 && result.p.mu2 > 0)
+        assert(Number.isFinite(result.pdf(2)) && result.pdf(2) > 0)
+      })
+
+      it('DiscreteWeibull.fit should return a usable DiscreteWeibull instance', () => {
+        const data = new dist.DiscreteWeibull(0.5, 1.5).seed(42).sample(200)
+        const result = dist.DiscreteWeibull.fit(data)
+        assert(result instanceof dist.DiscreteWeibull)
+        assert(result.p.q > 0 && result.p.q < 1 && result.p.beta > 0)
+        assert(Number.isFinite(result.pdf(0)) && result.pdf(0) > 0)
+      })
+
+      it('Logarithmic.fit should recover a and b close to planted values', () => {
+        const data = new dist.Logarithmic(1, 5).seed(42).sample(200)
+        const result = dist.Logarithmic.fit(data)
+        assert(result instanceof dist.Logarithmic)
+        assert(Math.abs(result.p.a - 1) < 0.2 && Math.abs(result.p.b - 5) < 0.3)
+      })
+
+      it('ExponentialLogarithmic.fit should return a usable ExponentialLogarithmic instance', () => {
+        const data = new dist.ExponentialLogarithmic(0.7, 1).seed(42).sample(200)
+        const result = dist.ExponentialLogarithmic.fit(data)
+        assert(result instanceof dist.ExponentialLogarithmic)
+        assert(result.p.p > 0 && result.p.p < 1 && result.p.beta > 0)
+        assert(Number.isFinite(result.pdf(1)) && result.pdf(1) > 0)
+      })
+
+      it('Borel.fit should recover mu close to planted value', () => {
+        const data = new dist.Borel(0.5).seed(42).sample(200)
+        const result = dist.Borel.fit(data)
+        assert(result instanceof dist.Borel)
+        assert(Math.abs(result.p.mu - 0.5) < 0.1)
+      })
+
+      it('HeadsMinusTails.fit should return a usable HeadsMinusTails instance', () => {
+        const data = new dist.HeadsMinusTails(5).seed(42).sample(200)
+        const result = dist.HeadsMinusTails.fit(data)
+        assert(result instanceof dist.HeadsMinusTails)
+        assert(result.p.n > 0)
+        assert(Number.isFinite(result.pdf(0)) && result.pdf(0) > 0)
+      })
+
+      it('BorelTanner.fit should return a usable BorelTanner instance', () => {
+        const data = new dist.BorelTanner(0.5, 3).seed(42).sample(200)
+        const result = dist.BorelTanner.fit(data)
+        assert(result instanceof dist.BorelTanner)
+        assert(result.p.mu >= 0 && result.p.mu < 1 && result.p.n > 0)
+        assert(Number.isFinite(result.pdf(result.p.n)) && result.pdf(result.p.n) > 0)
+      })
+
+      it('ConwayMaxwellPoisson.fit should return a usable ConwayMaxwellPoisson instance', () => {
+        const data = new dist.ConwayMaxwellPoisson(3, 2).seed(42).sample(200)
+        const result = dist.ConwayMaxwellPoisson.fit(data)
+        assert(result instanceof dist.ConwayMaxwellPoisson)
+        assert(result.p.lambda > 0 && result.p.nu > 0)
+        assert(Number.isFinite(result.pdf(3)) && result.pdf(3) > 0)
+      })
+
+      it('PolyaAeppli.fit should return a usable PolyaAeppli instance', () => {
+        const data = new dist.PolyaAeppli(2, 0.5).seed(42).sample(200)
+        const result = dist.PolyaAeppli.fit(data)
+        assert(result instanceof dist.PolyaAeppli)
+        assert(result.p.lambda > 0 && result.p.theta > 0 && result.p.theta < 1)
+        assert(Number.isFinite(result.pdf(2)) && result.pdf(2) > 0)
+      })
+
+      it('NeymanA.fit should return a usable NeymanA instance', () => {
+        const data = new dist.NeymanA(3, 2).seed(42).sample(200)
+        const result = dist.NeymanA.fit(data)
+        assert(result instanceof dist.NeymanA)
+        assert(result.p.lambda > 0 && result.p.phi > 0)
+        assert(Number.isFinite(result.pdf(6)) && result.pdf(6) > 0)
+      })
+
+      it('GeneralizedHermite.fit should return a usable GeneralizedHermite instance', () => {
+        const data = new dist.GeneralizedHermite(1, 0.5, 2).seed(42).sample(200)
+        const result = dist.GeneralizedHermite.fit(data)
+        assert(result instanceof dist.GeneralizedHermite)
+        assert(result.p.a1 > 0 && result.p.a2 > 0 && result.p.m > 1)
+        assert(Number.isFinite(result.pdf(2)) && result.pdf(2) > 0)
+      })
+
+      it('Delaporte.fit should return a usable Delaporte instance', () => {
+        const data = new dist.Delaporte(2, 1, 1).seed(42).sample(200)
+        const result = dist.Delaporte.fit(data)
+        assert(result instanceof dist.Delaporte)
+        assert(result.p.alpha > 0 && result.p.beta > 0 && result.p.lambda > 0)
+        assert(Number.isFinite(result.pdf(3)) && result.pdf(3) > 0)
+      })
     })
   })
 
@@ -701,6 +831,45 @@ describe('dist', () => {
       // cdfTable[0] = 0.5+eps, cdfTable[1] ≈ 1 + 2eps > 1; re-reading from cache must still return ≤ 1
       assert.isAtMost(d._cdf(0), 1)
       assert.isAtMost(d._cdf(1), 1)
+    })
+  })
+
+  describe('.fit() Categorical subclasses', () => {
+    it('Binomial.fit should recover PMF close to planted values', () => {
+      const data = new dist.Binomial(10, 0.3).seed(42).sample(200)
+      const result = dist.Binomial.fit(data)
+      assert(result instanceof dist.Binomial)
+      assert(Number.isFinite(result.pdf(3)) && result.pdf(3) > 0)
+      assert(Math.abs(result.pdf(3) - new dist.Binomial(10, 0.3).pdf(3)) < 0.05)
+    })
+
+    it('Zipf.fit should return a usable Zipf instance', () => {
+      const data = new dist.Zipf(2, 50).seed(42).sample(200)
+      const result = dist.Zipf.fit(data)
+      assert(result instanceof dist.Zipf)
+      assert(Number.isFinite(result.pdf(1)) && result.pdf(1) > 0)
+      assert(Math.abs(result.pdf(1) - new dist.Zipf(2, 50).pdf(1)) < 0.1)
+    })
+
+    it('Hypergeometric.fit should return a usable Hypergeometric instance', () => {
+      const data = new dist.Hypergeometric(20, 10, 8).seed(42).sample(200)
+      const result = dist.Hypergeometric.fit(data)
+      assert(result instanceof dist.Hypergeometric)
+      assert(Number.isFinite(result.pdf(4)) && result.pdf(4) > 0)
+    })
+
+    it('NegativeHypergeometric.fit should return a usable NegativeHypergeometric instance', () => {
+      const data = new dist.NegativeHypergeometric(20, 10, 3).seed(42).sample(200)
+      const result = dist.NegativeHypergeometric.fit(data)
+      assert(result instanceof dist.NegativeHypergeometric)
+      assert(Number.isFinite(result.pdf(2)) && result.pdf(2) > 0)
+    })
+
+    it('BetaBinomial.fit should return a usable BetaBinomial instance', () => {
+      const data = new dist.BetaBinomial(10, 2, 3).seed(42).sample(200)
+      const result = dist.BetaBinomial.fit(data)
+      assert(result instanceof dist.BetaBinomial)
+      assert(Number.isFinite(result.pdf(4)) && result.pdf(4) > 0)
     })
   })
 


### PR DESCRIPTION
Closes #438

## Summary
- Adds `static _fitInit(data)` method-of-moments initializers to 22 discrete (and 2 continuous) distributions so that `Cls.fit(data)` starts Nelder-Mead from a data-aware seed instead of a random draw from `(0, 5)`.
- 2 of the 24 distributions in scope (`BetaGeometric`, `BetaNegativeBinomial`) are skipped — both are commented out of `src/dist/index.js` and have incomplete implementations; a follow-up issue (#475) tracks the anonymous-class fix for `BetaGeometric`.
- During code review, the `LogSeries` asymptotic inversion was corrected from `p ≈ 1 - 1/mean` to `p ≈ 1 - 1/sqrt(mean)` (E[X] ≈ 1/(1-p)² near p→1, not 1/(1-p)); and `Zeta`/`Zipf` Hill estimators gained a `sumLog ≤ 0` guard to prevent an `s = Infinity` seed when all data equal 1.

## Design decisions
- [ADR-0012: Distribution fit via Nelder-Mead](decisions/0012-distribution-fit-nelder-mead.md) — establishes the `_fitInit` hook pattern this PR implements.

## Non-trivial changes
- **`src/dist/log-series.js`**: Corrected asymptotic inversion: `1 - 1/mean` → `1 - 1/sqrt(mean)`. The log-series mean is E[X] ≈ 1/(1-p)² near p→1, so inverting with the linear formula systematically underestimates p. See `solutions/distribution/2026-05-28-1120-log-series-fitinit-asymptotic-inversion.md`.
- **`src/dist/zeta.js`, `src/dist/zipf.js`**: Added `sumLog ≤ 0 → return default` guard on the Hill estimator to prevent `s = Infinity` when all observations equal 1, which would trap the optimizer at a boundary cliff.
- **22 `src/dist/*.js` files**: Each adds a `static _fitInit(data)` override with a one-line WHY comment. Formulas are standard MoM: mean/variance equations solved for the distribution's natural parameters. `Math.max.apply` replaced with `reduce()` throughout to avoid call-stack overflow on large arrays.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `[Unreleased] → Added` entry for the 22 new `_fitInit` overrides.
- **`test/dist.js`**: 22 new `it()` blocks — one per distribution — asserting `Cls.fit(syntheticData)` returns a valid instance and produces finite pdf values at a representative point.
- **`solutions/distribution/2026-05-28-1120-log-series-fitinit-asymptotic-inversion.md`**: Solution document capturing the log-series asymptotic inversion pitfall for future sessions.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHxhBD4SGegR3ZUAgP4LMr)_