### PR TITLE
Remove .param-name class from parameters table Name header

### DIFF
--- a/docs/templates/index.pug
+++ b/docs/templates/index.pug
@@ -60,7 +60,7 @@ block content
                 table.margined
                     thead
                         tr
-                            th.param-name Name
+                            th Name
                             th.param-type Type
                             th.param-desc Description
                     tbody


### PR DESCRIPTION
Closes #513

## Summary
- Removes the `.param-name` CSS class from the `<th>Name</th>` element in `docs/templates/index.pug` so all three column headers (Name, Type, Description) render under the same `thead th` rule with consistent font-size, weight, case, and colour
- `npm run docs` builds without errors

## Design decisions
- [ADR-0014: Categorical this.c natural params split](decisions/0014-categorical-this-c-natural-params-split.md) — documents the split of internal Categorical lookup state (`n`, `min`) into `this.c`, keeping `this.p` for natural user-facing parameters only

## Non-trivial changes
- **`src/dist/_distribution.js`**: New public `params()` accessor returning `this.p` (natural parameters only)
- **`src/dist/categorical.js`**: Internal state `n` and `min` moved from `this.p` to `this.c`; all nine Categorical subclasses now override `this.p` post-`super()` with their own natural parameters (e.g. `{ p }` for Bernoulli, `{ n, p }` for Binomial)
- **`src/dist/noncentral-chi.js`**: `_pdf`, `_cdf`, and `_generator` rewritten to use `this.c.lambda2` directly; `this.p.lambda` now stores user-facing λ (not λ²)
- **`src/dist/hyperexponential.js`**: Validation changed from product-based rate check (which silently accepted pairs of negative rates) to per-element minimum check
- **Multiple distributions** (Weibull, Chi2, MaxwellBoltzmann, ExponentiatedWeibull, GeneralizedGamma, LogGamma, HalfGeneralizedNormal, Rayleigh): `this.k` overridden to correct parameter count for accurate AIC/BIC in multi-level inheritance chains
- **`src/dist/bernoulli.js`**: `_q` fixed to read `this.pdfTable[0]` instead of `this.p.weights[0]` (the latter no longer exists after the Categorical refactor)

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`docs/templates/index.pug`**: Remove `.param-name` from `<th>Name</th>` (the #513 fix)
- **`CHANGELOG.md`**: Changelog entries for all fixes
- **`.claude/README.md`**: Skill rename `/pull-request` → `/pr`
- **`decisions/0014-categorical-this-c-natural-params-split.md`**: New ADR

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01K71MqGAfPAjLNYnRezxRSH)_