### PR TITLE
Fix Bates scale/shift constants to use rounded ni

### DIFF
--- a/src/dist/bates.js
+++ b/src/dist/bates.js
@@ -42,8 +42,8 @@ export default class Bates extends IrwinHall {
 
     // Extend speed-up constants with Bates affine transform coefficients
     Object.assign(this.c, {
-      scale: n / (b - a),
-      shift: n * a / (b - a)
+      scale: ni / (b - a),
+      shift: ni * a / (b - a)
     })
   }
 

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -196,6 +196,19 @@ export default [{
       { x: 0.8, pdf: 0.539999999999999, cdf: 0.964 },
       { x: 0.9, pdf: 0.135, cdf: 0.9955 }
     ]
+  }, {
+    name: 'non-integer n rounds to 3, unit interval',
+    params: () => [2.7, 0, 1],
+    symmetry: 0.5,
+    refVals: [
+      { x: 0.1, pdf: 0.135, cdf: 0.0045 },
+      { x: 0.2, pdf: 0.54, cdf: 0.036 },
+      { x: 0.35, pdf: 1.6425, cdf: 0.192875 },
+      { x: 0.5, pdf: 2.25, cdf: 0.5 },
+      { x: 0.65, pdf: 1.6425, cdf: 0.807125 },
+      { x: 0.8, pdf: 0.539999999999999, cdf: 0.964 },
+      { x: 0.9, pdf: 0.135, cdf: 0.9955 }
+    ]
   }],
   // scipy.stats.irwinhall(10): pdf rescaled by n/(b-a)=0.5 at y=(x-5)*10/20
   refVals: [


### PR DESCRIPTION
Closes #461

## Summary
- `Bates` constructor computed `scale` and `shift` affine-transform constants from the raw float `n` while passing `ni = Math.round(n)` to the parent `IrwinHall`, causing PDF/CDF/quantile/sample to return incorrect values whenever `n` is not already an integer
- Fixed both constants to use `ni` so the affine transform is consistent with the parent distribution's integer parameter
- Added a regression test case for `n = 2.7` (rounds to 3) with reference values matching `Bates(3, 0, 1)` to prevent recurrence

## Non-trivial changes
- **`src/dist/bates.js`**: `scale: n / (b - a)` and `shift: n * a / (b - a)` corrected to use `ni` — the mismatch caused the affine transform to scale by a different `n` than IrwinHall's PDF/CDF used, producing wrong output for any non-integer input

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Regression test case added for `Bates(2.7, 0, 1)` with same reference values as `Bates(3, 0, 1)`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjU2TCvAtYnN7tzW7weyAZ)_