### PR TITLE
test: remove vacuous Exponential.fit instanceof-only assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ d.lnL(data)       // log-likelihood over an array of observations
 d.aic(data)       // Akaike information criterion
 d.bic(data)       // Bayesian information criterion
 d.test(data)      // KS test (continuous) or chi-squared test (discrete)
+d.seed(value)     // set PRNG seed; returns the instance
 d.save()          // serialise PRNG state + parameters to a plain object
 d.load(state)     // restore from a saved state; returns the instance
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A comprehensive JavaScript library for probability distributions, random variate
 
 ## Features
 
-- **140+ probability distributions** — continuous and discrete, each with PDF/PMF, CDF, quantile, hazard, survival, likelihood, AIC/BIC, and built-in goodness-of-fit testing
+- **140+ probability distributions** — continuous and discrete, each with PDF/PMF, CDF, quantile (`q`), hazard, survival, log-likelihood (`lnL`), AIC/BIC, goodness-of-fit testing, and MLE fitting (`fit`)
 - **Statistical measures** — location (mean, median, mode, …), dispersion (variance, IQR, Gini, …), shape (skewness, kurtosis, …), and dependence (Pearson, Spearman, Kendall, …)
 - **Hypothesis tests** — Bartlett, Levene, Brown–Forsythe, Mann–Whitney U, HSIC
 - **MCMC samplers** — random-walk Metropolis and slice sampling with Gelman–Rubin convergence diagnostics
@@ -138,17 +138,22 @@ Every distribution exposes a consistent interface:
 ```javascript
 const d = new ran.dist.Gamma(2, 1)
 
+d.type()          // 'continuous' or 'discrete'
+d.params()        // current parameter object, e.g. { alpha: 2, beta: 1 }
+d.support()       // [{ value, closed }, { value, closed }] — lower/upper bounds
 d.sample(n)       // generate n random variates
 d.pdf(x)          // probability density / mass function
 d.cdf(x)          // cumulative distribution function
-d.quantile(p)     // inverse CDF
+d.q(p)            // inverse CDF (quantile function)
 d.survival(x)     // complementary CDF  (1 − CDF)
 d.hazard(x)       // hazard rate        (pdf / survival)
 d.cHazard(x)      // cumulative hazard  (−log survival)
-d.likelihood(xs)  // log-likelihood over an array of observations
-d.aic(xs)         // Akaike information criterion
-d.bic(xs)         // Bayesian information criterion
-d.test(xs)        // KS test (continuous) or chi-squared test (discrete)
+d.lnL(data)       // log-likelihood over an array of observations
+d.aic(data)       // Akaike information criterion
+d.bic(data)       // Bayesian information criterion
+d.test(data)      // KS test (continuous) or chi-squared test (discrete)
+
+ran.dist.Gamma.fit(data)  // static — MLE fit; returns a new instance
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -148,10 +148,13 @@ d.q(p)            // inverse CDF (quantile function)
 d.survival(x)     // complementary CDF  (1 − CDF)
 d.hazard(x)       // hazard rate        (pdf / survival)
 d.cHazard(x)      // cumulative hazard  (−log survival)
+d.lnPdf(x)        // log probability density / mass
 d.lnL(data)       // log-likelihood over an array of observations
 d.aic(data)       // Akaike information criterion
 d.bic(data)       // Bayesian information criterion
 d.test(data)      // KS test (continuous) or chi-squared test (discrete)
+d.save()          // serialise PRNG state + parameters to a plain object
+d.load(state)     // restore from a saved state; returns the instance
 
 ran.dist.Gamma.fit(data)  // static — MLE fit; returns a new instance
 ```

--- a/test/dist.js
+++ b/test/dist.js
@@ -417,12 +417,6 @@ describe('dist', () => {
         assert(Math.abs(result.p.sigma - Math.sqrt(2)) < 0.1)
       })
 
-      it('Exponential.fit should return an Exponential instance', () => {
-        const data = Array.from({ length: 20 }, (_, i) => (i + 1) * 0.1)
-        const result = dist.Exponential.fit(data)
-        assert(result instanceof dist.Exponential)
-      })
-
       it('Alpha.fit() returns a valid Alpha instance', () => {
         const data = new dist.Alpha(2, 1).seed(42).sample(100)
         const result = dist.Alpha.fit(data)


### PR DESCRIPTION
The recovery test at line 642 already verifies the fitted lambda is
close to the planted value, making the instanceof-only check redundant
and misleading.

Closes #467

https://claude.ai/code/session_01QsNV5kgiMZAnCYrZJN4Uen