### PR TITLE
Fix DoublyNoncentralChi2 fit() non-identifiability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,13 @@ npm run standard
 # Run JSDoc linter (eslint-plugin-jsdoc)
 npm run jsdoclint
 
-# Run tests (Mocha)
+# Run tests (Mocha + coverage thresholds)
 npm test
+# IMPORTANT: always run npm test directly — never pipe it through grep or other
+# commands. The mocha output prints "N passing" even when nyc's coverage
+# thresholds are breached; the failure is only visible in the exit code and the
+# "ERROR: Coverage for X does not meet global threshold" lines that a grep pipe
+# will swallow. Thresholds: branches 90%, lines 98%, functions 100%, statements 98%.
 
 # Build minified bundle
 npm run build

--- a/src/dist/doubly-noncentral-chi2.js
+++ b/src/dist/doubly-noncentral-chi2.js
@@ -1,5 +1,6 @@
 import Distribution from './_distribution'
 import NoncentralChi2 from './noncentral-chi2'
+import nelderMead from '../algorithms/nelder-mead'
 
 /**
  * Probability density function for the [doubly non-central $\chi^2$ distribution]{@link https://doi.org/10.1093/biomet/36.1-2.202}:
@@ -8,6 +9,12 @@ import NoncentralChi2 from './noncentral-chi2'
  *
  * where $f_{\chi^2}(x; \nu)$ is the central $\chi^2$ density with $\nu$ degrees of freedom, $k_1, k_2 \in \mathbb{N}^+$ and $\lambda_1, \lambda_2 \ge 0$. Support: $x \in [0, \infty)$.
  * Formula follows from the Poisson-mixture representation of the non-central χ² in P. B. Patnaik. The non-central χ²- and F-distributions and their applications. *Biometrika*, 36(1–2):202–232, 1949.
+ *
+ * **Non-identifiability warning:** `DoublyNoncentralChi2(k1, k2, λ1, λ2)` is
+ * statistically identical to `NoncentralChi2(k1+k2, λ1+λ2)` — the PDF and
+ * CDF depend only on the sums. Only the sums `k1+k2` and `λ1+λ2` are
+ * identifiable from data. After calling `fit()`, the individual parameters are
+ * an arbitrary symmetric split of the fitted sums; do not interpret them individually.
  *
  * @class DoublyNoncentralChi2
  * @memberof ran.dist
@@ -42,10 +49,40 @@ export default class DoublyNoncentralChi2 extends NoncentralChi2 {
     ])
   }
 
-  static _fitInit (data) {
-    // Collapses to NoncentralChi2(k1+k2, λ1+λ2); split totals symmetrically
-    const [kTot, lambdaTot] = super._fitInit(data)
+  /**
+   * Fits a DoublyNoncentralChi2 to data. Because DNCχ²(k1,k2,λ1,λ2) ≡
+   * ncχ²(k1+k2,λ1+λ2), only the sums are identifiable; fitting is performed
+   * in the collapsed 2D space and the result is split symmetrically.
+   *
+   * @method fit
+   * @memberof ran.dist.DoublyNoncentralChi2
+   * @param {number[]} data Array of sample values.
+   * @returns {DoublyNoncentralChi2} Fitted distribution with k1+k2 and
+   *   lambda1+lambda2 equal to the MLE sums, split symmetrically.
+   */
+  static fit (data) {
+    // DNCχ²(k1,k2,λ1,λ2) ≡ ncχ²(k1+k2,λ1+λ2); fitting in 4D is degenerate
+    // because the likelihood surface is flat in any direction that preserves
+    // the sums. Fit in the 2D collapsed space instead, then split symmetrically.
+    const collapsed = NoncentralChi2.fit(data)
+    let kTot = collapsed.p.k
+    let lambdaTot = collapsed.p.lambda
+    if (kTot < 2) {
+      // kTot=1 can't be split (both k1, k2 must be >= 1). Re-optimize lambda
+      // for k=2 because the lambda fitted for k=1 is suboptimal for k=2.
+      kTot = 2
+      const [optLambda] = nelderMead(
+        ([lambda]) => {
+          try {
+            const v = -new NoncentralChi2(2, Math.max(0, lambda)).lnL(data)
+            return isNaN(v) ? Infinity : v
+          } catch (_) { return Infinity }
+        },
+        [lambdaTot]
+      )
+      lambdaTot = Math.max(0, optLambda)
+    }
     const k = Math.max(1, Math.round(kTot / 2))
-    return [k, Math.max(1, kTot - k), lambdaTot / 2, lambdaTot / 2]
+    return new DoublyNoncentralChi2(k, Math.max(1, kTot - k), lambdaTot / 2, lambdaTot / 2)
   }
 }

--- a/test/dist.js
+++ b/test/dist.js
@@ -1525,6 +1525,15 @@ describe('dist', () => {
         assert(Math.abs((result.p.lambda1 + result.p.lambda2) - 3) <= 2)
       })
 
+      it('DoublyNoncentralChi2.fit should enforce k1>=1 and k2>=1 when collapsed fit returns k=1', () => {
+        // chi-squared(1) data: NoncentralChi2.fit returns k=1, triggering kTot<2 clamp
+        const data = new dist.NoncentralChi2(1, 0).seed(42).sample(500)
+        const result = dist.DoublyNoncentralChi2.fit(data)
+        assert(result instanceof dist.DoublyNoncentralChi2)
+        assert(result.p.k1 >= 1)
+        assert(result.p.k2 >= 1)
+      })
+
       it('DoublyNoncentralBeta.fit should recover alpha and beta close to planted values', () => {
         const data = new dist.DoublyNoncentralBeta(2, 3, 1, 1).seed(42).sample(500)
         const result = dist.DoublyNoncentralBeta.fit(data)


### PR DESCRIPTION
Closes #492

## Summary
- `DoublyNoncentralChi2(k1, k2, λ1, λ2) ≡ NoncentralChi2(k1+k2, λ1+λ2)` — the old `_fitInit` override returned 4 params and let Nelder-Mead search a degenerate 4D likelihood surface, converging to an arbitrary split.
- Replaced `_fitInit` with a proper `static fit()` override that fits in the 2D collapsed space via `NoncentralChi2.fit(data)`, then splits the result symmetrically.
- Added a JSDoc non-identifiability warning on the class so users know individual split parameters are not meaningful.

## Non-trivial changes
- **`src/dist/doubly-noncentral-chi2.js`**: Replaces `static _fitInit()` (4-param seed for a degenerate 4D Nelder-Mead) with `static fit()` that delegates to `NoncentralChi2.fit(data)` in 2D, then splits `kTot` and `lambdaTot` symmetrically. When `NoncentralChi2.fit` returns `k=1` (the minimum, not splittable into two positive integers), `kTot` is clamped to 2 and `lambda` is re-optimized for the constrained k=2 model via a 1D Nelder-Mead pass.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtTd1zGZAyFGGM79vyxkGU)_