### PR TITLE
Fix Mielke.p to expose k and s instead of Dagum aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Mielke` distribution: `.p` now correctly exposes `{ k, s }` instead of Dagum's inherited `{ p, a, b }` bag; `_pdf`, `_cdf`, and `_q` are overridden to use `k` and `s` directly so that `fit()` parameter recovery and any code reading back `.p.k` / `.p.s` behaves as documented (#480).
+
 - `R`, `F`, `FisherZ`, and `BaldingNichols` `.fit()` no longer inherit `Beta`'s `[alpha, beta]` initializer, which produced a wrong-arity (`R`) or wrong-parametrization init vector that made `fit()` throw or converge to nonsense; each now seeds Nelder-Mead from a distribution-correct method-of-moments estimate (#441).
 
 - `besselISpherical(n, x)` now uses a Taylor series for |x| < 1, eliminating catastrophic cancellation in the closed-form expressions for n ≥ 1; relative error is now bounded by 2ε for all small arguments (#425).

--- a/src/dist/dagum.js
+++ b/src/dist/dagum.js
@@ -21,6 +21,8 @@ export default class Dagum extends Distribution {
     super('continuous', 3)
 
     // Validate parameters
+    // Index signature allows subclasses (e.g. Mielke) to override this.p with different parameter names
+    /** @type {Object.<string, number>} */
     this.p = { p, a, b }
     Distribution.validate({ p, a, b }, [
       'p > 0',

--- a/src/dist/mielke.js
+++ b/src/dist/mielke.js
@@ -26,6 +26,9 @@ export default class Mielke extends Dagum {
       's > 0'
     ])
 
+    // Dagum's constructor sets this.p = {p, a, b}; override with Mielke's own names
+    this.p = { k, s }
+
     // Set support
     this.s = [{
       value: 0,
@@ -34,6 +37,18 @@ export default class Mielke extends Dagum {
       value: Infinity,
       closed: false
     }]
+  }
+
+  _pdf (x) {
+    return this.p.k * Math.pow(x, this.p.k - 1) / Math.pow(1 + Math.pow(x, this.p.s), 1 + this.p.k / this.p.s)
+  }
+
+  _cdf (x) {
+    return Math.pow(1 + Math.pow(x, -this.p.s), -this.p.k / this.p.s)
+  }
+
+  _q (p) {
+    return Math.pow(Math.pow(p, -this.p.s / this.p.k) - 1, -1 / this.p.s)
   }
 
   static _fitInit (data) {

--- a/test/dist.js
+++ b/test/dist.js
@@ -1032,9 +1032,8 @@ describe('dist', () => {
         const data = new dist.Mielke(2, 1).seed(42).sample(200)
         const result = dist.Mielke.fit(data)
         assert(result instanceof dist.Mielke)
-        // Mielke stores params via Dagum: p.p = k/s, p.a = s, so k = p.p * p.a
-        assert(Math.abs(result.p.p * result.p.a - 2) < 0.6)
-        assert(Math.abs(result.p.a - 1) < 0.5)
+        assert(Math.abs(result.p.k - 2) < 0.6)
+        assert(Math.abs(result.p.s - 1) < 0.5)
       })
 
       it('Uniform.fit should recover xmin and xmax close to planted values', () => {


### PR DESCRIPTION
Closes #480

## Summary
- `Mielke` extends `Dagum` and previously left `this.p` as Dagum's `{p, a, b}` bag, making `.p.k` and `.p.s` both `undefined` for any `Mielke` instance
- Fixed by overriding `this.p = { k, s }` in the constructor and adding `_pdf`, `_cdf`, `_q` methods that use `k` and `s` directly (required because Dagum's inherited methods read `this.p.p/a/b` which are now absent)
- Removed the `result.p.p * result.p.a` workaround from the `Mielke.fit` test

## Non-trivial changes
- **`src/dist/mielke.js`**: Added `_pdf`, `_cdf`, and `_q` overrides expressing the Mielke Beta-Kappa formulas in terms of `k` and `s` directly. This is necessary because the parent Dagum methods reference `this.p.p`, `this.p.a`, `this.p.b`, which no longer exist after the `this.p` override. All three formulas are algebraically equivalent to the Dagum formulas evaluated at `p=k/s, a=s, b=1`.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Replaced `result.p.p * result.p.a` workaround with direct `result.p.k` / `result.p.s` assertions
- **`CHANGELOG.md`**: Added `### Fixed` entry for this bug

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01NynzdVof4aSnkDHNQPXyZz)_