### PR TITLE
Fix anonymous class declaration in BetaGeometric

### DIFF
--- a/src/dist/beta-geometric.js
+++ b/src/dist/beta-geometric.js
@@ -16,7 +16,7 @@ import rBeta from './_beta'
  * @param {number} beta Second shape parameter.
  * @constructor
  */
-export default class extends PreComputed {
+export default class BetaGeometric extends PreComputed {
   /**
    * @param {number} alpha First shape parameter.
    * @param {number} beta Second shape parameter.


### PR DESCRIPTION
Closes #475

## Summary
- Adds an explicit class name to `BetaGeometric` in `src/dist/beta-geometric.js`, changing `export default class extends PreComputed` to `export default class BetaGeometric extends PreComputed`.
- Without this name, `tsc`'s JSDoc-driven declaration generation produces an anonymous `_default` type in `dist/index.d.ts`, breaking `npm run typecheck`.
- No functional change — PMF, CDF, and sampling behaviour are identical.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_014jpjRgF1R5eFJDu46u7zqu)_