### PR TITLE
Fix SkewNormal positional speed-up constant array

### DIFF
--- a/src/dist/skew-normal.js
+++ b/src/dist/skew-normal.js
@@ -39,10 +39,10 @@ export default class SkewNormal extends Normal {
 
     // Speed-up constants (be aware of the constants for the parent)
     const delta = this.p.alpha / Math.sqrt(1 + this.p.alpha * this.p.alpha)
-    this.c1 = [
+    Object.assign(this.c, {
       delta,
-      Math.sqrt(1 - delta * delta)
-    ]
+      deltaComplement: Math.sqrt(1 - delta * delta)
+    })
   }
 
   _generator () {
@@ -55,7 +55,7 @@ export default class SkewNormal extends Normal {
     const mag = Math.sqrt(-2 * Math.log(bmu))
     const u0 = mag * Math.sin(2 * Math.PI * bmv)
     const v = mag * Math.cos(2 * Math.PI * bmv)
-    const u1 = this.c1[0] * u0 + this.c1[1] * v
+    const u1 = this.c.delta * u0 + this.c.deltaComplement * v
     const z = u0 >= 0 ? u1 : -u1
     return this.p.xi + this.p.omega * z
   }


### PR DESCRIPTION
Closes #472

## Summary
- `SkewNormal` stored speed-up constants in a positional array `this.c1 = [delta, sqrt(1-delta²)]`, violating the named-object convention from [ADR-0008](decisions/0008-this-c-named-object-convention.md).
- Replace with `Object.assign(this.c, { delta, deltaComplement })` and update the two references in `_generator()` to use `this.c.delta` / `this.c.deltaComplement`.
- No mathematical change — delta and deltaComplement values are identical; only the storage convention changes.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/dist/skew-normal.js`**: `this.c1 = [delta, sqrt(1-delta²)]` → `Object.assign(this.c, { delta, deltaComplement })`, and `this.c1[0]`/`this.c1[1]` → `this.c.delta`/`this.c.deltaComplement` in `_generator()`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01McheNHTYJBtA8KEGizG8Ts)_