### PR TITLE
Add _fitInit MOM overrides for Beta-family distributions

### DIFF
--- a/src/dist/arcsine.js
+++ b/src/dist/arcsine.js
@@ -46,6 +46,15 @@ export default class Arcsine extends Distribution {
     }
   }
 
+  static _fitInit (data) {
+    // E[X]=(a+b)/2, Var[X]=(b−a)²/8: invert to get a = mean−√(2·var), b = mean+√(2·var)
+    const n = data.length
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1
+    const halfRange = Math.sqrt(2 * variance)
+    return [mean - halfRange, mean + halfRange]
+  }
+
   _generator () {
     // Inverse transform sampling
     return this._q(this.r.next())

--- a/src/dist/beta-prime.js
+++ b/src/dist/beta-prime.js
@@ -33,6 +33,16 @@ export default class BetaPrime extends Beta {
     }]
   }
 
+  static _fitInit (data) {
+    // y = x/(1+x) maps BetaPrime's (0,∞) support to (0,1); Beta MOM in that space recovers (α,β)
+    const n = data.length
+    const y = data.map(x => x / (1 + x))
+    const mean = y.reduce((s, x) => s + x, 0) / n
+    const variance = y.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1e-4
+    const factor = Math.max(mean * (1 - mean) / variance - 1, 0.1)
+    return [mean * factor, (1 - mean) * factor]
+  }
+
   _generator () {
     // Direct sampling from gamma (ignoring super)
     const x = gamma(this.r, this.p.alpha, 1)

--- a/src/dist/beta.js
+++ b/src/dist/beta.js
@@ -46,6 +46,15 @@ export default class Beta extends Distribution {
     }
   }
 
+  static _fitInit (data) {
+    // Beta MOM: α = x̄·φ, β = (1−x̄)·φ, φ = x̄(1−x̄)/var − 1
+    const n = data.length
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1e-4
+    const factor = Math.max(mean * (1 - mean) / variance - 1, 0.1)
+    return [mean * factor, (1 - mean) * factor]
+  }
+
   _generator () {
     // Direct generation
     return rBeta(this.r, this.p.alpha, this.p.beta)

--- a/src/dist/kumaraswamy.js
+++ b/src/dist/kumaraswamy.js
@@ -37,6 +37,15 @@ export default class Kumaraswamy extends Distribution {
     }]
   }
 
+  static _fitInit (data) {
+    // Beta MOM on (0,1) data gives a close-enough (a,b) starting point for Nelder-Mead
+    const n = data.length
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1e-4
+    const factor = Math.max(mean * (1 - mean) / variance - 1, 0.1)
+    return [mean * factor, (1 - mean) * factor]
+  }
+
   _generator () {
     // Inverse transform sampling
     return this._q(this.r.next())

--- a/src/dist/mielke.js
+++ b/src/dist/mielke.js
@@ -35,4 +35,14 @@ export default class Mielke extends Dagum {
       closed: false
     }]
   }
+
+  static _fitInit (data) {
+    // y = x/(1+x) compresses (0,∞) to (0,1); Beta MOM on y gives (k,s) concentration estimates
+    const n = data.length
+    const y = data.map(x => x / (1 + x))
+    const mean = y.reduce((s, x) => s + x, 0) / n
+    const variance = y.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1e-4
+    const factor = Math.max(mean * (1 - mean) / variance - 1, 0.1)
+    return [mean * factor, (1 - mean) * factor]
+  }
 }

--- a/src/dist/power-law.js
+++ b/src/dist/power-law.js
@@ -19,4 +19,11 @@ export default class PowerLaw extends Kumaraswamy {
   constructor (a) {
     super(a, 1)
   }
+
+  static _fitInit (data) {
+    // f(x)=a·x^{a−1} → E[log X] = −1/a; MLE is a = −1/mean(log x), closed-form
+    const n = data.length
+    const logMean = data.reduce((s, x) => s + Math.log(x), 0) / n
+    return [Math.max(-1 / logMean, 0.1)]
+  }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -423,10 +423,10 @@ describe('dist', () => {
       })
 
       it('Distribution._fitInit fallback should work for scalar-constructor distributions', () => {
-        // BetaPrime has no _fitInit override so fit() exercises the base-class random-retry path
-        const data = new dist.BetaPrime(2, 3).seed(42).sample(100)
-        const result = dist.BetaPrime.fit(data)
-        assert(result instanceof dist.BetaPrime)
+        // Burr has no _fitInit override so fit() exercises the base-class random-retry path
+        const data = new dist.Burr(2, 3).seed(42).sample(100)
+        const result = dist.Burr.fit(data)
+        assert(result instanceof dist.Burr)
       })
 
       it('Pareto.fit should recover xmin close to min(data)', () => {
@@ -958,6 +958,54 @@ describe('dist', () => {
         assert(result instanceof dist.DoubleGamma)
         assert(Math.abs(result.p.alpha - 2) < 0.4)
         assert(Math.abs(result.p.beta - 0.5) < 0.15)
+      })
+
+      it('Beta.fit should recover alpha and beta close to planted values', () => {
+        const data = new dist.Beta(2, 3).seed(42).sample(200)
+        const result = dist.Beta.fit(data)
+        assert(result instanceof dist.Beta)
+        assert(Math.abs(result.p.alpha - 2) < 0.6)
+        assert(Math.abs(result.p.beta - 3) < 0.8)
+      })
+
+      it('BetaPrime.fit should recover alpha and beta close to planted values', () => {
+        const data = new dist.BetaPrime(2, 3).seed(42).sample(200)
+        const result = dist.BetaPrime.fit(data)
+        assert(result instanceof dist.BetaPrime)
+        assert(Math.abs(result.p.alpha - 2) < 0.7)
+        assert(Math.abs(result.p.beta - 3) < 1.0)
+      })
+
+      it('Kumaraswamy.fit should recover a and b close to planted values', () => {
+        const data = new dist.Kumaraswamy(2, 3).seed(42).sample(200)
+        const result = dist.Kumaraswamy.fit(data)
+        assert(result instanceof dist.Kumaraswamy)
+        assert(Math.abs(result.p.a - 2) < 0.7)
+        assert(Math.abs(result.p.b - 3) < 1.0)
+      })
+
+      it('PowerLaw.fit should recover a close to planted value', () => {
+        const data = new dist.PowerLaw(2).seed(42).sample(200)
+        const result = dist.PowerLaw.fit(data)
+        assert(result instanceof dist.PowerLaw)
+        assert(Math.abs(result.p.a - 2) < 0.4)
+      })
+
+      it('Arcsine.fit should recover a and b close to planted values', () => {
+        const data = new dist.Arcsine(1, 5).seed(42).sample(200)
+        const result = dist.Arcsine.fit(data)
+        assert(result instanceof dist.Arcsine)
+        assert(Math.abs(result.p.a - 1) < 0.4)
+        assert(Math.abs(result.p.b - 5) < 0.4)
+      })
+
+      it('Mielke.fit should recover k and s close to planted values', () => {
+        const data = new dist.Mielke(2, 1).seed(42).sample(200)
+        const result = dist.Mielke.fit(data)
+        assert(result instanceof dist.Mielke)
+        // Mielke stores params via Dagum: p.p = k/s, p.a = s, so k = p.p * p.a
+        assert(Math.abs(result.p.p * result.p.a - 2) < 0.6)
+        assert(Math.abs(result.p.a - 1) < 0.5)
       })
     })
   })


### PR DESCRIPTION
Closes #432

## Summary
- Adds `static _fitInit(data)` method-of-moments overrides to Beta, BetaPrime, Kumaraswamy, PowerLaw, Arcsine, and Mielke so `fit()` starts Nelder-Mead from an informed estimate rather than a random retry.
- Strategy: Beta/Kumaraswamy use direct Beta MOM on (0,1) data; BetaPrime/Mielke first apply `y = x/(1+x)` to compress unbounded support to (0,1) before applying Beta MOM; Arcsine inverts its exact moment equations; PowerLaw uses the closed-form MLE `a = −1/mean(log x)`.
- Six new fit-recovery tests added; the base-class fallback test updated from BetaPrime (which now has its own override) to Burr.

## Design decisions
- [ADR-0012: Distribution fit via Nelder-Mead](decisions/0012-distribution-fit-nelder-mead.md) — governs the `_fitInit` hook contract and Nelder-Mead optimizer used by `fit()`.

## Non-trivial changes
- **`src/dist/beta.js`**: Beta MOM `α = x̄·φ, β = (1−x̄)·φ` where `φ = x̄(1−x̄)/var − 1`; factor clamped to 0.1 to guard against high-variance degenerate data.
- **`src/dist/beta-prime.js`**: Transform `y = x/(1+x)` maps BetaPrime's (0,∞) support to (0,1); then Beta MOM on y recovers (α, β) exactly.
- **`src/dist/kumaraswamy.js`**: Beta MOM used as an approximation on (0,1) data; exact Kumaraswamy MOM requires digamma inversion so this gives a close-enough starting point.
- **`src/dist/power-law.js`**: For `f(x)=a·x^{a−1}`, `E[log X] = −1/a`; the closed-form MLE `a = −1/mean(log x)` is used directly (no iteration needed).
- **`src/dist/arcsine.js`**: Exact MOM inversion: `E[X]=(a+b)/2`, `Var[X]=(b−a)²/8` → `a = mean−√(2·var)`, `b = mean+√(2·var)`.
- **`src/dist/mielke.js`**: Same `y = x/(1+x)` transform as BetaPrime; for `s=1` this is exact (gives Beta(k,1)); for other s it places Nelder-Mead in the right neighbourhood.
- **`test/dist.js`**: Fallback test switched from BetaPrime (now has override) to Burr; six fit-recovery tests added, one per distribution.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: BetaPrime fallback test comment updated to reflect new override.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2vgtJkpT3wowdn784cREZ)_