### PR TITLE
Add ZipfMandelbrot._fitInit with Hill and PMF-ratio estimators

### DIFF
--- a/src/dist/zipf-mandelbrot.js
+++ b/src/dist/zipf-mandelbrot.js
@@ -14,6 +14,23 @@ import Distribution from './_distribution'
  */
 export default class ZipfMandelbrot extends Categorical {
   // Special case of categorical
+  static _fitInit (data) {
+    // N ≈ max(data); Hill estimator for s; q from rank-1/rank-2 PMF ratio
+    const n = data.length
+    const N = data.reduce((m, x) => x > m ? x : m, 1)
+    const sumLog = data.reduce((s, x) => s + Math.log(x), 0)
+    const s = sumLog <= 0 ? 2 : Math.max(1.1, Math.min(20, 1 + n / sumLog))
+    const freq = {}
+    for (const x of data) freq[x] = (freq[x] || 0) + 1
+    const f1 = (freq[1] || 1) / n
+    const f2 = (freq[2] || 0) / n
+    if (f2 <= 0) return [N, s, 0]
+    // P(1)/P(2) = ((2+q)/(1+q))^s → q = (2 - e^r)/(e^r - 1), r = log(f1/f2)/s
+    const er = Math.exp(Math.log(f1 / f2) / s)
+    const q = (er >= 2 || er <= 1 + 1e-6) ? 0 : Math.max(0, (2 - er) / (er - 1))
+    return [N, s, q]
+  }
+
   /**
    * @param {number} N Number of elements (support size). If not an integer, it is rounded to the nearest integer.
    * @param {number} s Exponent of the distribution.

--- a/test/dist.js
+++ b/test/dist.js
@@ -4,6 +4,7 @@ import { adTest, chiTest, Tests, checkRefVals, checkQuantileVals } from './test-
 import { float } from '../src/core'
 import * as dist from '../src/dist'
 import PreComputed from '../src/dist/_pre-computed'
+import Distribution from '../src/dist/_distribution'
 import continuousCases from './dist-cases-continuous'
 import discreteCases from './dist-cases-discrete'
 
@@ -422,10 +423,24 @@ describe('dist', () => {
         assert(result instanceof dist.Exponential)
       })
 
-      it('Distribution._fitInit fallback: Alpha.fit() returns a valid Alpha instance', () => {
+      it('Alpha.fit() returns a valid Alpha instance', () => {
         const data = new dist.Alpha(2, 1).seed(42).sample(100)
         const result = dist.Alpha.fit(data)
         assert(result instanceof dist.Alpha)
+      })
+
+      it('Distribution._fitInit fallback random-retry path covers try-success and catch', () => {
+        // All exported distributions now have _fitInit overrides, so call the base-class
+        // method directly via a fake 2-param class with an ordering constraint (a < b).
+        // ~50% of random draws in (0,5) violate a>=b, exercising both the catch and return paths.
+        class FakeDist {
+          static get length () { return 2 }
+          constructor (a, b) {
+            if (a >= b) throw new Error('invalid')
+          }
+        }
+        const params = Distribution._fitInit.call(FakeDist, [1, 2, 3])
+        assert(params.length === 2 && params[0] < params[1])
       })
 
       it('ZipfMandelbrot._fitInit should return valid params for typical data', () => {

--- a/test/dist.js
+++ b/test/dist.js
@@ -428,13 +428,19 @@ describe('dist', () => {
         assert(result instanceof dist.Alpha)
       })
 
-      it('Distribution._fitInit fallback random-retry path: ZipfMandelbrot.fit() returns a usable instance', () => {
-        // ZipfMandelbrot is the only exported distribution with no _fitInit override and k>0, so it exercises the base-class random-retry seed loop; the seed is unseeded Math.random, so we assert only usable-instance invariants rather than recovery
+      it('ZipfMandelbrot._fitInit should return valid params for typical data', () => {
         const data = new dist.ZipfMandelbrot(10, 2, 0).seed(42).sample(120)
-        const result = dist.ZipfMandelbrot.fit(data)
-        assert(result instanceof dist.ZipfMandelbrot)
-        const p1 = result.pdf(1)
-        assert(Number.isFinite(p1) && p1 > 0 && p1 <= 1)
+        const init = dist.ZipfMandelbrot._fitInit(data)
+        assert(init.length === 3)
+        assert(Number.isFinite(init[0]) && init[0] >= 1)   // N >= 1
+        assert(Number.isFinite(init[1]) && init[1] > 1)    // s > 1
+        assert(Number.isFinite(init[2]) && init[2] >= 0)   // q >= 0
+      })
+
+      it('ZipfMandelbrot._fitInit should fall back to q=0 when no rank-2 data exists', () => {
+        const init = dist.ZipfMandelbrot._fitInit([1, 1, 1, 1])
+        assert(init[2] === 0) // q falls back to 0 when only rank-1 observed
+        assert(init[1] > 1)   // s still valid
       })
 
       it('Pareto.fit should recover xmin close to min(data)', () => {
@@ -1898,6 +1904,14 @@ describe('dist', () => {
       assert(result instanceof dist.Zipf)
       assert(Number.isFinite(result.pdf(1)) && result.pdf(1) > 0)
       assert(Math.abs(result.pdf(1) - new dist.Zipf(2, 50).pdf(1)) < 0.1)
+    })
+
+    it('ZipfMandelbrot.fit should return a usable ZipfMandelbrot instance', () => {
+      const data = new dist.ZipfMandelbrot(20, 2, 1).seed(42).sample(300)
+      const result = dist.ZipfMandelbrot.fit(data)
+      assert(result instanceof dist.ZipfMandelbrot)
+      assert(Number.isFinite(result.pdf(1)) && result.pdf(1) > 0)
+      assert(Math.abs(result.pdf(1) - new dist.ZipfMandelbrot(20, 2, 1).pdf(1)) < 0.1)
     })
 
     it('Hypergeometric.fit should return a usable Hypergeometric instance', () => {

--- a/test/dist.js
+++ b/test/dist.js
@@ -432,15 +432,15 @@ describe('dist', () => {
         const data = new dist.ZipfMandelbrot(10, 2, 0).seed(42).sample(120)
         const init = dist.ZipfMandelbrot._fitInit(data)
         assert(init.length === 3)
-        assert(Number.isFinite(init[0]) && init[0] >= 1)   // N >= 1
-        assert(Number.isFinite(init[1]) && init[1] > 1)    // s > 1
-        assert(Number.isFinite(init[2]) && init[2] >= 0)   // q >= 0
+        assert(Number.isFinite(init[0]) && init[0] >= 1) // N >= 1
+        assert(Number.isFinite(init[1]) && init[1] > 1) // s > 1
+        assert(Number.isFinite(init[2]) && init[2] >= 0) // q >= 0
       })
 
       it('ZipfMandelbrot._fitInit should fall back to q=0 when no rank-2 data exists', () => {
         const init = dist.ZipfMandelbrot._fitInit([1, 1, 1, 1])
         assert(init[2] === 0) // q falls back to 0 when only rank-1 observed
-        assert(init[1] > 1)   // s still valid
+        assert(init[1] > 1) // s still valid
       })
 
       it('Pareto.fit should recover xmin close to min(data)', () => {


### PR DESCRIPTION
## Summary
- Adds a data-aware `_fitInit` to `ZipfMandelbrot`, replacing the base-class random-retry fallback which previously required up to 500 attempts at random seeds
- Estimates `N` from `max(data)`, `s` via the Hill estimator (`1 + n/∑log xᵢ`), and `q` by solving the rank-1/rank-2 PMF ratio analytically: `P(1)/P(2) = ((2+q)/(1+q))^s` → `q = (2−eʳ)/(eʳ−1)` where `r = log(f₁/f₂)/s`; falls back to `q=0` when rank-2 data is absent or the ratio already matches pure Zipf

## Non-trivial changes
- **`src/dist/zipf-mandelbrot.js`**: New `static _fitInit(data)` method. The Hill estimator is the standard MLE seed for power-law exponents; the PMF-ratio formula for `q` is derived from the closed-form Mandelbrot PMF, ensuring `q=0` exactly when data matches a pure Zipf prediction and `q>0` when the rank-1/rank-2 gap is narrower than Zipf would predict.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Replaced stale "random-retry path" test (ZipfMandelbrot no longer exercises that path) with two targeted `_fitInit` unit tests and one `ZipfMandelbrot.fit` integration test alongside the existing `Zipf.fit` test.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbnyzML4gWsiMcJn7VqJkn)_