### PR TITLE
Fix BaldingNichols not storing F and p on this.p

### DIFF
--- a/src/dist/balding-nichols.js
+++ b/src/dist/balding-nichols.js
@@ -29,6 +29,7 @@ export default class BaldingNichols extends Beta {
     ])
     const f = (1 - F) / F
     super(f * p, f * (1 - p))
+    this.p = Object.assign(this.p, { F, p })
 
     // Set support
     this.s = [{

--- a/test/dist.js
+++ b/test/dist.js
@@ -1258,11 +1258,14 @@ describe('dist', () => {
         const data = new dist.BaldingNichols(0.1, 0.3).seed(42).sample(200)
         const result = dist.BaldingNichols.fit(data)
         assert(result instanceof dist.BaldingNichols)
-        // BaldingNichols stores Beta's alpha/beta; back out F = 1/(a+b+1), p = a/(a+b)
-        const a = result.p.alpha
-        const b = result.p.beta
-        assert(Math.abs(1 / (a + b + 1) - 0.1) < 0.05)
-        assert(Math.abs(a / (a + b) - 0.3) < 0.05)
+        assert(Math.abs(result.p.F - 0.1) < 0.05)
+        assert(Math.abs(result.p.p - 0.3) < 0.05)
+      })
+
+      it('BaldingNichols constructor should expose F and p on this.p', () => {
+        const d = new dist.BaldingNichols(0.1, 0.3)
+        assert(d.p.F === 0.1)
+        assert(d.p.p === 0.3)
       })
 
       it('F.fit should return a usable F instance with positive degrees of freedom', () => {


### PR DESCRIPTION
Closes #490

## Summary
- `BaldingNichols` only stored the derived `alpha`/`beta` parameters from its `Beta` parent in `this.p`, silently dropping the original `F` and `p` arguments — making `instance.p.F` and `instance.p.p` return `undefined`
- Added `Object.assign(this.p, { F, p })` after `super()`, matching the established pattern used by all other reparametrised Beta subclasses (`R`, `F`, `PERT`, `BetaRectangular`)
- Updated the `fit` test to assert `result.p.F` and `result.p.p` directly instead of back-computing from `alpha`/`beta`

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/balding-nichols.js`**: Added `Object.assign(this.p, { F, p })` after `super()` call — 1 line
- **`test/dist.js`**: Simplified fit recovery test to read `result.p.F`/`result.p.p` directly; added constructor test for `this.p` exposure

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHjnCcLAvDDREG2fbNoBk9)_