### PR TITLE
Fix NoncentralChi p.lambda storing lambda² instead of lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `NoncentralChi`: `.p.lambda` now stores the user-facing noncentrality parameter `λ` instead of `λ²`; constructing `new NoncentralChi(k, λ).p.lambda` and reading back after `NoncentralChi.fit(data)` now return `λ`, not `λ²` (#491).
+
 - `Mielke` distribution: `aic()` and `bic()` now use the correct parameter count of 2 (not 3 inherited from `Dagum`); the penalty term was over-counted by 1 in every AIC/BIC evaluation (#505).
 
 - Multi-level `Distribution` subclasses now report the correct free-parameter count `k`, fixing systematically wrong `aic()`/`bic()` values: `Weibull` (2), `ExponentiatedWeibull` (3), `Chi2` (1), `MaxwellBoltzmann` (1), `GeneralizedGamma` (3), `LogGamma` (3), and the downstream `Rayleigh` (1) and `HalfGeneralizedNormal` (2). Each previously inherited a mismatched `k` from a parent further up the inheritance chain (#510).

--- a/src/dist/noncentral-chi.js
+++ b/src/dist/noncentral-chi.js
@@ -1,3 +1,5 @@
+import { marcumP, besselI, besselISpherical } from '../special'
+import noncentralChi2 from './_noncentral-chi2'
 import Distribution from './_distribution'
 import NoncentralChi2 from './noncentral-chi2'
 
@@ -27,6 +29,11 @@ export default class NoncentralChi extends NoncentralChi2 {
       'lambda > 0'
     ])
 
+    // Override p to expose user-facing lambda; super stored lambda²
+    this.p = { k: ki, lambda }
+    // Store lambda² for internal delegation to NoncentralChi2 logic
+    Object.assign(this.c, { lambda2: lambda * lambda })
+
     // Set support
     this.s = [{
       value: 0,
@@ -38,16 +45,24 @@ export default class NoncentralChi extends NoncentralChi2 {
   }
 
   _generator () {
-    // Direct sampling by transforming non-central chi2 variate
-    return Math.sqrt(super._generator())
+    return Math.sqrt(noncentralChi2(this.r, this.p.k, this.c.lambda2))
   }
 
   _pdf (x) {
-    return 2 * x * super._pdf(x * x)
+    if (x === 0) {
+      return 0
+    }
+    const x2 = x * x
+    const lambda2 = this.c.lambda2
+    if (this.c.kIsEven) {
+      return x * Math.exp(-0.5 * (x2 + lambda2) + (this.p.k / 4 - 0.5) * Math.log(x2 / lambda2)) * besselI(Math.round(this.p.k / 2) - 1, Math.sqrt(lambda2 * x2))
+    } else {
+      return x * Math.exp(-0.5 * (x2 + lambda2)) * Math.pow(x2 / lambda2, this.p.k / 4 - 0.5) * besselISpherical(Math.floor((this.p.k - 3) / 2), Math.sqrt(lambda2 * x2)) * Math.sqrt(2 * Math.sqrt(x2 * lambda2) / Math.PI)
+    }
   }
 
   _cdf (x) {
-    return super._cdf(x * x)
+    return marcumP(this.p.k / 2, this.c.lambda2 / 2, x * x / 2)
   }
 
   static _fitInit (data) {

--- a/test/dist.js
+++ b/test/dist.js
@@ -1489,8 +1489,7 @@ describe('dist', () => {
         const result = dist.NoncentralChi.fit(data)
         assert(result instanceof dist.NoncentralChi)
         assert(Math.abs(result.p.k - 4) < 0.5)
-        // result.p.lambda stores lambda² (NoncentralChi2 internal form); see #491
-        assert(Math.abs(Math.sqrt(result.p.lambda) - 2) < 0.5)
+        assert(Math.abs(result.p.lambda - 2) < 0.5)
       })
 
       it('NoncentralT.fit should recover nu and mu close to planted values', () => {


### PR DESCRIPTION
Closes #491

## Summary
- `NoncentralChi.p.lambda` was silently storing `lambda²` (the value passed to the `NoncentralChi2` super-constructor) instead of the user-facing `lambda`, causing a round-trip inconsistency and a broken fit-test workaround.
- After `super(ki, lambda * lambda)`, `this.p` is now overridden to store `{ k: ki, lambda }` and `lambda²` is kept in `this.c.lambda2` for internal delegation.
- `_pdf`, `_cdf`, and `_generator` are rewritten to use `this.c.lambda2` directly (bypassing `super.*` calls that would have read `this.p.lambda` and produced wrong results).

## Non-trivial changes
- **`src/dist/noncentral-chi.js`**: Behavioral fix — `p.lambda` now holds the user-facing noncentrality parameter. `_generator` uses the `noncentralChi2` sampler with `this.c.lambda2`; `_cdf` calls `marcumP` directly with `this.c.lambda2`; `_pdf` inlines the even/odd-k Bessel formula with `this.c.lambda2`, eliminating the need for `super._pdf` (which would have used the now-correct `this.p.lambda`).

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Removed `Math.sqrt()` workaround in the fit-test assertion; now checks `result.p.lambda` directly against the planted value.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ4Nm4RjUGzVaGd1SkD7Yt)_