### PR TITLE
Run build before docs so dist/ranjs.min.js is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,7 +460,7 @@
     "jsdoclint": "./node_modules/.bin/eslint --no-eslintrc --config .eslintrc.jsdoc.js src/dist/_distribution.js 'src/dist/[!_]*.js' src/core/index.js src/location src/dispersion src/shape src/dependence src/test",
     "standard": "./node_modules/.bin/standard --fix src/**/*.js test/*.js",
     "test": "./node_modules/.bin/cross-env NODE_ENV=test ./node_modules/.bin/nyc ./node_modules/.bin/_mocha --require @babel/register",
-    "docs": "node ./docs/index.js",
+    "docs": "npm run build && node ./docs/index.js",
     "build": "./node_modules/.bin/rollup -c && ./node_modules/.bin/tsc -p tsconfig.build.json",
     "typecheck": "./node_modules/.bin/tsc --noEmit",
     "check-decl": "node scripts/check-subpath-exports.js",


### PR DESCRIPTION
## Summary
- `npm run docs` now runs `npm run build` first so `dist/ranjs.min.js` exists when the demo page loads it via a local `../dist/ranjs.min.js` path
- Without this, running `npm run docs` in a clean checkout produces a working HTML page that silently fails at runtime because the bundle is missing

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`package.json`**: `"docs"` script changed from `node ./docs/index.js` to `npm run build && node ./docs/index.js`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtwNSqYTF4rgWdWPNd4DP2)_