### PR TITLE
Fix four demo page issues

### DIFF
--- a/docs/styles/demo.scss
+++ b/docs/styles/demo.scss
@@ -29,7 +29,7 @@ body:has(.demo-controls) {
 // Sticky strip just below the top nav bar.
 .demo-controls {
   position: sticky;
-  top: $dimTopBarHeight;
+  top: 0;
   z-index: 80;
   display: flex;
   flex-wrap: wrap;

--- a/docs/templates/demo.pug
+++ b/docs/templates/demo.pug
@@ -10,7 +10,7 @@ block content
 
         .demo-param-group
             label(for="sample-size") Samples
-            input#sample-size(type="number", value="500", min="50", max="5000", step="50")
+            input#sample-size(type="number", value="10000", min="10000", max="20000", step="1000")
 
         button.demo-fit-btn#fit-btn Fit to samples
 
@@ -35,7 +35,7 @@ block content
             tbody#fit-tbody
 
 block scripts
-    script(src="https://cdn.jsdelivr.net/npm/ranjs/dist/ranjs.min.js")
+    script(src="../dist/ranjs.min.js")
     script(src="https://cdn.jsdelivr.net/npm/dalian/dist/dalian.min.js")
     script.
         const DISTRIBUTIONS = {
@@ -215,8 +215,24 @@ block scripts
 
           // CDF panel
           const empPoints = makeEmpiricalCdf(samples)
-          const cdfXs = linspace(xMin, xMax, 200)
-          const cdfPoints = cdfXs.map(x => ({x, y: dist.cdf(x)})).filter(p => isFinite(p.y))
+          let cdfPoints
+          if (cfg.type === 'discrete') {
+            // For discrete dists, evaluate CDF at each integer and draw a
+            // staircase by duplicating points: (k-1, CDF(k-1)), (k, CDF(k-1))
+            // so the step rises at the integer, not between integers.
+            const kMin = Math.round(xMin)
+            const kMax = Math.round(xMax)
+            cdfPoints = []
+            for (let k = kMin; k <= kMax; k++) {
+              const prev = k > kMin ? dist.cdf(k - 1) : 0
+              cdfPoints.push({x: k, y: prev})
+              cdfPoints.push({x: k, y: dist.cdf(k)})
+            }
+            cdfPoints = cdfPoints.filter(p => isFinite(p.y))
+          } else {
+            const cdfXs = linspace(xMin, xMax, 200)
+            cdfPoints = cdfXs.map(x => ({x, y: dist.cdf(x)})).filter(p => isFinite(p.y))
+          }
 
           empCdfChart
             .width(wCdf).height(CHART_H)


### PR DESCRIPTION
## Summary
- Fix discrete CDF rendering to show a proper staircase (step rises at each integer k, not between integers)
- Switch ranjs import from CDN to local `../dist/ranjs.min.js` so `fit()` (not yet published) is available
- Tighten sample size input to min=10000/max=20000/step=1000 for more meaningful statistical demos
- Set `.demo-controls` `top: 0` (was `$dimTopBarHeight`) so the control bar sticks to the very top

## Non-trivial changes
- **`docs/templates/demo.pug`**: Discrete CDF was sampled at 200 evenly-spaced x values, causing the step to appear between integers rather than at them. The fix evaluates `cdf(k-1)` and `cdf(k)` at each integer k and emits two points per step, producing a correct staircase aligned with the PMF bars.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`docs/styles/demo.scss`**: `top: $dimTopBarHeight` → `top: 0` on `.demo-controls`
- **`docs/templates/demo.pug`**: Sample size input range/default updated; CDN script tag replaced with local path

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtwNSqYTF4rgWdWPNd4DP2)_