### PR TITLE
Fix Hyperexponential weight and rate validation

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -19,7 +19,7 @@ This directory contains the skills and agents that power the development workflo
 │   ├── hotfix/SKILL.md       # Leaf: small targeted fix (no research/plan)
 │   ├── commit/SKILL.md       # Leaf: git commit
 │   ├── review/SKILL.md       # Leaf: code review
-│   ├── pull-request/SKILL.md # Leaf: GitHub PR creation + activity watch (CI autofix, review replies)
+│   ├── pr/SKILL.md           # Leaf: GitHub PR creation + activity watch (CI autofix, review replies)
 │   ├── validate/SKILL.md     # Leaf: verify issue acceptance criteria
 │   └── compound/SKILL.md     # Leaf: document solved problems
 └── agents/         # Specialized subagents (not user-invocable)
@@ -73,7 +73,7 @@ Standalone skills that do one thing. Can be called directly or composed by orche
 | [`/commit`](skills/commit/SKILL.md) | Stage and commit with generated message | _(no args)_ |
 | [`/push`](skills/push/SKILL.md) | Push commits to remote | _(no args)_ |
 | [`/review`](skills/review/SKILL.md) | Code review against plan + quality checks | _(no args, reviews current branch)_ |
-| [`/pull-request`](skills/pull-request/SKILL.md) | Create a PR with change categorization, then watch it (auto-fix CI, respond to reviews) | _(no args)_ |
+| [`/pr`](skills/pr/SKILL.md) | Create a PR with change categorization, then watch it (auto-fix CI, respond to reviews) | _(no args)_ |
 | [`/validate`](skills/validate/SKILL.md) | Verify issue acceptance criteria are met | `#issue` or issue URL |
 | [`/next`](skills/next/SKILL.md) | Pick the best next issue from the backlog | Milestone _(optional)_ |
 | [`/suggest`](skills/suggest/SKILL.md) | Suggest and create future issues from codebase analysis | _(no args)_ |
@@ -116,7 +116,7 @@ research → plan → implement → validate → review → ship
 /review                 # Review before pushing
 /compound               # Document what was learned
 /push                   # Push to remote (includes compound commit)
-/pull-request           # Create the PR
+/pr                   # Create the PR
 ```
 
 ### Exploration (no plan needed)
@@ -219,7 +219,7 @@ Launched **in parallel** by [`/suggest`](skills/suggest/SKILL.md). Each scout sc
 
 /push ───────→ (no agents, just git push)
 
-/pull-request → (no agents, ADR gate for non-trivial PRs)
+/pr → (no agents, ADR gate for non-trivial PRs)
 
 /build ──────→ research → plan → implement → validate → triage → review → ship(commit, compound, push, PR)
                Uses all agents: discovery-*, design-*, recovery-*, ops-triage, review-*, ops-*

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -177,9 +177,9 @@ Execute sequentially via the Skill tool **in a single uninterrupted sequence**:
 
 a. **Commit** — invoke `/commit`
 b. **Push** — invoke `/push`
-c. **Pull Request** — invoke `/pull-request`
+c. **Pull Request** — invoke `/pr`
 
-**Do NOT pause, confirm, or ask for permission before push or pull-request.** These are expected pipeline steps already authorized by the user invoking `/build`. Treat them identically to commit — run immediately.
+**Do NOT pause, confirm, or ask for permission before push or pr.** These are expected pipeline steps already authorized by the user invoking `/build`. Treat them identically to commit — run immediately.
 
 **Escalation**: Never.
 

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -82,7 +82,7 @@ Invoke all three sub-skills in sequence **without any pause or output between th
 
 a. **Commit** — invoke `/commit`
 b. **Push** — invoke `/push` immediately after `/commit` returns
-c. **Pull Request** — invoke `/pull-request` immediately after `/push` returns
+c. **Pull Request** — invoke `/pr` immediately after `/push` returns
 
 ### 8. Report
 

--- a/.claude/skills/hotfix/SKILL.md
+++ b/.claude/skills/hotfix/SKILL.md
@@ -86,7 +86,7 @@ Invoke all three sub-skills in sequence **without any pause or output between th
 
 a. **Commit** — invoke `/commit`
 b. **Push** — invoke `/push` immediately after `/commit` returns
-c. **Pull Request** — invoke `/pull-request` immediately after `/push` returns
+c. **Pull Request** — invoke `/pr` immediately after `/push` returns
 
 ### 8. Report
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -8,7 +8,7 @@ Categorize every change as trivial or non-trivial so reviewers can focus their a
 
 ## Workflow
 
-When the user invokes `/pull-request`:
+When the user invokes `/pr`:
 
 ### 1. Gather Context
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ TypeScript declarations are **generated** from JSDoc annotations via `tsc --allo
 - When editing multiple files, make all independent edits in parallel.
 - When performing multi-step tasks, show a progress list with checkboxes (e.g., `- [x]` done, `- [ ]` pending) and update it as you go.
 - **Always use selectable options** (via the `AskUserQuestion` tool) when asking the user to make a choice or design decision during planning or implementation. Never ask the user to type their choice as free text. Always include a final option labeled "Other" or "Type something" so the user can provide a custom answer if none of the options fit.
-- **Never stop mid-pipeline.** When a sub-skill (`/commit`, `/push`, `/pull-request`, etc.) is invoked from within a parent skill (`/hotfix`, `/build`, `/implement`, etc.), continue executing the parent workflow immediately after the sub-skill returns. Do not pause for user input between steps unless the parent skill explicitly requires it. Do not output text that implies completion (e.g. "Done!", "Committed!") between steps — save all status reporting for the parent skill's final report.
+- **Never stop mid-pipeline.** When a sub-skill (`/commit`, `/push`, `/pr`, etc.) is invoked from within a parent skill (`/hotfix`, `/build`, `/implement`, etc.), continue executing the parent workflow immediately after the sub-skill returns. Do not pause for user input between steps unless the parent skill explicitly requires it. Do not output text that implies completion (e.g. "Done!", "Committed!") between steps — save all status reporting for the parent skill's final report.
 
 ## Code Style
 
@@ -160,5 +160,5 @@ ADRs capture significant design decisions and their rationale. They live in `dec
 - **Status lifecycle:** Proposed → Accepted → (Superseded or Deprecated). Accepted ADRs are immutable — supersede, don't edit.
 - **Who writes them:** The `/plan` skill produces ADRs automatically for non-trivial design decisions. For manual work, write the ADR before or alongside the implementation.
 - **Inline references:** After writing an ADR, add a reference at the most relevant code location — a WHY comment at the affected class/function. Use the relative path format: `decisions/NNNN-slug.md — one-line rationale`.
-- **PR gate:** Non-trivial PRs must reference at least one ADR. The `/pull-request` skill enforces this.
+- **PR gate:** Non-trivial PRs must reference at least one ADR. The `/pr` skill enforces this.
 - **Location:** `decisions/` at the repo root.

--- a/src/dist/hyperexponential.js
+++ b/src/dist/hyperexponential.js
@@ -23,21 +23,24 @@ export default class Hyperexponential extends Distribution {
   constructor (parameters) {
     super('continuous', parameters.length)
 
-    // Validate parameters
     const weights = parameters.map(d => d.weight)
+    const rates = parameters.map(d => d.rate)
+    Distribution.validate({
+      r_min: rates.reduce((m, x) => x < m ? x : m, Infinity),
+      w_min: weights.reduce((m, x) => x < m ? x : m, Infinity),
+      n: weights.length
+    }, [
+      'r_min > 0',
+      'w_min > 0',
+      'n > 0'
+    ])
+
     const norm = weights.reduce((acc, d) => d + acc, 0)
     this.p = Object.assign(this.p, {
       weights: weights.map(d => d / norm),
-      rates: parameters.map(d => d.rate),
+      rates,
       n: weights.length
     })
-    Distribution.validate({
-      lambda_i: parameters.reduce((acc, d) => acc * d.rate, 1),
-      n: weights.length
-    }, [
-      'lambda_i > 0',
-      'n > 0'
-    ])
 
     // Set support
     this.s = [{
@@ -49,7 +52,7 @@ export default class Hyperexponential extends Distribution {
     }]
 
     // Categorical generator for weight
-    this.aliasTable = new AliasTable(parameters.map(d => d.weight))
+    this.aliasTable = new AliasTable(weights)
   }
 
   _generator () {

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -2073,8 +2073,11 @@ export default [{
   name: 'Hyperexponential',
   invalidParams: [
     [], // all params required
-    [{ weight: -1, rate: 1 }, { weight: 1, rate: 1 }],
-    [{ weight: 0, rate: 1 }, { weight: 1, rate: 1 }], // lambda_i > 0
+    [[{ weight: -1, rate: 1 }, { weight: 1, rate: 1 }]], // w_min > 0
+    [[{ weight: 0, rate: 1 }, { weight: 1, rate: 1 }]], // w_min > 0
+    [[{ weight: 1, rate: -1 }, { weight: 1, rate: 1 }]], // r_min > 0
+    [[{ weight: 1, rate: 0 }, { weight: 1, rate: 1 }]], // r_min > 0
+    [[{ weight: 1, rate: -2 }, { weight: 1, rate: -3 }]], // r_min > 0 (product of two negatives is positive, min-based check catches it)
     [[]] // n > 0
   ],
   cases: [{


### PR DESCRIPTION
Closes #473

> **⚠ Missing ADR**: This PR contains non-trivial changes but no Architecture Decision Record was found.
> Consider adding one at `decisions/` to document the design rationale.
> See `decisions/0000-template.md` for the format.

## Summary
- Replaces the product-based rate constraint (`lambda_i > 0`) with a per-component minimum check (`r_min > 0`) — the old approach silently accepted an even count of negative rates because their product is positive
- Adds explicit weight validation (`w_min > 0`) so non-positive weights are rejected before `this.p` is assigned
- Validates before assigning `this.p` to avoid partially mutating the object on invalid input
- Fixes `invalidParams` test entries that were spread incorrectly (causing `TypeError` instead of the intended validation error) and adds missing rate-validation cases

## Non-trivial changes
- **`src/dist/hyperexponential.js`**: Validation logic changed — `lambda_i` product replaced by `r_min = rates.reduce(min)` and `w_min = weights.reduce(min)`. Validate is now called before `this.p` is assigned. `AliasTable` construction reuses the already-extracted `weights` array instead of mapping `parameters` a second time.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: `invalidParams` entries corrected to use `[[...]]` double-wrapping (matching the single-array constructor signature); two new invalid-rate cases added for negative and zero rates
- **`.claude/skills/pr/SKILL.md`**, **`.claude/skills/hotfix/SKILL.md`**, **`.claude/skills/fix/SKILL.md`**, **`.claude/skills/build/SKILL.md`**, **`.claude/README.md`**, **`CLAUDE.md`**: `/pull-request` skill renamed to `/pr` throughout

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_013As1qRu73VwWQneQiv4X7T)_