### PR TITLE
Fix Mielke parameter count so AIC/BIC use k=2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Mielke` distribution: `aic()` and `bic()` now use the correct parameter count of 2 (not 3 inherited from `Dagum`); the penalty term was over-counted by 1 in every AIC/BIC evaluation (#505).
+
 - `R`, `F`, `FisherZ`, and `BaldingNichols` `.fit()` no longer inherit `Beta`'s `[alpha, beta]` initializer, which produced a wrong-arity (`R`) or wrong-parametrization init vector that made `fit()` throw or converge to nonsense; each now seeds Nelder-Mead from a distribution-correct method-of-moments estimate (#441).
 
 - `besselISpherical(n, x)` now uses a Taylor series for |x| < 1, eliminating catastrophic cancellation in the closed-form expressions for n ≥ 1; relative error is now bounded by 2ε for all small arguments (#425).

--- a/src/dist/mielke.js
+++ b/src/dist/mielke.js
@@ -20,6 +20,9 @@ export default class Mielke extends Dagum {
   constructor (k, s) {
     super(k / s, s, 1)
 
+    // Mielke has 2 free parameters (k, s); override the 3 inherited from Dagum
+    this.k = 2
+
     // Validate parameters
     Distribution.validate({ k, s }, [
       'k > 0',

--- a/test/dist.js
+++ b/test/dist.js
@@ -2087,4 +2087,23 @@ describe('dist', () => {
       assert.strictEqual(d.bic(sample), Math.log(sample.length) * 1 - 2 * d.lnL(sample))
     })
   })
+
+  // Mielke: AIC/BIC parameter-count regression — this.k must be 2, not 3 inherited from Dagum.
+  describe('Mielke', () => {
+    const sample = [0.1, 0.5, 1.0, 1.5, 2.0, 0.3, 0.8, 1.2, 2.5, 0.6]
+    const d = new dist.Mielke(2, 2)
+
+    it('should have paramCount k=2', () => {
+      assert.strictEqual(d.k, 2)
+    })
+
+    it('aic() should include the parameter penalty (k=2)', () => {
+      // AIC = 2*(k - lnL); with k=2 the penalty is 4. k=3 (inherited from Dagum) over-counts by 2.
+      assert.strictEqual(d.aic(sample), 2 * (2 - d.lnL(sample)))
+    })
+
+    it('bic() should include the parameter penalty (k=2)', () => {
+      assert.strictEqual(d.bic(sample), Math.log(sample.length) * 2 - 2 * d.lnL(sample))
+    })
+  })
 })


### PR DESCRIPTION
Closes #505

## Summary
- `Mielke` inherits `this.k = 3` from `Dagum`'s constructor but only has 2 free parameters (`k`, `s`). This caused `aic()` and `bic()` to over-penalise by 1 in every evaluation.
- Added `this.k = 2` after the `super()` call, mirroring the existing `this.p` override already in the constructor.
- Added three regression tests to guard against future regressions.

## Non-trivial changes
- **`src/dist/mielke.js:24`**: `this.k = 2` overrides the 3 inherited from `Dagum`. Without this, `aic()` returns `2*(3 - lnL)` instead of `2*(2 - lnL)` — a constant bias of 2 in every model-selection evaluation.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `### Fixed` bullet for #505.
- **`test/dist.js`**: Three regression tests (`k=2`, `aic()`, `bic()`) modelled on the existing Lindley regression block.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoCBqMcBK9mvRZqUFCxfw3)_