### PR TITLE
Fix wrong this.k parameter count in multi-level distribution subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Mielke` distribution: `aic()` and `bic()` now use the correct parameter count of 2 (not 3 inherited from `Dagum`); the penalty term was over-counted by 1 in every AIC/BIC evaluation (#505).
 
+- Multi-level `Distribution` subclasses now report the correct free-parameter count `k`, fixing systematically wrong `aic()`/`bic()` values: `Weibull` (2), `ExponentiatedWeibull` (3), `Chi2` (1), `MaxwellBoltzmann` (1), `GeneralizedGamma` (3), `LogGamma` (3), and the downstream `Rayleigh` (1) and `HalfGeneralizedNormal` (2). Each previously inherited a mismatched `k` from a parent further up the inheritance chain (#510).
+
 - `Mielke` distribution: `.p` now correctly exposes `{ k, s }` instead of Dagum's inherited `{ p, a, b }` bag; `_pdf`, `_cdf`, and `_q` are overridden to use `k` and `s` directly so that `fit()` parameter recovery and any code reading back `.p.k` / `.p.s` behaves as documented (#480).
 
 - `R`, `F`, `FisherZ`, and `BaldingNichols` `.fit()` no longer inherit `Beta`'s `[alpha, beta]` initializer, which produced a wrong-arity (`R`) or wrong-parametrization init vector that made `fit()` throw or converge to nonsense; each now seeds Nelder-Mead from a distribution-correct method-of-moments estimate (#441).

--- a/src/dist/chi2.js
+++ b/src/dist/chi2.js
@@ -20,6 +20,9 @@ export default class Chi2 extends Gamma {
   constructor (k) {
     super(Math.round(k) / 2, 0.5)
 
+    // Chi2 has 1 free parameter (k); override the 2 inherited from Gamma
+    this.k = 1
+
     // Validate parameters
     Distribution.validate({ k }, [
       'k > 0'

--- a/src/dist/exponentiated-weibull.js
+++ b/src/dist/exponentiated-weibull.js
@@ -22,6 +22,9 @@ export default class ExponentiatedWeibull extends Weibull {
   constructor (lambda, k, alpha) {
     super(lambda, k)
 
+    // ExponentiatedWeibull has 3 free parameters (lambda, k, alpha); override the 2 inherited from Weibull
+    this.k = 3
+
     // Validate parameters.
     this.p = Object.assign(this.p, { lambda2: lambda, alpha })
     Distribution.validate({ lambda, k, alpha }, [

--- a/src/dist/generalized-gamma.js
+++ b/src/dist/generalized-gamma.js
@@ -23,6 +23,9 @@ export default class GeneralizedGamma extends Gamma {
     super(d / p, Math.pow(a, -p))
     this._q = undefined // Gamma._q is wrong for the power transform; fall back to _qEstimateRoot
 
+    // GeneralizedGamma has 3 free parameters (a, d, p); override the 2 inherited from Gamma
+    this.k = 3
+
     // Validate parameters
     this.p = Object.assign(this.p, { a, d, p })
     Distribution.validate({ a, d, p }, [

--- a/src/dist/half-generalized-normal.js
+++ b/src/dist/half-generalized-normal.js
@@ -19,6 +19,9 @@ export default class HalfGeneralizedNormal extends GeneralizedNormal {
   constructor (alpha, beta) {
     super(0, alpha, beta)
 
+    // HalfGeneralizedNormal has 2 free parameters (alpha, beta); override the 3 inherited from GeneralizedNormal
+    this.k = 2
+
     // Set support
     this.s = [{
       value: 0,

--- a/src/dist/log-gamma.js
+++ b/src/dist/log-gamma.js
@@ -23,6 +23,9 @@ export default class LogGamma extends Gamma {
     super(alpha, beta)
     this._q = undefined // Gamma._q is wrong for the log transform; fall back to _qEstimateRoot
 
+    // LogGamma has 3 free parameters (alpha, beta, mu); override the 2 inherited from Gamma
+    this.k = 3
+
     // Validate parameters
     this.p = Object.assign(this.p, { mu })
     Distribution.validate({ mu }, [

--- a/src/dist/maxwell-boltzmann.js
+++ b/src/dist/maxwell-boltzmann.js
@@ -21,6 +21,9 @@ export default class MaxwellBoltzmann extends Gamma {
     super(1.5, 0.5 / (a * a))
     this._q = undefined // Gamma._q is wrong for the sqrt transform; fall back to _qEstimateRoot
 
+    // MaxwellBoltzmann has 1 free parameter (a); override the 2 inherited from Gamma
+    this.k = 1
+
     // Validate parameters
     Distribution.validate({ a }, [
       'a > 0'

--- a/src/dist/rayleigh.js
+++ b/src/dist/rayleigh.js
@@ -18,6 +18,9 @@ export default class Rayleigh extends Weibull {
    */
   constructor (sigma) {
     super(sigma * Math.SQRT2, 2)
+
+    // Rayleigh has 1 free parameter (sigma); override the 2 inherited from Weibull
+    this.k = 1
   }
 
   static _fitInit (data) {

--- a/src/dist/weibull.js
+++ b/src/dist/weibull.js
@@ -22,6 +22,9 @@ export default class Weibull extends Exponential {
   constructor (lambda, k) {
     super(1)
 
+    // Weibull has 2 free parameters (lambda, k); override the 1 inherited from Exponential
+    this.k = 2
+
     // Validate parameters
     this.p = Object.assign(this.p, { lambda2: lambda, k })
     Distribution.validate({ lambda, k }, [

--- a/test/dist.js
+++ b/test/dist.js
@@ -2105,4 +2105,38 @@ describe('dist', () => {
       assert.strictEqual(d.bic(sample), Math.log(sample.length) * 2 - 2 * d.lnL(sample))
     })
   })
+
+  // Multi-level inheritance parameter-count regressions (issue #510). Each subclass inherits the wrong
+  // this.k from a parent further up the chain unless it overrides; a wrong k silently distorts aic()/bic().
+  const paramCountCases = [
+    { name: 'Weibull', ctor: () => new dist.Weibull(1, 1), k: 2, inherited: '1 from Exponential' },
+    { name: 'DoubleWeibull', ctor: () => new dist.DoubleWeibull(1, 1), k: 2, inherited: '1 from Weibull' },
+    { name: 'ExponentiatedWeibull', ctor: () => new dist.ExponentiatedWeibull(1, 1, 1), k: 3, inherited: '2 from Weibull' },
+    { name: 'Rayleigh', ctor: () => new dist.Rayleigh(1), k: 1, inherited: '2 from Weibull' },
+    { name: 'Chi2', ctor: () => new dist.Chi2(4), k: 1, inherited: '2 from Gamma' },
+    { name: 'Chi', ctor: () => new dist.Chi(4), k: 1, inherited: '2 from Gamma via Chi2' },
+    { name: 'MaxwellBoltzmann', ctor: () => new dist.MaxwellBoltzmann(1), k: 1, inherited: '2 from Gamma' },
+    { name: 'GeneralizedGamma', ctor: () => new dist.GeneralizedGamma(1, 1, 1), k: 3, inherited: '2 from Gamma' },
+    { name: 'GeneralizedNormal', ctor: () => new dist.GeneralizedNormal(0, 1, 2), k: 3, inherited: '2 from Gamma via GeneralizedGamma' },
+    { name: 'HalfGeneralizedNormal', ctor: () => new dist.HalfGeneralizedNormal(1, 2), k: 2, inherited: '3 from GeneralizedNormal' },
+    { name: 'LogGamma', ctor: () => new dist.LogGamma(1, 1, 0), k: 3, inherited: '2 from Gamma' }
+  ]
+  paramCountCases.forEach(({ name, ctor, k, inherited }) => {
+    describe(`${name} parameter count`, () => {
+      const sample = [0.1, 0.5, 1.0, 1.5, 2.0, 0.3, 0.8, 1.2, 2.5, 0.6]
+      const d = ctor()
+
+      it(`should have paramCount k=${k}, not the ${inherited}`, () => {
+        assert.strictEqual(d.k, k)
+      })
+
+      it(`aic() should use the corrected parameter penalty (k=${k})`, () => {
+        assert.strictEqual(d.aic(sample), 2 * (k - d.lnL(sample)))
+      })
+
+      it(`bic() should use the corrected parameter penalty (k=${k})`, () => {
+        assert.strictEqual(d.bic(sample), Math.log(sample.length) * k - 2 * d.lnL(sample))
+      })
+    })
+  })
 })


### PR DESCRIPTION
Closes #510

## Summary
- Several distributions that subclass another distribution (rather than `Distribution` directly) inherited the wrong `this.k` free-parameter count, producing systematically wrong `aic()` and `bic()` penalties. This is the same root cause fixed for `Mielke` in #505.
- Each affected class now sets `this.k` to its true free-parameter count immediately after `super(...)`, mirroring the `Mielke` fix.
- Added AIC/BIC parameter-count regression tests for all 11 distributions in the inheritance chains (8 with explicit overrides + 3 that now inherit correctly).

## Non-trivial changes
Each `this.k` correction changes the `aic()`/`bic()` penalty term (behavioral change — model-selection scores shift):

- **`src/dist/weibull.js`**: `this.k = 2` (was 1, inherited from `Exponential`).
- **`src/dist/exponentiated-weibull.js`**: `this.k = 3` (was 2, inherited from `Weibull`).
- **`src/dist/rayleigh.js`**: `this.k = 1` (downstream audit catch — would otherwise inherit 2 from the now-corrected `Weibull`).
- **`src/dist/chi2.js`**: `this.k = 1` (was 2, inherited from `Gamma`).
- **`src/dist/maxwell-boltzmann.js`**: `this.k = 1` (was 2, inherited from `Gamma`).
- **`src/dist/generalized-gamma.js`**: `this.k = 3` (was 2, inherited from `Gamma`).
- **`src/dist/half-generalized-normal.js`**: `this.k = 2` (downstream audit catch — would otherwise inherit 3 from the now-corrected `GeneralizedNormal`).
- **`src/dist/log-gamma.js`**: `this.k = 3` (was 2, inherited from `Gamma`).

`DoubleWeibull` (←`Weibull`=2), `Chi` (←`Chi2`=1), and `GeneralizedNormal` (←`GeneralizedGamma`=3) need no explicit override: their free-parameter count matches their now-corrected immediate parent, so they inherit the right value (same reasoning the issue uses to keep `LogNormal`/`Erlang`/`InverseGamma` out of scope). Regression tests still pin these three to guard against future drift.

**No ADR**: this is a bug fix correcting wrong constants, not an API/convention change — per `CLAUDE.md` bug fixes are documented in the changelog (done) rather than an ADR, consistent with the #505 precedent.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added an `[Unreleased] > Fixed` entry documenting the corrected parameter counts.
- **`test/dist.js`**: Added a data-driven `forEach` regression block (k / aic / bic per distribution), mirroring the existing `Mielke`/`Lindley` blocks.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7fdYPAhdX2hQssPnuHVTg)_