### PR TITLE
Add _fitInit overrides for 10 bounded-support distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `_fitInit` data-aware initializers added to 10 bounded-support continuous distributions (`Bates`, `Triangular`, `Trapezoidal`, `PERT`, `BetaRectangular`, `UQuadratic`, `Uniform`, `UniformProduct`, `Anglit`, `RaisedCosine`); support endpoints are seeded from sample min/max and shape parameters from method-of-moments estimates, eliminating the random-retry fallback for these distributions (#433).
 - `_fitInit` data-aware method-of-moments initializers added to 22 discrete distributions (`Binomial`, `NegativeBinomial`, `Skellam`, `DiscreteWeibull`, `Zeta`, `YuleSimon`, `LogSeries`, `FlorySchulz`, `Borel`, `BorelTanner`, `HeadsMinus Tails`, `ConwayMaxwellPoisson`, `PolyaAeppli`, `NeymanA`, `GeneralizedHermite`, `Delaporte`, `Zipf`, `Hypergeometric`, `NegativeHypergeometric`, `BetaBinomial`, `Logarithmic`, `ExponentialLogarithmic`); `Cls.fit(data)` now starts Nelder-Mead from a moment-matched seed instead of a random draw (#438).
 - `gaussLegendre(f, a, b, n)` algorithm: fixed-order Gauss-Legendre quadrature with precomputed nodes and weights for n=5, 10, and 20; exact for polynomials of degree ≤ 2n−1 (#402).
 - `Distribution.fit(data)` static method for maximum-likelihood parameter estimation via Nelder-Mead simplex optimizer (#404)

--- a/src/dist/anglit.js
+++ b/src/dist/anglit.js
@@ -62,4 +62,14 @@ export default class Anglit extends Distribution {
   _q (p) {
     return this.p.mu + this.p.beta * (Math.asin(Math.sqrt(p)) - Math.PI / 4)
   }
+
+  static _fitInit (data) {
+    // mu from sample mean (location); beta from support width: range = π·beta/2 → beta = 2·range/π
+    const n = data.length
+    const mu = data.reduce((s, x) => s + x, 0) / n
+    const lo = Math.min(...data)
+    const hi = Math.max(...data)
+    const beta = 2 * (hi - lo) / Math.PI || 1
+    return [mu, beta]
+  }
 }

--- a/src/dist/bates.js
+++ b/src/dist/bates.js
@@ -61,4 +61,18 @@ export default class Bates extends IrwinHall {
     const { scale, shift } = this.c
     return super._cdf(scale * x - shift)
   }
+
+  static _fitInit (data) {
+    // Endpoints from sample extremes; n from variance moment: Var(Bates) = (b-a)²/(12n) → n = (b-a)²/(12σ̂²)
+    const nData = data.length
+    const lo = Math.min(...data)
+    const hi = Math.max(...data)
+    const eps = (hi - lo) * 0.01 || 1e-6
+    const a = lo - eps
+    const b = hi + eps
+    const mean = data.reduce((s, x) => s + x, 0) / nData
+    const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / nData || 1
+    const n = Math.max(1, Math.round((b - a) ** 2 / (12 * variance)))
+    return [n, a, b]
+  }
 }

--- a/src/dist/beta-rectangular.js
+++ b/src/dist/beta-rectangular.js
@@ -61,4 +61,12 @@ export default class BetaRectangular extends Beta {
     const y = x - this.p.a
     return this.p.theta * super._cdf(y / this.c.bMinusA) + this.c.oneMinusTheta * y / this.c.bMinusA
   }
+
+  static _fitInit (data) {
+    // Endpoints from sample extremes; neutral shape params (2,2) and theta=0.5 avoid degenerate beta boundary
+    const lo = Math.min(...data)
+    const hi = Math.max(...data)
+    const eps = (hi - lo) * 0.01 || 1e-6
+    return [2, 2, 0.5, lo - eps, hi + eps]
+  }
 }

--- a/src/dist/pert.js
+++ b/src/dist/pert.js
@@ -50,4 +50,17 @@ export default class PERT extends Beta {
   _cdf (x) {
     return super._cdf((x - this.p.a) / (this.p.c - this.p.a))
   }
+
+  static _fitInit (data) {
+    // Endpoints from sample extremes; mode via PERT mean formula: E[X] = (a+4b+c)/6 → b = (6μ̂ - a - c)/4
+    const n = data.length
+    const lo = Math.min(...data)
+    const hi = Math.max(...data)
+    const eps = (hi - lo) * 0.01 || 1e-6
+    const a = lo - eps
+    const c = hi + eps
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const b = Math.max(a + eps, Math.min(c - eps, (6 * mean - a - c) / 4))
+    return [a, b, c]
+  }
 }

--- a/src/dist/raised-cosine.js
+++ b/src/dist/raised-cosine.js
@@ -55,4 +55,14 @@ export default class RaisedCosine extends Distribution {
     const z = (x - this.p.mu) / this.p.s
     return 0.5 * (1 + z + Math.sin(Math.PI * z) / Math.PI)
   }
+
+  static _fitInit (data) {
+    // mu from sample mean (equals center for a symmetric distribution); s from support half-range: range = 2s
+    const n = data.length
+    const mu = data.reduce((s, x) => s + x, 0) / n
+    const lo = Math.min(...data)
+    const hi = Math.max(...data)
+    const s = Math.max(1e-6, (hi - lo) / 2)
+    return [mu, s]
+  }
 }

--- a/src/dist/trapezoidal.js
+++ b/src/dist/trapezoidal.js
@@ -81,4 +81,15 @@ export default class Trapezoidal extends Distribution {
       return this.p.d - Math.sqrt(this.c.scale * this.c.dc * (1 - p))
     }
   }
+
+  static _fitInit (data) {
+    // Endpoints from sample extremes; flat-region boundaries from quartiles as a balanced initial simplex
+    const sorted = [...data].sort((x, y) => x - y)
+    const lo = sorted[0]
+    const hi = sorted[sorted.length - 1]
+    const eps = (hi - lo) * 0.01 || 1e-6
+    const q1 = sorted[Math.floor(sorted.length * 0.25)]
+    const q3 = Math.max(sorted[Math.floor(sorted.length * 0.75)], q1 + eps)
+    return [lo - eps, q1, q3, hi + eps]
+  }
 }

--- a/src/dist/triangular.js
+++ b/src/dist/triangular.js
@@ -71,4 +71,17 @@ export default class Triangular extends Distribution {
       ? this.p.a + Math.sqrt(p * this.c.baCa)
       : this.p.b - Math.sqrt((1 - p) * this.c.baBc)
   }
+
+  static _fitInit (data) {
+    // Endpoints from sample extremes; mode via method-of-moments: E[X] = (a+b+c)/3 → c = 3μ̂ - a - b
+    const n = data.length
+    const lo = Math.min(...data)
+    const hi = Math.max(...data)
+    const eps = (hi - lo) * 0.01 || 1e-6
+    const a = lo - eps
+    const b = hi + eps
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const c = Math.max(a, Math.min(b, 3 * mean - a - b))
+    return [a, b, c]
+  }
 }

--- a/src/dist/u-quadratic.js
+++ b/src/dist/u-quadratic.js
@@ -59,4 +59,12 @@ export default class UQuadratic extends Distribution {
   _q (p) {
     return Math.cbrt(3 * p / this.c.alpha - this.c.halfRangeCubed) + this.c.beta
   }
+
+  static _fitInit (data) {
+    // MLEs for bounded-support endpoints are the sample extremes; small buffer satisfies a < b
+    const lo = Math.min(...data)
+    const hi = Math.max(...data)
+    const eps = (hi - lo) * 0.01 || 1e-6
+    return [lo - eps, hi + eps]
+  }
 }

--- a/src/dist/uniform-product.js
+++ b/src/dist/uniform-product.js
@@ -48,4 +48,10 @@ export default class UniformProduct extends Distribution {
   _cdf (x) {
     return gammaUpperIncomplete(this.p.n, -Math.log(x))
   }
+
+  static _fitInit (data) {
+    // n from log-moment: -log(X) = sum of n Exp(1) variates, so E[-log X] = n
+    const meanNegLog = data.reduce((s, x) => s - Math.log(x), 0) / data.length
+    return [Math.max(2, Math.round(meanNegLog))]
+  }
 }

--- a/src/dist/uniform.js
+++ b/src/dist/uniform.js
@@ -58,4 +58,12 @@ export default class Uniform extends Distribution {
   _q (p) {
     return p * this.c.range + this.p.xmin
   }
+
+  static _fitInit (data) {
+    // MLEs for bounded-support endpoints are the sample extremes; small buffer satisfies xmin < xmax
+    const lo = Math.min(...data)
+    const hi = Math.max(...data)
+    const eps = (hi - lo) * 0.01 || 1e-6
+    return [lo - eps, hi + eps]
+  }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -1007,6 +1007,94 @@ describe('dist', () => {
         assert(Math.abs(result.p.p * result.p.a - 2) < 0.6)
         assert(Math.abs(result.p.a - 1) < 0.5)
       })
+
+      it('Uniform.fit should recover xmin and xmax close to planted values', () => {
+        const data = new dist.Uniform(1, 5).seed(42).sample(200)
+        const result = dist.Uniform.fit(data)
+        assert(result instanceof dist.Uniform)
+        assert(Math.abs(result.p.xmin - 1) < 0.2)
+        assert(Math.abs(result.p.xmax - 5) < 0.2)
+      })
+
+      it('UQuadratic.fit should recover a and b close to planted values', () => {
+        const data = new dist.UQuadratic(0, 4).seed(42).sample(200)
+        const result = dist.UQuadratic.fit(data)
+        assert(result instanceof dist.UQuadratic)
+        assert(Math.abs(result.p.a - 0) < 0.3)
+        assert(Math.abs(result.p.b - 4) < 0.3)
+      })
+
+      it('Triangular.fit should recover a, b, and c close to planted values', () => {
+        const data = new dist.Triangular(1, 5, 3).seed(42).sample(200)
+        const result = dist.Triangular.fit(data)
+        assert(result instanceof dist.Triangular)
+        assert(Math.abs(result.p.a - 1) < 0.3)
+        assert(Math.abs(result.p.b - 5) < 0.3)
+        assert(Math.abs(result.p.c - 3) < 0.5)
+      })
+
+      it('Bates.fit should return a usable Bates instance close to planted support', () => {
+        const data = new dist.Bates(3, 1, 5).seed(42).sample(200)
+        const result = dist.Bates.fit(data)
+        assert(result instanceof dist.Bates)
+        // n is integer-rounded so Nelder-Mead may land ±1 from planted n=3; allow [2,4]
+        assert(result.p.n >= 2 && result.p.n <= 4)
+        assert(Math.abs(result.p.b - result.p.a - 4) < 1)
+      })
+
+      it('Trapezoidal.fit should recover a, b, c, d close to planted values', () => {
+        const data = new dist.Trapezoidal(0, 1, 3, 5).seed(42).sample(200)
+        const result = dist.Trapezoidal.fit(data)
+        assert(result instanceof dist.Trapezoidal)
+        assert(Math.abs(result.p.a - 0) < 0.3)
+        assert(Math.abs(result.p.b - 1) < 0.5)
+        assert(Math.abs(result.p.c - 3) < 1.0)
+        assert(Math.abs(result.p.d - 5) < 0.3)
+      })
+
+      it('PERT.fit should recover a, b, and c close to planted values', () => {
+        const data = new dist.PERT(0, 3, 6).seed(42).sample(200)
+        const result = dist.PERT.fit(data)
+        assert(result instanceof dist.PERT)
+        assert(Math.abs(result.p.a - 0) < 0.3)
+        assert(Math.abs(result.p.c - 6) < 0.3)
+        assert(Math.abs(result.p.b - 3) < 0.5)
+      })
+
+      it('BetaRectangular.fit should return a valid instance close to planted values', () => {
+        const data = new dist.BetaRectangular(2, 3, 0.7, 0, 4).seed(42).sample(300)
+        const result = dist.BetaRectangular.fit(data)
+        assert(result instanceof dist.BetaRectangular)
+        // Shape params can be hard to disentangle with 5 params; check they're in a reasonable range
+        assert(result.p.alpha > 0.5 && result.p.alpha < 10)
+        assert(result.p.beta > 0.5 && result.p.beta < 10)
+        assert(result.p.theta > 0.1 && result.p.theta <= 1)
+        assert(Math.abs(result.p.a - 0) < 0.3)
+        assert(Math.abs(result.p.b - 4) < 0.3)
+      })
+
+      it('UniformProduct.fit should recover n close to planted value', () => {
+        const data = new dist.UniformProduct(3).seed(42).sample(200)
+        const result = dist.UniformProduct.fit(data)
+        assert(result instanceof dist.UniformProduct)
+        assert(result.p.n === 3)
+      })
+
+      it('Anglit.fit should recover mu and beta close to planted values', () => {
+        const data = new dist.Anglit(1, 1.5).seed(42).sample(200)
+        const result = dist.Anglit.fit(data)
+        assert(result instanceof dist.Anglit)
+        assert(Math.abs(result.p.mu - 1) < 0.3)
+        assert(Math.abs(result.p.beta - 1.5) < 0.4)
+      })
+
+      it('RaisedCosine.fit should recover mu and s close to planted values', () => {
+        const data = new dist.RaisedCosine(2, 3).seed(42).sample(200)
+        const result = dist.RaisedCosine.fit(data)
+        assert(result instanceof dist.RaisedCosine)
+        assert(Math.abs(result.p.mu - 2) < 0.4)
+        assert(Math.abs(result.p.s - 3) < 0.4)
+      })
     })
   })
 


### PR DESCRIPTION
Closes #433

## Summary
- Adds `static _fitInit(data)` overrides to 10 bounded-support continuous distributions: `Bates`, `Triangular`, `Trapezoidal`, `PERT`, `BetaRectangular`, `UQuadratic`, `Uniform`, `UniformProduct`, `Anglit`, `RaisedCosine`.
- Support endpoints are seeded from sample min/max (slightly inflated to satisfy strict-inequality constraints); inner shape parameters are derived from method-of-moments estimates.
- Eliminates the random-retry fallback for these distributions, giving Nelder-Mead a well-informed starting point.

## Design decisions
- [ADR-0012: Distribution.fit() Static MLE Method via Nelder-Mead + _fitInit Hook](decisions/0012-distribution-fit-nelder-mead.md) — documents the `_fitInit` override pattern; this PR follows the abstract-method-first rollout for bounded-support distributions.

## Non-trivial changes
- **`src/dist/uniform.js`**: `_fitInit` returns `[min-ε, max+ε]`; MLE for uniform support endpoints is the sample extremes.
- **`src/dist/u-quadratic.js`**: Same endpoint-from-extremes strategy (only two parameters).
- **`src/dist/triangular.js`**: Mode `c` derived via method-of-moments: `E[X] = (a+b+c)/3 → c = 3μ̂ − a − b`; clamped to `[a, b]`.
- **`src/dist/bates.js`**: `n` derived from variance moment `Var = (b−a)²/(12n) → n = (b−a)²/(12σ̂²)`; rounded to nearest integer. Note: Nelder-Mead treats `n` as continuous so recovery is approximate (tracked in #481).
- **`src/dist/trapezoidal.js`**: Flat-region boundaries `b`/`c` seeded from Q1/Q3; `q3` guarded to be strictly greater than `q1` to avoid an invalid initial simplex vertex when Q1 == Q3.
- **`src/dist/pert.js`**: Mode `b` from PERT mean formula: `E[X] = (a+4b+c)/6 → b = (6μ̂ − a − c)/4`; clamped to `(a, c)`.
- **`src/dist/beta-rectangular.js`**: Neutral shape parameters (α=2, β=2, θ=0.5) avoid degenerate beta boundary at init; endpoints from sample extremes.
- **`src/dist/uniform-product.js`**: `n` from log-moment: `E[−log X] = n` (since `−log U ~ Exp(1)`); clamped to ≥ 2.
- **`src/dist/anglit.js`**: `mu` from sample mean; `beta` from support-width relation `range = π·beta/2 → beta = 2·range/π`.
- **`src/dist/raised-cosine.js`**: `mu` from sample mean (symmetric distribution); `s` from support half-range `s = (max−min)/2`.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added entry for this feature under `[Unreleased] → Added`.
- **`test/dist.js`**: 10 new fit-recovery tests, one per distribution.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRF7keKqtFKofdaiwRa4K)_