### PR TITLE
Add interactive distribution demo page (#504)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /dist/**/*.d.ts
 /docs/index.html
 /docs/porting-scipy.html
+/docs/demo.html
 /docs/styles/style.css
 
 # Idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Interactive distribution demo page (`docs/demo.html`): select from 15 curated distributions, adjust parameters, visualise histogram+PDF and empirical+theoretical CDF side-by-side (rendered with dalian), and run MLE fitting via `fit()` to see how closely the fitted parameters match the planted values (#504).
+
 - `static _fitInit(data)` overrides for `InverseGaussian`, `ReciprocalInverseGaussian`, `Nakagami`, `Hoyt`, `Lindley`, `Alpha`, and `QExponential`: each seeds the Nelder-Mead MLE optimizer from a distribution-specific method-of-moments estimate, replacing the base-class random-retry fallback and improving `.fit()` convergence reliability for these distributions (#486).
 - `static _fitInit(data)` overrides for the specialty no-closed-form distributions `Gompertz`, `Makeham`, `Muth`, `BenktanderII`, `BirnbaumSaunders`, `Davis`, `GeneralizedExponential`, and `Rice`: each provides a best-effort data-aware seed (shifted fatigue-life estimators for `BirnbaumSaunders`, Rayleigh-limit moment inversion for `Rice`, location-shift seeds for `Davis`, and conservative 1/mean-scaled defaults for the rest) so `.fit()` starts from a sensible point instead of the base-class random retry (#488).
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -160,6 +160,12 @@ function parseEntry (entry) {
       output: 'porting-scipy.html',
       navLabel: 'SciPy Porting',
       data: {}
+    },
+    {
+      template: './docs/templates/demo.pug',
+      output: 'demo.html',
+      navLabel: 'Demo',
+      data: {}
     }
   ]
 

--- a/docs/styles/demo.scss
+++ b/docs/styles/demo.scss
@@ -1,0 +1,176 @@
+// Demo page styles. All rules are scoped under body:has(.demo-controls) or
+// .demo-* class selectors to avoid leaking into the API and porting pages.
+// See solutions/tooling/2026-05-24-1439-shared-stylesheet-cross-page-selector-leak.md
+@import "colors";
+@import "dimensions";
+
+
+// ---- Full-width layout override (demo only) ---------------------------------
+// The demo page omits the sidebar entirely. Without this override the desktop
+// rule in desktop.scss pushes main 260px right even when aside is absent.
+body:has(.demo-controls) {
+  main {
+    left: 0;
+    width: 100%;
+    padding: 0 0 64px;
+    max-width: none;
+  }
+
+  // Remove per-child max-width so charts can stretch to full column width.
+  main > * {
+    max-width: none;
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+
+// ---- Control bar ------------------------------------------------------------
+// Sticky strip just below the top nav bar.
+.demo-controls {
+  position: sticky;
+  top: $dimTopBarHeight;
+  z-index: 80;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 20px;
+  background: $colorPanel;
+  border-bottom: 1px solid $colorLine;
+
+  label {
+    font-size: 13px;
+    color: $colorMuted;
+    white-space: nowrap;
+  }
+
+  select,
+  input[type="number"] {
+    font-family: inherit;
+    font-size: 13px;
+    color: $colorInk;
+    background: $colorBg;
+    border: 1px solid $colorLine;
+    border-radius: 4px;
+    padding: 4px 8px;
+    outline: none;
+
+    &:focus { border-color: $colorBlue; }
+  }
+
+  select { min-width: 160px; }
+
+  input[type="number"] { width: 72px; }
+}
+
+.demo-param-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.demo-fit-btn {
+  margin-left: auto;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: $colorBg;
+  background: $colorBlue;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 14px;
+  cursor: pointer;
+
+  &:hover { opacity: 0.88; }
+  &:disabled { opacity: 0.45; cursor: default; }
+}
+
+
+// ---- Chart area -------------------------------------------------------------
+.demo-charts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  padding: 0 20px;
+  margin-top: 20px;
+
+  @media screen and (min-width: 800px) {
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+  }
+}
+
+.demo-chart-panel {
+  h3 {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: $colorAccent;
+    margin: 0 0 8px;
+  }
+}
+
+// Container trick: height:0 + padding-bottom creates a fixed-aspect box;
+// both absolutely-positioned SVGs from dalian stack inside it.
+.demo-chart-wrap {
+  position: relative;
+  height: 0;
+  padding-bottom: 380px;
+  overflow: hidden;
+  background: $colorBg;
+  border: 1px solid $colorLine;
+  border-radius: 6px;
+  margin-bottom: 24px;
+}
+
+
+// ---- Fit results ------------------------------------------------------------
+.demo-fit-section {
+  padding: 0 20px;
+  margin-top: 4px;
+
+  h3 {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: $colorAccent;
+    margin: 0 0 10px;
+  }
+
+  p.demo-fit-msg {
+    font-size: 13px;
+    color: $colorMuted;
+    margin: 0 0 16px;
+  }
+}
+
+.demo-fit-table {
+  width: auto;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-bottom: 24px;
+
+  th, td {
+    padding: 5px 14px;
+    border: 1px solid $colorLine;
+    text-align: right;
+  }
+
+  th {
+    background: $colorPanel;
+    font-weight: 600;
+    color: $colorMuted;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 11px;
+  }
+
+  td:first-child { text-align: left; font-family: 'IBM Plex Mono', monospace; }
+
+  .dev-pos { color: $colorAccent; }
+  .dev-neg { color: $colorBlue; }
+  .dev-zero { color: $colorMuted; }
+}

--- a/docs/styles/index.scss
+++ b/docs/styles/index.scss
@@ -10,3 +10,4 @@
 @import "desktop";
 @import "table";
 @import "porting";
+@import "demo";

--- a/docs/templates/demo.pug
+++ b/docs/templates/demo.pug
@@ -1,0 +1,374 @@
+extends _layout
+
+block content
+    .demo-controls
+        .demo-param-group
+            label(for="dist-select") Distribution
+            select#dist-select
+
+        div#param-inputs
+
+        .demo-param-group
+            label(for="sample-size") Samples
+            input#sample-size(type="number", value="500", min="50", max="5000", step="50")
+
+        button.demo-fit-btn#fit-btn Fit to samples
+
+    .demo-charts
+        .demo-chart-panel
+            h3 PDF / PMF
+            div#pdf-chart.demo-chart-wrap
+        .demo-chart-panel
+            h3 CDF
+            div#cdf-chart.demo-chart-wrap
+
+    .demo-fit-section#fit-section(style="display:none")
+        h3 MLE Fit Results
+        p.demo-fit-msg#fit-msg
+        table.demo-fit-table#fit-table
+            thead
+                tr
+                    th Param
+                    th Planted
+                    th Fitted
+                    th Deviation
+            tbody#fit-tbody
+
+block scripts
+    script(src="https://cdn.jsdelivr.net/npm/ranjs/dist/ranjs.min.js")
+    script(src="https://cdn.jsdelivr.net/npm/dalian/dist/dalian.min.js")
+    script.
+        const DISTRIBUTIONS = {
+          Beta:            { type: 'continuous', args: [{name:'alpha', default:2},    {name:'beta', default:5}] },
+          Cauchy:          { type: 'continuous', args: [{name:'x0', default:0},       {name:'gamma', default:1}] },
+          Exponential:     { type: 'continuous', args: [{name:'lambda', default:1}] },
+          Gamma:           { type: 'continuous', args: [{name:'alpha', default:2},    {name:'beta', default:1}] },
+          LogNormal:       { type: 'continuous', args: [{name:'mu', default:0},       {name:'sigma', default:1}] },
+          Normal:          { type: 'continuous', args: [{name:'mu', default:0},       {name:'sigma', default:1}] },
+          Pareto:          { type: 'continuous', args: [{name:'xmin', default:1},     {name:'alpha', default:2}] },
+          StudentT:        { type: 'continuous', args: [{name:'nu', default:5}] },
+          Uniform:         { type: 'continuous', args: [{name:'xmin', default:0},     {name:'xmax', default:5}] },
+          Weibull:         { type: 'continuous', args: [{name:'lambda', pkey:'lambda2', default:1}, {name:'k', default:1.5}] },
+          Binomial:        { type: 'discrete',   fitDisplay: false, args: [{name:'n', default:10}, {name:'p', default:0.4}] },
+          Geometric:       { type: 'discrete',   args: [{name:'p', default:0.3}] },
+          NegativeBinomial:{ type: 'discrete',   args: [{name:'r', default:5},       {name:'p', default:0.4}] },
+          Poisson:         { type: 'discrete',   args: [{name:'lambda', default:4}] },
+          Zipf:            { type: 'discrete',   fitDisplay: false, args: [{name:'s', default:1}, {name:'N', default:20}] }
+        }
+
+        const distSelect = document.getElementById('dist-select')
+        const paramInputs = document.getElementById('param-inputs')
+        const sampleSizeInput = document.getElementById('sample-size')
+        const fitBtn = document.getElementById('fit-btn')
+        const fitSection = document.getElementById('fit-section')
+        const fitMsg = document.getElementById('fit-msg')
+        const fitTbody = document.getElementById('fit-tbody')
+
+        let currentSamples = null
+        let debounceTimer = null
+        let histChart, pdfLineChart, empCdfChart, theoCdfChart
+        const CHART_H = 380
+
+        // ---- Helpers -------------------------------------------------------
+
+        function chartWidth (id) {
+          return document.getElementById(id).offsetWidth || 600
+        }
+
+        function clamp (v, lo, hi) {
+          return v < lo ? lo : v > hi ? hi : v
+        }
+
+        function linspace (a, b, n) {
+          const step = (b - a) / (n - 1)
+          return Array.from({length: n}, (_, i) => a + i * step)
+        }
+
+        function computeXRange (dist, samples, cfg) {
+          if (cfg.type === 'continuous') {
+            let lo = dist.q(0.001)
+            let hi = dist.q(0.999)
+            // Clamp infinities to sample range with small padding
+            const smin = Math.min(...samples)
+            const smax = Math.max(...samples)
+            const pad = (smax - smin) * 0.1 || 1
+            if (!isFinite(lo)) lo = smin - pad
+            if (!isFinite(hi)) hi = smax + pad
+            return [lo, hi]
+          } else {
+            const smin = Math.min(...samples)
+            const smax = Math.max(...samples)
+            return [smin - 1, smax + 2]
+          }
+        }
+
+        function makeBins (samples, xMin, xMax, nBins) {
+          const binWidth = (xMax - xMin) / nBins
+          const counts = new Array(nBins).fill(0)
+          for (const v of samples) {
+            const i = clamp(Math.floor((v - xMin) / binWidth), 0, nBins - 1)
+            counts[i]++
+          }
+          const n = samples.length
+          return counts.map((c, i) => ({
+            name: 'bin_' + i,
+            value: c / (n * binWidth)
+          }))
+        }
+
+        function makeDiscreteBars (samples, xMin, xMax) {
+          const freq = {}
+          for (const v of samples) {
+            const k = Math.round(v)
+            freq[k] = (freq[k] || 0) + 1
+          }
+          const n = samples.length
+          const bars = []
+          for (let k = Math.round(xMin); k <= Math.round(xMax); k++) {
+            bars.push({ name: 'val_' + k, value: (freq[k] || 0) / n })
+          }
+          return bars
+        }
+
+        function makeEmpiricalCdf (samples) {
+          const sorted = samples.slice().sort((a, b) => a - b)
+          const n = sorted.length
+          return sorted.map((v, i) => ({x: v, y: (i + 1) / n}))
+        }
+
+        // ---- Chart init (called once after DOM ready) -----------------------
+
+        function initCharts () {
+          const wPdf = chartWidth('pdf-chart')
+          const wCdf = chartWidth('cdf-chart')
+
+          histChart = dalian.BarChart('hist', '#pdf-chart')
+            .width(wPdf).height(CHART_H)
+
+          pdfLineChart = dalian.LineChart('pdf-line', '#pdf-chart')
+            .width(wPdf).height(CHART_H)
+            .leftAxis.hideAxisLine(true).leftAxis.label('').leftAxis.values([])
+            .bottomAxis.hideAxisLine(true).bottomAxis.label('').bottomAxis.values([])
+
+          empCdfChart = dalian.LineChart('emp-cdf', '#cdf-chart')
+            .width(wCdf).height(CHART_H)
+
+          theoCdfChart = dalian.LineChart('theo-cdf', '#cdf-chart')
+            .width(wCdf).height(CHART_H)
+            .leftAxis.hideAxisLine(true).leftAxis.label('').leftAxis.values([])
+            .bottomAxis.hideAxisLine(true).bottomAxis.label('').bottomAxis.values([])
+        }
+
+        // ---- Core render ---------------------------------------------------
+
+        function renderDemo (name, params, n) {
+          const cfg = DISTRIBUTIONS[name]
+          const dist = new ranjs.dist[name](...params)
+          const samples = dist.sample(n)
+          const [xMin, xMax] = computeXRange(dist, samples, cfg)
+          const wPdf = chartWidth('pdf-chart')
+          const wCdf = chartWidth('cdf-chart')
+
+          if (cfg.type === 'continuous') {
+            const nBins = Math.min(50, Math.max(10, Math.ceil(Math.sqrt(n))))
+            const bins = makeBins(samples, xMin, xMax, nBins)
+            const xs = linspace(xMin, xMax, 200)
+            const pdfPoints = xs.map(x => ({x, y: dist.pdf(x)})).filter(p => isFinite(p.y))
+            const yPdfMax = Math.max(
+              ...bins.map(b => b.value),
+              ...pdfPoints.map(p => p.y)
+            ) * 1.25 || 1
+
+            histChart
+              .width(wPdf).height(CHART_H)
+              .xRange.min(xMin).xRange.max(xMax)
+              .yRange.min(0).yRange.max(yPdfMax)
+              .data(bins).render()
+
+            pdfLineChart
+              .width(wPdf).height(CHART_H)
+              .xRange.min(xMin).xRange.max(xMax)
+              .yRange.min(0).yRange.max(yPdfMax)
+              .data([{name: 'pdf', values: pdfPoints}]).render()
+
+          } else {
+            const bars = makeDiscreteBars(samples, xMin, xMax)
+            const xs = linspace(xMin, xMax, Math.round(xMax - xMin) + 1)
+            const pmfPoints = xs.map(x => ({x, y: dist.pdf(Math.round(x))})).filter(p => isFinite(p.y))
+            const yPmfMax = Math.max(
+              ...bars.map(b => b.value),
+              ...pmfPoints.map(p => p.y)
+            ) * 1.25 || 1
+
+            histChart
+              .width(wPdf).height(CHART_H)
+              .xRange.min(xMin).xRange.max(xMax)
+              .yRange.min(0).yRange.max(yPmfMax)
+              .data(bars).render()
+
+            pdfLineChart
+              .width(wPdf).height(CHART_H)
+              .xRange.min(xMin).xRange.max(xMax)
+              .yRange.min(0).yRange.max(yPmfMax)
+              .data([{name: 'pmf', values: pmfPoints}]).render()
+          }
+
+          // CDF panel
+          const empPoints = makeEmpiricalCdf(samples)
+          const cdfXs = linspace(xMin, xMax, 200)
+          const cdfPoints = cdfXs.map(x => ({x, y: dist.cdf(x)})).filter(p => isFinite(p.y))
+
+          empCdfChart
+            .width(wCdf).height(CHART_H)
+            .xRange.min(xMin).xRange.max(xMax)
+            .yRange.min(0).yRange.max(1.05)
+            .data([{name: 'empirical', values: empPoints}]).render()
+
+          theoCdfChart
+            .width(wCdf).height(CHART_H)
+            .xRange.min(xMin).xRange.max(xMax)
+            .yRange.min(0).yRange.max(1.05)
+            .data([{name: 'cdf', values: cdfPoints}]).render()
+
+          return samples
+        }
+
+        // ---- Parameter inputs ----------------------------------------------
+
+        function getCurrentParamInputs () {
+          return Array.from(paramInputs.querySelectorAll('input[type="number"]'))
+        }
+
+        function populateParams (name) {
+          const cfg = DISTRIBUTIONS[name]
+          paramInputs.innerHTML = ''
+          cfg.args.forEach(arg => {
+            const group = document.createElement('div')
+            group.className = 'demo-param-group'
+
+            const lbl = document.createElement('label')
+            lbl.textContent = arg.name
+            lbl.setAttribute('for', 'param-' + arg.name)
+
+            const inp = document.createElement('input')
+            inp.type = 'number'
+            inp.id = 'param-' + arg.name
+            inp.value = arg.default
+            inp.step = 'any'
+            inp.addEventListener('input', scheduleUpdate)
+
+            group.appendChild(lbl)
+            group.appendChild(inp)
+            paramInputs.appendChild(group)
+          })
+        }
+
+        // ---- Update loop ---------------------------------------------------
+
+        function scheduleUpdate () {
+          clearTimeout(debounceTimer)
+          debounceTimer = setTimeout(doUpdate, 300)
+        }
+
+        function doUpdate () {
+          const name = distSelect.value
+          const cfg = DISTRIBUTIONS[name]
+          const inputs = getCurrentParamInputs()
+          const params = cfg.args.map((a, i) => {
+            const v = parseFloat(inputs[i] && inputs[i].value)
+            return isNaN(v) ? a.default : v
+          })
+          const n = parseInt(sampleSizeInput.value) || 500
+          currentSamples = null
+          fitSection.style.display = 'none'
+          try {
+            currentSamples = renderDemo(name, params, n)
+          } catch (e) {
+            // Invalid params — charts remain stale; silently skip
+          }
+        }
+
+        // ---- Fit button ----------------------------------------------------
+
+        function showFitResults (rows) {
+          fitTbody.innerHTML = ''
+          rows.forEach(row => {
+            const tr = document.createElement('tr')
+            const devClass = !isFinite(row.deviation) ? 'dev-zero'
+              : row.deviation > 0 ? 'dev-pos' : row.deviation < 0 ? 'dev-neg' : 'dev-zero'
+            const devText = !isFinite(row.deviation) ? '—'
+              : (row.deviation > 0 ? '+' : '') + row.deviation.toFixed(2) + '%'
+            tr.innerHTML = '<td>' + row.name + '</td>'
+              + '<td>' + row.planted.toPrecision(4) + '</td>'
+              + '<td>' + row.fitted.toPrecision(4) + '</td>'
+              + '<td class="' + devClass + '">' + devText + '</td>'
+            fitTbody.appendChild(tr)
+          })
+          fitMsg.textContent = ''
+          fitSection.style.display = ''
+        }
+
+        fitBtn.addEventListener('click', () => {
+          if (!currentSamples) return
+          const name = distSelect.value
+          const cfg = DISTRIBUTIONS[name]
+          const inputs = getCurrentParamInputs()
+          const planted = cfg.args.map((a, i) => {
+            const v = parseFloat(inputs[i] && inputs[i].value)
+            return isNaN(v) ? a.default : v
+          })
+
+          if (cfg.fitDisplay === false) {
+            fitMsg.textContent = 'Fit display not supported for ' + name + ' (pre-computed table distribution).'
+            fitTbody.innerHTML = ''
+            fitSection.style.display = ''
+            return
+          }
+
+          fitBtn.disabled = true
+          fitBtn.textContent = 'Fitting…'
+
+          setTimeout(() => {
+            try {
+              const fitted = ranjs.dist[name].fit(currentSamples)
+              const rows = cfg.args.map((a, idx) => {
+                // See solutions/tooling/2026-05-29-1734-this-p-subclass-pkey-fit-display.md
+                const key = a.pkey || a.name
+                const fittedVal = fitted.p[key]
+                const plantedVal = planted[idx]
+                const dev = (plantedVal !== 0 && isFinite(plantedVal))
+                  ? (fittedVal - plantedVal) / plantedVal * 100
+                  : NaN
+                return {name: a.name, planted: plantedVal, fitted: fittedVal, deviation: dev}
+              })
+              showFitResults(rows)
+            } catch (e) {
+              fitMsg.textContent = 'Fit failed: ' + e.message
+              fitTbody.innerHTML = ''
+              fitSection.style.display = ''
+            }
+            fitBtn.disabled = false
+            fitBtn.textContent = 'Fit to samples'
+          }, 0)
+        })
+
+        // ---- Init ----------------------------------------------------------
+
+        document.addEventListener('DOMContentLoaded', () => {
+          Object.keys(DISTRIBUTIONS).forEach(name => {
+            const opt = document.createElement('option')
+            opt.value = name
+            opt.textContent = name
+            distSelect.appendChild(opt)
+          })
+          distSelect.value = 'Normal'
+          distSelect.addEventListener('change', () => {
+            populateParams(distSelect.value)
+            doUpdate()
+          })
+          sampleSizeInput.addEventListener('input', scheduleUpdate)
+
+          populateParams('Normal')
+          initCharts()
+          doUpdate()
+        })

--- a/solutions/tooling/2026-05-29-1734-this-p-subclass-pkey-fit-display.md
+++ b/solutions/tooling/2026-05-29-1734-this-p-subclass-pkey-fit-display.md
@@ -1,0 +1,50 @@
+---
+date: 2026-05-29T17:34:47Z
+category: "tooling"
+problem: "External code reading fitted.p by constructor argument name silently gets undefined for distributions that rename an inherited parameter in this.p"
+status: complete
+related_issue: "#504"
+related_plan: "thoughts/plans/2026-05-29-1210-demo-page.md"
+tags: [this.p, subclass, parameter-key, fit, weibull, pkey, registry]
+---
+
+# Solution: this.p Subclass Parameter Key Mismatch in Fit Display
+
+**Date**: 2026-05-29T17:34:47Z
+**Category**: tooling
+**Related Issue**: #504
+
+## Problem
+
+When displaying MLE fit results for Weibull, reading `fitted.p.lambda` returns `undefined`. The fit result table showed `undefined` for the fitted lambda value instead of the recovered scale parameter. No error is thrown — the field simply does not exist in `fitted.p`.
+
+## Root Cause
+
+Weibull extends Exponential. Exponential stores its scale parameter as `this.p.lambda`. To avoid overwriting the inherited key, Weibull stores its own scale under `this.p.lambda2`. The constructor takes `(lambda, k)`, but the result lands in `this.p.lambda2`, not `this.p.lambda`.
+
+Any external code that iterates constructor argument names (`'lambda'`, `'k'`) and directly looks up `fitted.p[argName]` will silently receive `undefined` for the scale, because `fitted.p` has no `lambda` key — only `lambda2`.
+
+This class of mismatch affects every distribution that extends another and renames an inherited parameter to avoid a key collision.
+
+## Fix
+
+Added an optional `pkey` field to the DISTRIBUTIONS registry entries. When present, `pkey` overrides the `this.p` lookup key independently of the display name used in the UI label:
+
+```js
+Weibull: { args: [{name:'lambda', pkey:'lambda2', default:1}, {name:'k', default:1.5}] }
+```
+
+Fit result display reads `fitted.p[a.pkey || a.name]` — falls back to the arg name when no override is needed. The UI label still shows `lambda` (the constructor arg name); only the `this.p` lookup is redirected.
+
+## Prevention Strategy
+
+When writing any code that reads `fitted.p` or `dist.p` by key name derived from a constructor argument list, always check whether the distribution extends another class that may have claimed that key. The safe pattern is to provide an explicit key mapping (like `pkey`) rather than assuming constructor arg names match `this.p` keys. When auditing a new distribution: if it calls `super(...)` and the parent also has a parameter with the same name, check that the subclass constructor stores with a different key and that any registry entry documents the mapping.
+
+## Related Solutions
+
+- `solutions/tooling/2026-05-16-1135-docs-pages-array-build.md` — docs build page registration pattern
+- `solutions/tooling/2026-05-24-1439-shared-stylesheet-cross-page-selector-leak.md` — SCSS `:has()` guard scoping
+
+## Key Insight
+
+When a distribution extends another and renames an inherited parameter in `this.p` to avoid collision (e.g., Weibull's `lambda2`), external code reading `fitted.p` by constructor argument name will silently get `undefined`; always map constructor names to `this.p` keys explicitly in any registry that drives fit-result display.


### PR DESCRIPTION
## Summary

- Adds `docs/demo.html` — an interactive page where visitors can select from 15 curated distributions, adjust parameters, view a histogram+PDF overlay and empirical+theoretical CDF side-by-side (rendered with dalian), and run MLE fitting via `fit()` to compare recovered parameters against planted values
- Adds `docs/styles/demo.scss` — demo-specific styles scoped under `body:has(.demo-controls)` to prevent leaking into the API and porting pages
- Registers the demo page in `docs/index.js` (one `pages` entry) so `npm run docs` builds it and the nav shows a "Demo" link on all pages
- Adds `docs/demo.html` to `.gitignore` (consistent with other generated HTML outputs)

## Technical notes

- **`pkey` registry field**: Weibull stores its scale parameter as `this.p.lambda2` (inherits from Exponential which owns `this.p.lambda`). The DISTRIBUTIONS registry uses `{ name: 'lambda', pkey: 'lambda2' }` so fit-result display reads the correct internal key. See `solutions/tooling/2026-05-29-1734-this-p-subclass-pkey-fit-display.md`.
- **`fitDisplay: false`**: Binomial and Zipf are PreComputed subclasses whose `this.p` stores opaque `weights` arrays — named constructor params are not recoverable from `fitted.p`. The fit button shows an explanatory message for these.
- **Chart overlay technique**: `BarChart` and `LineChart` target the same `#pdf-chart` div; the overlay chart suppresses its axes via `.leftAxis.hideAxisLine(true).leftAxis.label('').leftAxis.values([])`. Container uses `height:0; padding-bottom:380px` so both absolutely-positioned SVGs stack at the same pixel coordinates.
- **Discrete x-range**: lower bound is `smin - 1` (no `Math.max(0, ...)` clamp) so Zipf (support `[1, N]`) doesn't get a spurious empty bar at x=0.

## Test plan

- [ ] `npm run docs` completes without errors and produces `docs/demo.html`
- [ ] Nav bar on all pages shows "Demo" link
- [ ] Selecting a distribution updates charts within ~300ms
- [ ] Changing parameters debounces correctly and redraws
- [ ] Histogram bars align with the PDF/PMF curve overlay in the same panel
- [ ] Empirical and theoretical CDFs are both visible in the CDF panel
- [ ] "Fit to samples" on Normal with 500 samples → table shows mu/sigma with small deviation
- [ ] "Fit to samples" on Binomial → "Fit display not supported" message
- [ ] Edge case: Beta(0.01, 0.01) → charts don't crash

https://claude.ai/code/session_01BLKoSLJAe867dpNxiuNgt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLKoSLJAe867dpNxiuNgt1)_