### PR TITLE
Add _fitInit MOM overrides for 9 Gamma-family distributions

### DIFF
--- a/src/dist/chi2.js
+++ b/src/dist/chi2.js
@@ -25,4 +25,10 @@ export default class Chi2 extends Gamma {
       'k > 0'
     ])
   }
+
+  static _fitInit (data) {
+    // E[X] = k, so the sample mean directly estimates the degrees of freedom
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [Math.max(1, Math.round(mean))]
+  }
 }

--- a/src/dist/double-gamma.js
+++ b/src/dist/double-gamma.js
@@ -44,4 +44,13 @@ export default class DoubleGamma extends Gamma {
     const y = super._cdf(Math.abs(x))
     return (x > 0 ? 1 + y : 1 - y) / 2
   }
+
+  static _fitInit (data) {
+    // |X| ~ Gamma(α,β): gamma MOM on absolute values
+    const n = data.length
+    const absData = data.map(x => Math.abs(x))
+    const mean = absData.reduce((s, x) => s + x, 0) / n
+    const variance = absData.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1
+    return [mean ** 2 / variance, mean / variance]
+  }
 }

--- a/src/dist/erlang.js
+++ b/src/dist/erlang.js
@@ -28,4 +28,12 @@ export default class Erlang extends Gamma {
       'lambda > 0'
     ])
   }
+
+  static _fitInit (data) {
+    // MOM: E[X]=k/λ, Var[X]=k/λ² → k = round(mean²/var), λ = mean/var
+    const n = data.length
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1
+    return [Math.max(1, Math.round(mean ** 2 / variance)), mean / variance]
+  }
 }

--- a/src/dist/gamma-gompertz.js
+++ b/src/dist/gamma-gompertz.js
@@ -57,4 +57,10 @@ export default class GammaGompertz extends Distribution {
   _q (p) {
     return Math.log(1 + this.p.beta * (Math.pow(1 - p, -1 / this.p.s) - 1)) / this.p.b
   }
+
+  static _fitInit (data) {
+    // Seed b ≈ 1/mean as approximate rate; extra shapes s, β seeded at neutral values for Nelder-Mead
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [1 / Math.max(mean, 1e-6), 1, 2]
+  }
 }

--- a/src/dist/gamma.js
+++ b/src/dist/gamma.js
@@ -56,4 +56,12 @@ export default class Gamma extends Distribution {
   _q (p) {
     return gammaLowerIncompleteInv(this.p.alpha, p) / this.p.beta
   }
+
+  static _fitInit (data) {
+    // MOM: E[X]=α/β, Var[X]=α/β² → α = mean²/var, β = mean/var
+    const n = data.length
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1
+    return [mean ** 2 / variance, mean / variance]
+  }
 }

--- a/src/dist/generalized-gamma.js
+++ b/src/dist/generalized-gamma.js
@@ -53,4 +53,12 @@ export default class GeneralizedGamma extends Gamma {
   _cdf (x) {
     return super._cdf(Math.pow(x, this.p.p))
   }
+
+  static _fitInit (data) {
+    // p=1 collapses to Gamma(d, 1/a): E[X]=a·d, Var[X]=a²·d → d=mean²/var, a=var/mean
+    const n = data.length
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1
+    return [variance / mean, mean ** 2 / variance, 1]
+  }
 }

--- a/src/dist/inverse-chi2.js
+++ b/src/dist/inverse-chi2.js
@@ -52,4 +52,10 @@ export default class InverseChi2 extends Distribution {
     // See solutions/correctness/2026-05-18-1133-inverse-chi2-cdf-complementary-gamma.md
     return gammaUpperIncomplete(this.p.nu / 2, 0.5 / x)
   }
+
+  static _fitInit (data) {
+    // E[X] = 1/(ν−2) for ν > 2, so ν ≈ 2 + 1/mean; floor mean to avoid Infinity from near-zero mean
+    const mean = data.reduce((s, x) => s + x, 0) / data.length
+    return [Math.max(3, Math.round(2 + 1 / Math.max(mean, 1e-6)))]
+  }
 }

--- a/src/dist/inverse-gamma.js
+++ b/src/dist/inverse-gamma.js
@@ -49,4 +49,13 @@ export default class InverseGamma extends Gamma {
     // CDF = Q(alpha, beta/x) = p → beta/x = invGL(alpha, 1-p) → x = beta / invGL(alpha, 1-p)
     return this.p.beta / gammaLowerIncompleteInv(this.p.alpha, 1 - p)
   }
+
+  static _fitInit (data) {
+    // E[X]=β/(α−1), Var/E²=1/(α−2) → α = 2 + mean²/var, β = mean·(α−1)
+    const n = data.length
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1
+    const alpha = 2 + mean ** 2 / variance
+    return [alpha, mean * (alpha - 1)]
+  }
 }

--- a/src/dist/log-gamma.js
+++ b/src/dist/log-gamma.js
@@ -51,4 +51,13 @@ export default class LogGamma extends Gamma {
   _cdf (x) {
     return super._cdf(Math.log(x - this.p.mu + 1))
   }
+
+  static _fitInit (data) {
+    // log(x−μ+1) ~ Gamma(α,β) with μ=0: gamma MOM on log(x+1) seeds the Gamma parameters
+    const n = data.length
+    const transformed = data.map(x => Math.log(x + 1))
+    const mean = transformed.reduce((s, x) => s + x, 0) / n
+    const variance = transformed.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1
+    return [mean ** 2 / variance, mean / variance, 0]
+  }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -423,10 +423,10 @@ describe('dist', () => {
       })
 
       it('Distribution._fitInit fallback should work for scalar-constructor distributions', () => {
-        // Gamma has no _fitInit override so fit() exercises the base-class random-retry path
-        const data = new dist.Gamma(2, 0.5).seed(42).sample(100)
-        const result = dist.Gamma.fit(data)
-        assert(result instanceof dist.Gamma)
+        // BetaPrime has no _fitInit override so fit() exercises the base-class random-retry path
+        const data = new dist.BetaPrime(2, 3).seed(42).sample(100)
+        const result = dist.BetaPrime.fit(data)
+        assert(result instanceof dist.BetaPrime)
       })
 
       it('Pareto.fit should recover xmin close to min(data)', () => {
@@ -888,6 +888,76 @@ describe('dist', () => {
         assert(Math.abs(result.p.mu - 1) < 0.5)
         assert(Math.abs(result.p.s - 2) < 0.6)
         assert(Math.abs(result.p.c - 2) < 0.6)
+      })
+
+      it('Gamma.fit should recover alpha and beta close to planted values', () => {
+        const data = new dist.Gamma(2, 0.5).seed(42).sample(200)
+        const result = dist.Gamma.fit(data)
+        assert(result instanceof dist.Gamma)
+        assert(Math.abs(result.p.alpha - 2) < 0.4)
+        assert(Math.abs(result.p.beta - 0.5) < 0.15)
+      })
+
+      it('InverseGamma.fit should recover alpha and beta close to planted values', () => {
+        const data = new dist.InverseGamma(3, 2).seed(42).sample(200)
+        const result = dist.InverseGamma.fit(data)
+        assert(result instanceof dist.InverseGamma)
+        assert(Math.abs(result.p.alpha - 3) < 0.6)
+        assert(Math.abs(result.p.beta - 2) < 0.8)
+      })
+
+      it('Erlang.fit should recover k and lambda close to planted values', () => {
+        const data = new dist.Erlang(3, 1).seed(42).sample(200)
+        const result = dist.Erlang.fit(data)
+        assert(result instanceof dist.Erlang)
+        assert(Math.abs(result.p.alpha - 3) <= 1)
+        assert(Math.abs(result.p.beta - 1) < 0.25)
+      })
+
+      it('Chi2.fit should recover k close to planted value', () => {
+        const data = new dist.Chi2(4).seed(42).sample(200)
+        const result = dist.Chi2.fit(data)
+        assert(result instanceof dist.Chi2)
+        assert(Math.abs(result.p.alpha * 2 - 4) <= 1)
+      })
+
+      it('InverseChi2.fit should recover nu close to planted value', () => {
+        const data = new dist.InverseChi2(6).seed(42).sample(200)
+        const result = dist.InverseChi2.fit(data)
+        assert(result instanceof dist.InverseChi2)
+        assert(Math.abs(result.p.nu - 6) <= 1)
+      })
+
+      it('LogGamma.fit should recover alpha and beta close to planted values', () => {
+        const data = new dist.LogGamma(2, 1, 0).seed(42).sample(200)
+        const result = dist.LogGamma.fit(data)
+        assert(result instanceof dist.LogGamma)
+        assert(Math.abs(result.p.alpha - 2) < 0.6)
+        assert(Math.abs(result.p.beta - 1) < 0.4)
+      })
+
+      it('GeneralizedGamma.fit should return a usable GeneralizedGamma instance', () => {
+        const data = new dist.GeneralizedGamma(2, 3, 1).seed(42).sample(200)
+        const result = dist.GeneralizedGamma.fit(data)
+        assert(result instanceof dist.GeneralizedGamma)
+        assert(result.p.a > 0 && result.p.d > 0 && result.p.p > 0)
+        assert(Number.isFinite(result.pdf(4)) && result.pdf(4) > 0)
+      })
+
+      it('GammaGompertz.fit should return a usable GammaGompertz instance', () => {
+        const data = new dist.GammaGompertz(1, 2, 3).seed(42).sample(200)
+        const result = dist.GammaGompertz.fit(data)
+        assert(result instanceof dist.GammaGompertz)
+        assert(result.p.b > 0 && result.p.s > 0 && result.p.beta > 0)
+        assert(Number.isFinite(result.pdf(1)) && result.pdf(1) > 0)
+      })
+
+      it('DoubleGamma.fit should recover alpha and beta close to planted values', () => {
+        const data = new dist.DoubleGamma(2, 0.5).seed(42).sample(200)
+        const result = dist.DoubleGamma.fit(data)
+        assert(result instanceof dist.DoubleGamma)
+        assert(Math.abs(result.p.alpha - 2) < 0.4)
+        assert(Math.abs(result.p.beta - 0.5) < 0.15)
       })
     })
   })


### PR DESCRIPTION
Closes #431

## Summary
- Adds `static _fitInit(data)` to Gamma, InverseGamma, Erlang, Chi2, InverseChi2, LogGamma, GeneralizedGamma, GammaGompertz, and DoubleGamma, seeding Nelder-Mead from `mean²/var` (shape) and `var/mean` (scale)
- Distributions with extra shape parameters (GeneralizedGamma, GammaGompertz) seed them at neutral defaults since their moment systems are underdetermined with only 2 moments
- Variance fallback uses `|| 1` rather than `|| mean` to prevent NaN propagation when sample variance is zero

## Design decisions
- [ADR-0012: Distribution.fit() Static MLE Method via Nelder-Mead + _fitInit Hook](decisions/0012-distribution-fit-nelder-mead.md) — this PR is a per-distribution rollout step in the abstract-method-first plan described in the ADR

## Non-trivial changes
- **`src/dist/gamma.js`**: Standard gamma MOM: `α = mean²/var`, `β = mean/var`; inherited by Erlang, LogGamma, GeneralizedGamma, DoubleGamma which share the same Gamma base
- **`src/dist/inverse-gamma.js`**: MOM derived from `Var/E² = 1/(α−2)` → `α = 2 + mean²/var`, `β = mean·(α−1)`; non-obvious because the scale β enters the variance formula differently from the Gamma rate
- **`src/dist/inverse-chi2.js`**: Mean inversion `E[X] = 1/(ν−2)` → `ν ≈ 2 + 1/mean`; guarded with `Math.max(mean, 1e-6)` to prevent Infinity for near-zero mean data
- **`src/dist/log-gamma.js`**: Applies gamma MOM to the transformed variable `log(x+1)` (which is Gamma-distributed when μ=0); seeds μ=0 and lets Nelder-Mead drift it
- **`src/dist/generalized-gamma.js`**: Seeds `p=1` to collapse to Gamma, then derives `a=var/mean`, `d=mean²/var` from Gamma MOM at that reduction
- **`src/dist/gamma-gompertz.js`**: No closed-form moments; heuristic seed `b≈1/mean`, `s=1`, `β=2` gives Nelder-Mead a finite, valid starting point

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: 9 new `fit()` recovery tests (one per distribution); updated base-class fallback test to use `BetaPrime` now that `Gamma` has its own `_fitInit`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_017oc8icz3himEoD3T1oPHto)_