### PR TITLE
Watch the PR after creation in /pull-request skill

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -19,7 +19,7 @@ This directory contains the skills and agents that power the development workflo
 │   ├── hotfix/SKILL.md       # Leaf: small targeted fix (no research/plan)
 │   ├── commit/SKILL.md       # Leaf: git commit
 │   ├── review/SKILL.md       # Leaf: code review
-│   ├── pull-request/SKILL.md # Leaf: GitHub PR creation
+│   ├── pull-request/SKILL.md # Leaf: GitHub PR creation + activity watch (CI autofix, review replies)
 │   ├── validate/SKILL.md     # Leaf: verify issue acceptance criteria
 │   └── compound/SKILL.md     # Leaf: document solved problems
 └── agents/         # Specialized subagents (not user-invocable)
@@ -73,7 +73,7 @@ Standalone skills that do one thing. Can be called directly or composed by orche
 | [`/commit`](skills/commit/SKILL.md) | Stage and commit with generated message | _(no args)_ |
 | [`/push`](skills/push/SKILL.md) | Push commits to remote | _(no args)_ |
 | [`/review`](skills/review/SKILL.md) | Code review against plan + quality checks | _(no args, reviews current branch)_ |
-| [`/pull-request`](skills/pull-request/SKILL.md) | Create a PR with change categorization | _(no args)_ |
+| [`/pull-request`](skills/pull-request/SKILL.md) | Create a PR with change categorization, then watch it (auto-fix CI, respond to reviews) | _(no args)_ |
 | [`/validate`](skills/validate/SKILL.md) | Verify issue acceptance criteria are met | `#issue` or issue URL |
 | [`/next`](skills/next/SKILL.md) | Pick the best next issue from the backlog | Milestone _(optional)_ |
 | [`/suggest`](skills/suggest/SKILL.md) | Suggest and create future issues from codebase analysis | _(no args)_ |

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -127,12 +127,44 @@ EOF
 )"
 ```
 
-### 8. Report
+### 8. Watch the PR (CI + reviews)
+
+Immediately after the PR is created, **subscribe to its activity** so CI failures and
+review comments are handled without the user having to ask:
+
+```
+subscribe_pr_activity(<pr-number>)
+```
+
+> **Availability**: `subscribe_pr_activity` is provided by the remote-execution / GitHub
+> webhook integration. If the tool is unavailable (e.g. a purely local `gh` session),
+> skip this step and tell the user the PR can't be auto-watched here.
+
+After subscribing, **end the turn** — do not poll with `sleep` or repeated status checks.
+PR events arrive as `<github-webhook-activity>` messages that wake the session. When one
+arrives, investigate it and follow this loop:
+
+- **CI check failed** → reproduce locally, diagnose the root cause, push the fix, and update
+  a short status checklist. Re-kick on each failure until green; the green status IS the
+  deliverable, not a no-op to skip. Reply only when it resolves the task or raises a question.
+- **Review comment** → if the fix is unambiguous and not architecturally significant, apply
+  and push it. If there is **any** ambiguity (a comment open to interpretation, or a change
+  touching something significant), use `AskUserQuestion` to confirm before acting.
+- **Duplicate / no-action-needed event** → skip silently.
+- **Merge conflict reported** → fetch the base branch, merge it in, resolve conflicts,
+  re-run `npm run standard && npm test`, and push.
+
+Stop watching the moment the user asks — call `unsubscribe_pr_activity(<pr-number>)` and push
+no further changes to that PR.
+
+### 9. Report
 
 > "PR created: <URL>
 >
 > **Closes**: #<issue> (or "None")
-> **Non-trivial changes**: <count> (or "None")"
+> **Non-trivial changes**: <count> (or "None")
+> **Watching**: subscribed to PR activity — I'll auto-fix failing CI and respond to review
+> comments as they arrive (or "not available in this environment")."
 
 ## Rules
 
@@ -140,8 +172,12 @@ EOF
 - Read the FULL diff before categorizing
 - Always include `Closes #N` when an issue is detectable
 - Be specific about what changed in non-trivial items
+- Subscribe to PR activity after creation and follow through on CI/review events
+- Escalate ambiguous review comments via `AskUserQuestion` before acting
 
 ### DO NOT:
 - Create a PR if on `main`
 - Invent an issue number
 - Add `Closes #N` for an already-closed issue
+- Poll for CI/review status with `sleep` or repeated checks — react to webhook events instead
+- Keep pushing to a PR after the user asks you to stop watching it


### PR DESCRIPTION
## Summary
- The `/pull-request` skill now **subscribes to PR activity** right after creating a PR, and defines an auto-handling loop: reproduce-and-fix failing CI, apply unambiguous review comments (escalating ambiguous ones via `AskUserQuestion`), resolve merge conflicts against the base, and skip no-op events — reacting to webhook events rather than polling. It unsubscribes the moment the user asks it to stop.
- Documents the availability caveat (the subscription mechanism is provided by the remote-execution / GitHub webhook integration; a purely local `gh` session skips the step).

## Non-trivial changes
- **`.claude/skills/pull-request/SKILL.md`**: new step 8 "Watch the PR (CI + reviews)" with the event-handling loop; Report step renumbered to 9 and extended with a "Watching" line; two new DO / DO NOT rules (subscribe & follow through; don't poll, don't keep pushing after a stop request).

<details>
<summary>Trivial changes</summary>

- **`.claude/README.md`**: updated the `/pull-request` skill description (table row + tree comment) to mention the post-creation watch behavior, per the repo convention that `.claude/` skill changes update the README.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lut8ErPDbY37CcwznvmZN9)_