### PR TITLE
Add _fitInit overrides for 7 Pareto-family distributions

### DIFF
--- a/src/dist/benini.js
+++ b/src/dist/benini.js
@@ -65,4 +65,12 @@ export default class Benini extends Distribution {
   _q (p) {
     return this.p.sigma * Math.exp(this.c.halfInvBeta * (Math.sqrt(this.c.alpha2 - this.c.fourBeta * Math.log(1 - p)) - this.p.alpha))
   }
+
+  static _fitInit (data) {
+    // sigma ≈ min(data) seeds scale; Hill estimator on log-excesses assumes near-Pareto tail (beta → 0)
+    const sigma = Math.min(...data) * 0.99
+    const n = data.length
+    const meanLogExcess = Math.max(data.reduce((s, x) => s + Math.log(x / sigma), 0) / n, 1e-9)
+    return [1 / meanLogExcess, 1, sigma]
+  }
 }

--- a/src/dist/bounded-pareto.js
+++ b/src/dist/bounded-pareto.js
@@ -62,4 +62,13 @@ export default class BoundedPareto extends Distribution {
   _q (p) {
     return Math.pow((this.c.Halpha + p * (this.c.Lalpha - this.c.Halpha)) / (this.c.Lalpha * this.c.Halpha), -1 / this.p.alpha)
   }
+
+  static _fitInit (data) {
+    // L ≈ min(data) seeds scale; Hill estimator gives shape α; H ≈ max(data) bounds the support
+    const L = Math.min(...data) * 0.99
+    const H = Math.max(...data) * 1.01
+    const n = data.length
+    const alpha = n / Math.max(data.reduce((s, x) => s + Math.log(x / L), 0), 1e-9)
+    return [L, H, alpha]
+  }
 }

--- a/src/dist/burr.js
+++ b/src/dist/burr.js
@@ -62,4 +62,15 @@ export default class Burr extends Distribution {
   _q (p) {
     return Math.pow(Math.pow(1 - p, this.c.negInvK) - 1, this.c.invC)
   }
+
+  static _fitInit (data) {
+    // log-scale variance gives c via log-logistic approximation; E[log(1+x^c)]=1/k (Exp identity) gives k
+    const n = data.length
+    const logData = data.map(x => Math.log(x))
+    const meanLog = logData.reduce((s, x) => s + x, 0) / n
+    const varLog = Math.max(logData.reduce((s, x) => s + (x - meanLog) ** 2, 0) / n, 1e-9)
+    const c = Math.max(Math.PI / Math.sqrt(3 * varLog), 0.1)
+    const k = Math.max(n / Math.max(data.reduce((s, x) => s + Math.log1p(Math.pow(x, c)), 0), 1e-9), 0.1)
+    return [c, k]
+  }
 }

--- a/src/dist/champernowne.js
+++ b/src/dist/champernowne.js
@@ -63,4 +63,15 @@ export default class Champernowne extends Distribution {
   _q (p) {
     return this.p.x0 + (2 / this.p.alpha) * Math.atanh(Math.tan((2 * p - 1) * this.c.atanK) / this.c.k)
   }
+
+  static _fitInit (data) {
+    // Median seeds x0; Var[X] ≈ pi^2/(4*alpha^2) for the symmetric (lambda=0) hyperbolic secant case gives alpha
+    const sorted = data.slice().sort((a, b) => a - b)
+    const n = sorted.length
+    const x0 = n % 2 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const std = Math.sqrt(Math.max(data.reduce((s, x) => s + (x - mean) ** 2, 0) / n, 1e-9))
+    const alpha = Math.max(Math.PI / (2 * std), 1e-3)
+    return [alpha, 0, x0]
+  }
 }

--- a/src/dist/dagum.js
+++ b/src/dist/dagum.js
@@ -55,4 +55,15 @@ export default class Dagum extends Distribution {
   _q (p) {
     return this.p.b * Math.pow(Math.pow(p, -1 / this.p.p) - 1, -1 / this.p.a)
   }
+
+  static _fitInit (data) {
+    // Geometric mean seeds scale b; log-logistic approximation for shape a (p=1 special case is log-logistic); p seeded at 1
+    const n = data.length
+    const logData = data.map(x => Math.log(x))
+    const meanLog = logData.reduce((s, x) => s + x, 0) / n
+    const varLog = Math.max(logData.reduce((s, x) => s + (x - meanLog) ** 2, 0) / n, 1e-9)
+    const b = Math.exp(meanLog)
+    const a = Math.max(Math.PI / Math.sqrt(3 * varLog), 0.1)
+    return [1, a, b]
+  }
 }

--- a/src/dist/generalized-pareto.js
+++ b/src/dist/generalized-pareto.js
@@ -61,4 +61,18 @@ export default class GeneralizedPareto extends Distribution {
     const y = this.p.xi === 0 ? -Math.log(1 - p) : (Math.pow(1 - p, -this.p.xi) - 1) / this.p.xi
     return this.p.mu + this.p.sigma * y
   }
+
+  static _fitInit (data) {
+    // mu at data minimum as threshold; MOM on shifted excesses: Var/E^2 = 1/(1-2*xi) gives xi and sigma
+    const mu = Math.min(...data)
+    const n = data.length
+    const y = data.map(x => x - mu)
+    const mean = y.reduce((s, x) => s + x, 0) / n
+    const variance = y.reduce((s, x) => s + (x - mean) ** 2, 0) / n
+    if (variance < 1e-9) {
+      return [mu, Math.max(mean, 1e-3), 0]
+    }
+    const xi = Math.max(Math.min(0.5 * (1 - mean * mean / variance), 0.4), -5)
+    return [mu, Math.max(mean * (1 - xi), 1e-3), xi]
+  }
 }

--- a/src/dist/lomax.js
+++ b/src/dist/lomax.js
@@ -53,4 +53,14 @@ export default class Lomax extends Distribution {
   _q (p) {
     return this.p.lambda * (Math.pow(1 - p, -1 / this.p.alpha) - 1)
   }
+
+  static _fitInit (data) {
+    // MOM: CV^2 = alpha/(alpha-2) links dispersion to tail index; lambda set via mean-alpha relation
+    const n = data.length
+    const mean = data.reduce((s, x) => s + x, 0) / n
+    const variance = Math.max(data.reduce((s, x) => s + (x - mean) ** 2, 0) / n, 1e-9)
+    const cv2 = variance / Math.max(mean * mean, 1e-9)
+    const alpha = cv2 > 1 ? 2 * cv2 / (cv2 - 1) : 3
+    return [Math.max(mean * (alpha - 1), 1e-3), alpha]
+  }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -1189,6 +1189,95 @@ describe('dist', () => {
         assert(Number.isFinite(init[0]))
         assert(init[1] > 0)
       })
+
+      it('BoundedPareto.fit should recover L and alpha and return a valid upper bound', () => {
+        const data = new dist.BoundedPareto(2, 20, 3).seed(42).sample(200)
+        const result = dist.BoundedPareto.fit(data)
+        assert(result instanceof dist.BoundedPareto)
+        assert(Math.abs(result.p.L - 2) < 0.5)
+        // MLE for H converges to max(data) since likelihood decreases for any H > max(data)
+        assert(result.p.H >= Math.max(...data))
+        assert(Math.abs(result.p.alpha - 3) < 0.8)
+      })
+
+      it('Lomax.fit should recover lambda and alpha close to planted values', () => {
+        const data = new dist.Lomax(2, 4).seed(42).sample(200)
+        const result = dist.Lomax.fit(data)
+        assert(result instanceof dist.Lomax)
+        assert(Math.abs(result.p.lambda - 2) < 0.8)
+        assert(Math.abs(result.p.alpha - 4) < 1.0)
+      })
+
+      it('GeneralizedPareto.fit should recover mu, sigma, and xi close to planted values', () => {
+        const data = new dist.GeneralizedPareto(1, 2, 0.2).seed(42).sample(200)
+        const result = dist.GeneralizedPareto.fit(data)
+        assert(result instanceof dist.GeneralizedPareto)
+        assert(Math.abs(result.p.mu - 1) < 0.3)
+        assert(Math.abs(result.p.sigma - 2) < 0.8)
+        assert(Math.abs(result.p.xi - 0.2) < 0.3)
+      })
+
+      it('Burr.fit should recover c and k close to planted values', () => {
+        const data = new dist.Burr(2, 3).seed(42).sample(200)
+        const result = dist.Burr.fit(data)
+        assert(result instanceof dist.Burr)
+        assert(Math.abs(result.p.c - 2) < 0.8)
+        assert(Math.abs(result.p.k - 3) < 1.0)
+      })
+
+      it('Dagum.fit should recover p, a, and b close to planted values', () => {
+        const data = new dist.Dagum(1, 2, 3).seed(42).sample(200)
+        const result = dist.Dagum.fit(data)
+        assert(result instanceof dist.Dagum)
+        assert(Math.abs(result.p.p - 1) < 0.4)
+        assert(Math.abs(result.p.a - 2) < 0.8)
+        assert(Math.abs(result.p.b - 3) < 1.0)
+      })
+
+      it('Champernowne.fit should recover alpha and x0 and return a valid lambda', () => {
+        const data = new dist.Champernowne(1, 0, 2).seed(42).sample(200)
+        const result = dist.Champernowne.fit(data)
+        assert(result instanceof dist.Champernowne)
+        assert(Math.abs(result.p.alpha - 1) < 0.4)
+        // lambda is poorly identified near 0 from n=200; check valid range instead
+        assert(result.p.lambda >= 0 && result.p.lambda < 1)
+        assert(Math.abs(result.p.x0 - 2) < 0.5)
+      })
+
+      it('Benini.fit should recover alpha, beta, and sigma close to planted values', () => {
+        const data = new dist.Benini(2, 1, 3).seed(42).sample(200)
+        const result = dist.Benini.fit(data)
+        assert(result instanceof dist.Benini)
+        assert(Math.abs(result.p.alpha - 2) < 0.8)
+        assert(Math.abs(result.p.beta - 1) < 0.4)
+        assert(Math.abs(result.p.sigma - 3) < 0.5)
+      })
+
+      it('BoundedPareto._fitInit should return valid params for constant data', () => {
+        const init = dist.BoundedPareto._fitInit([5, 5, 5])
+        assert(init[0] > 0 && init[1] > init[0] && init[2] > 0)
+      })
+
+      it('Lomax._fitInit should fall back to alpha=3 when CV <= 1', () => {
+        // near-constant data → CV ≈ 0 → triggers fallback
+        const init = dist.Lomax._fitInit([2, 2.001, 1.999, 2])
+        assert(init[0] > 0)
+        assert(init[1] === 3)
+      })
+
+      it('GeneralizedPareto._fitInit should return xi=0 for constant data', () => {
+        const init = dist.GeneralizedPareto._fitInit([3, 3, 3])
+        assert(Number.isFinite(init[0]))
+        assert(init[1] > 0)
+        assert(init[2] === 0)
+      })
+
+      it('Benini._fitInit should return positive alpha, beta, and sigma for any positive data', () => {
+        const init = dist.Benini._fitInit([2, 3, 4, 5])
+        assert(init[0] > 0)
+        assert(init[1] > 0)
+        assert(init[2] > 0)
+      })
     })
   })
 

--- a/test/dist.js
+++ b/test/dist.js
@@ -423,10 +423,10 @@ describe('dist', () => {
       })
 
       it('Distribution._fitInit fallback should work for scalar-constructor distributions', () => {
-        // Burr has no _fitInit override so fit() exercises the base-class random-retry path
-        const data = new dist.Burr(2, 3).seed(42).sample(100)
-        const result = dist.Burr.fit(data)
-        assert(result instanceof dist.Burr)
+        // Alpha has no _fitInit override so fit() exercises the base-class random-retry path
+        const data = new dist.Alpha(2, 1).seed(42).sample(100)
+        const result = dist.Alpha.fit(data)
+        assert(result instanceof dist.Alpha)
       })
 
       it('Pareto.fit should recover xmin close to min(data)', () => {


### PR DESCRIPTION
Closes #435

## Summary
- Adds `static _fitInit(data)` overrides to 7 Pareto-family distributions (BoundedPareto, Lomax, GeneralizedPareto, Burr, Dagum, Champernowne, Benini) to seed Nelder-Mead with data-aware initial parameters rather than relying on the base-class random-retry fallback
- Each override uses a statistically principled estimator: Hill estimator for Pareto-type tails, MOM on shifted excesses for GeneralizedPareto, log-logistic log-scale approximation for Burr/Dagum, and hyperbolic-secant variance identity for Champernowne
- Pareto already had `_fitInit` from a prior PR; this brings the full Pareto family into parity

## Design decisions
- [ADR-0012: Distribution.fit() Static MLE Method via Nelder-Mead + _fitInit Hook](decisions/0012-distribution-fit-nelder-mead.md) — `_fitInit` is a protected hook for per-distribution parameter seeding; overrides follow the same pattern as `_pdf`/`_cdf`

## Non-trivial changes
- **`src/dist/bounded-pareto.js`**: Hill estimator `α = n / Σ log(xᵢ/L)` with `L = min(data)×0.99`, `H = max(data)×1.01`; H recovery is bounded (MLE of H converges to `max(data)` due to likelihood monotonicity above the sample maximum)
- **`src/dist/lomax.js`**: MOM via `CV² = α/(α-2)` → `α = 2CV²/(CV²-1)` for `CV > 1`; falls back to `α=3` for near-constant data where CV ≤ 1
- **`src/dist/generalized-pareto.js`**: MOM on shifted excesses `y = x − min(data)`: `Var[Y]/E[Y]² = 1/(1−2ξ)` gives closed-form `ξ` and `σ`; degenerate (constant) data returns `ξ=0` early
- **`src/dist/burr.js`**: Two-step: log-logistic log-scale variance → shape `c`; then Exp identity `E[log(1+Xᶜ)] = 1/k` → shape `k`
- **`src/dist/dagum.js`**: Geometric mean seeds scale `b`; log-logistic log-scale approximation for shape `a`; `p` seeded at 1 (the log-logistic special case)
- **`src/dist/champernowne.js`**: Median → location `x0`; `Var[X] = π²/(4α²)` for the symmetric (λ=0) hyperbolic secant case gives `α`; `λ` started at 0
- **`src/dist/benini.js`**: `σ = min(data)×0.99`; Hill estimator on log-excesses `log(xᵢ/σ)` gives `α` under the near-Pareto (β→0) approximation; `β` seeded at 1

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: 7 new `.fit()` recovery tests and 4 `._fitInit()` edge-case tests following the existing pattern

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYQvWrqSuaXPhULmrPQcvj)_