### PR TITLE
Fix Bradford _fitInit small-c approximation coefficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Bradford._fitInit`: the small-`c` mean approximation coefficient corrected from `3·(1−2·mean)` to `6·(1−2·mean)`, matching the correct first-order expansion `E[X] ≈ ½ − c/12`; the previous coefficient underestimated the starting value of `c` by a factor of 2 (#498).
+
 - `NoncentralChi`: `.p.lambda` now stores the user-facing noncentrality parameter `λ` instead of `λ²`; constructing `new NoncentralChi(k, λ).p.lambda` and reading back after `NoncentralChi.fit(data)` now return `λ`, not `λ²` (#491).
 
 - `Mielke` distribution: `aic()` and `bic()` now use the correct parameter count of 2 (not 3 inherited from `Dagum`); the penalty term was over-counted by 1 in every AIC/BIC evaluation (#505).


### PR DESCRIPTION
Closes #498

## Summary
- The `Bradford._fitInit` method used `3·(1−2·mean)` as the inverted mean estimate for `c`, but the correct first-order expansion `E[X] ≈ ½ − c/12` inverts to `c ≈ 6·(1−2·mean)` — the coefficient was off by a factor of 2.
- The code fix (`6 * (1 - 2 * mean)` and updated inline comment) was already committed as part of PR #499 (triage finding from the issue-487 session). This PR adds the missing `CHANGELOG.md` entry to document the fix.
- All three acceptance criteria from the issue are satisfied: `_fitInit` returns `c` within 1.5 of true value, inline comment states `E[X] ≈ ½ − c/12`, and all tests pass.

## Design decisions
- [ADR-0014: Categorical this.c natural params split](decisions/0014-categorical-this-c-natural-params-split.md) — referenced by other commits on this branch; not relevant to the Bradford fix itself.

## Non-trivial changes
_No non-trivial changes — the code fix was already merged in PR #499; this PR is purely a changelog documentation entry._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `### Fixed` bullet documenting the Bradford `_fitInit` coefficient correction (#498)

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3nvDucLthQ4ZrJ5wurf4N)_