### PR TITLE
Codify 0/NaN/Infinity/throw return conventions; adopt scipy-style versioning

### DIFF
--- a/.claude/agents/ops-issue.md
+++ b/.claude/agents/ops-issue.md
@@ -1,6 +1,6 @@
 ---
 name: ops-issue
-description: Creates a single GitHub issue with structured body, priority label (high/medium/low), difficulty label (difficult/moderate/trivial), optional major label for breaking changes, and milestone assignment. Returns the created issue URL.
+description: Creates a single GitHub issue with structured body, priority label (high/medium/low), difficulty label (difficult/moderate/trivial), optional breaking label for breaking changes, and milestone assignment. Returns the created issue URL.
 model: haiku
 tools:
   - Bash
@@ -13,7 +13,7 @@ You are a specialist at creating well-structured GitHub issues.
 
 ## Your Purpose
 
-Create a single GitHub issue with a standardized body structure, two required label dimensions (priority and difficulty), an optional `major` label for breaking changes, and a milestone.
+Create a single GitHub issue with a standardized body structure, two required label dimensions (priority and difficulty), an optional `breaking` label for breaking changes, and a milestone.
 
 ## Input
 
@@ -22,8 +22,9 @@ You will receive:
 2. **body** — Issue body in markdown (see template below)
 3. **priority** — One of: `high`, `medium`, `low`
 4. **difficulty** — One of: `difficult`, `moderate`, `trivial`
-5. **breaking** (optional) — `true` if this issue introduces a breaking API change. Adds the `major` label and routes to the `v2.0.0` milestone. Default: `false`.
-6. **extra_labels** (optional) — Additional labels (e.g. `enhancement`, `bug`)
+5. **breaking** (optional) — `true` if this issue introduces a breaking API change. Adds the `breaking` label as a severity marker. Does **not** change the milestone — breaking changes ship in ordinary minor releases behind a deprecation cycle. Default: `false`.
+6. **milestone** (optional) — Milestone number or title to assign. If omitted, use the current next-release milestone (the lowest open `vX.Y.0`).
+7. **extra_labels** (optional) — Additional labels (e.g. `enhancement`, `bug`)
 
 If the input already contains a fully formed body, use it as-is. If the input is a rough description, structure it into the template below.
 
@@ -50,8 +51,8 @@ If the input already contains a fully formed body, use it as-is. If the input is
 ## Execution
 
 1. **Validate inputs** — priority must be one of `high`/`medium`/`low`; difficulty must be one of `difficult`/`moderate`/`trivial`. If invalid, default to `medium` and `moderate`. Determine labels and milestone:
-   - `breaking: true` → labels include `major`; milestone = `v2.0.0`
-   - `breaking: false` (default) → no semver label; milestone = `v1.25.0`
+   - `breaking: true` → labels include `breaking` (a severity marker only).
+   - The milestone is **independent of `breaking`**: use the explicit `milestone` input if given, otherwise the current next-release milestone (lowest open `vX.Y.0`). A breaking change gets the same milestone as everything else.
 
 2. **Detect available tooling** — Check whether `gh` is available by running `gh --version`. If it succeeds, use the `gh` CLI path (steps 3a–4a). If it fails or is not found, use the GitHub MCP server path (steps 3b–4b).
 
@@ -62,7 +63,7 @@ If the input already contains a fully formed body, use it as-is. If the input is
    Label colors:
    - `high` → `d73a4a` (red), `medium` → `fbca04` (yellow), `low` → `0e8a16` (green)
    - `difficult` → `5319e7` (purple), `moderate` → `1d76db` (blue), `trivial` → `bfdadc` (light gray)
-   - `major` → `b60205` (dark red)
+   - `breaking` → `b60205` (dark red)
 
 4a. **[gh path] Resolve milestone and create issue**:
    ```bash
@@ -71,15 +72,13 @@ If the input already contains a fully formed body, use it as-is. If the input is
    # gh milestone create --title "<milestone>"
    # MILESTONE_NUM=$(gh milestone list --json number,title -q '.[] | select(.title == "<milestone>") | .number')
    gh issue create --title "<title>" --body "<body>" \
-     --label "<priority>,<difficulty>[,major][,<extra_labels>]" \
+     --label "<priority>,<difficulty>[,breaking][,<extra_labels>]" \
      --milestone "$MILESTONE_NUM"
    ```
 
 3b. **[MCP path] Ensure labels exist** — Use `mcp__github__get_label` to check whether each required label exists. For any that are missing, apply them via `mcp__github__issue_write` — the API auto-creates unknown labels on first use.
 
-4b. **[MCP path] Resolve milestone number** — Use the following mapping (update when milestones change):
-   - `v1.25.0` → milestone number **1**
-   - `v2.0.0` → milestone number **2**
+4b. **[MCP path] Resolve milestone number** — If the caller passed an explicit `milestone` number, use it directly. Otherwise list milestones via `mcp__github__list_issues` (inspect the `milestone` object on returned issues) or the milestones API and pick the lowest open `vX.Y.0`. Do not hardcode a fixed number — the next-release milestone advances over time.
 
 5b. **[MCP path] Create the issue** — Call `mcp__github__issue_write` with `method: "create"`, passing `title`, `body`, `labels`, and `milestone` (number from step 4b).
 
@@ -88,8 +87,8 @@ If the input already contains a fully formed body, use it as-is. If the input is
 ## Rules
 
 1. **Always apply priority and difficulty** — every issue gets exactly one of each
-2. **Apply `major` only for breaking changes** — constructor/public-method rename or removal, or a wrong-distribution fix that changes computed values for the same inputs
-3. **Always assign a milestone** — `v2.0.0` for breaking issues, `v1.25.0` for everything else
+2. **Apply `breaking` only for breaking changes** — constructor/public-method rename or removal, or changed return shapes. It is a severity marker and does not affect the milestone. (Wrong-formula bug fixes are not breaking.)
+3. **Always assign a milestone** — the explicit `milestone` input if provided, otherwise the current next-release milestone (lowest open `vX.Y.0`). Breaking issues are not routed to a special milestone.
 4. **Imperative titles** — must start with a verb (Add, Create, Update, Fix, Implement, Remove, etc.) and be ≤ 70 chars
 5. **Testable acceptance criteria** — each criterion must be objectively verifiable
 6. **Output only the issue URL** — no explanation, no preamble, just the URL

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -44,35 +44,34 @@ LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
 **If a `version` argument was provided**, use it as `VERSION` directly.
 
-**Otherwise, infer the bump type** by checking whether any `major`-labelled
-issues were closed since the last tag:
+**Otherwise, default to a minor bump**: `X.Y.Z` → `X.(Y+1).0`.
+
+Under the numpy/scipy-style versioning policy, **breaking changes ship in
+minor releases** (behind a deprecation cycle), so the `breaking` label does
+**not** trigger a major bump. A major bump (`X.Y.Z` → `(X+1).0.0`) is reserved
+for a rare, sweeping overhaul and is only ever done by passing an explicit
+`version` argument — never inferred automatically from issue labels.
+
+Surface any `breaking`-labelled issues closed since the last tag so the
+operator is aware of behavior changes in this minor release (informational
+only — it does not change the bump type):
 
 ```bash
 if [ -n "$LAST_TAG" ]; then
   LAST_TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
-  MAJOR_CLOSED=$(gh issue list \
+  BREAKING_CLOSED=$(gh issue list \
     --state closed \
-    --label major \
+    --label breaking \
     --json number,closedAt,title \
     --jq ".[] | select(.closedAt > \"$LAST_TAG_DATE\") | \"#\(.number) \(.title)\"")
-else
-  MAJOR_CLOSED=$(gh issue list \
-    --state closed \
-    --label major \
-    --json number,title \
-    --jq '.[] | "#\(.number) \(.title)"')
 fi
 ```
 
-- If `MAJOR_CLOSED` is non-empty → **bump major**: `X.Y.Z` → `(X+1).0.0`
-- Otherwise → **bump minor**: `X.Y.Z` → `X.(Y+1).0`
-
-Compute `NEXT_VERSION` (the non-major milestone to create after this release):
+Compute `NEXT_VERSION` (the milestone to create after this release):
 - Any release `X.Y.0` → next is `X.(Y+1).0`
-- Major release `(X+1).0.0` → next is `(X+1).1.0`
 
-Print `VERSION`, the bump type (major/minor), any triggering major issues, and
-`NEXT_VERSION` so the operator can confirm before continuing.
+Print `VERSION`, the bump type, any `breaking`-labelled issues in the release,
+and `NEXT_VERSION` so the operator can confirm before continuing.
 
 ---
 
@@ -238,9 +237,9 @@ else
 fi
 ```
 
-Note: the `v2.0.0` major milestone (and any other future major milestone) is
-never touched by this skill — only the milestone whose title matches
-`v${VERSION}` is closed.
+Note: only the milestone whose title matches `v${VERSION}` is closed and
+rotated. Any future major-overhaul milestone, if one is ever created, is left
+untouched by this skill.
 
 ---
 
@@ -265,7 +264,7 @@ Milestone v{NEXT_VERSION}: created
   nothing is published to npm
 - **Milestone rotation is best-effort** — if the milestone is missing, warn
   and continue; do not abort the release
-- **Only touch the released milestone** — leave `v2.0.0` and any other future
-  major milestone untouched when releasing a minor version
+- **Only touch the released milestone** — leave any future major-overhaul
+  milestone untouched when releasing a minor version
 - **No interactive prompts mid-pipeline** — if anything is ambiguous, abort
   early with a clear message rather than pausing mid-release

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -34,11 +34,8 @@ jobs:
             await github.rest.issues.createComment({
               owner, repo, issue_number,
               body: [
-                '**No milestone assigned.** Please assign this issue to the appropriate release milestone:',
+                '**No milestone assigned.** Please assign this issue to the current next-release milestone (the lowest open `vX.Y.0`).',
                 '',
-                '| Issue type | Milestone |',
-                '|---|---|',
-                '| Breaking change (has `major` label) | `v2.0.0` |',
-                '| Everything else | `v1.25.0` |',
+                'There is no separate breaking-change milestone: per the numpy/scipy-style versioning policy, breaking changes ship in ordinary minor releases (behind a deprecation cycle). Issues labelled `breaking` go to the same milestone as everything else.',
               ].join('\n'),
             })

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,23 @@ npm run typecheck
 
 **Distribution naming:** File names are kebab-case (`log-normal.js`); exported class names are PascalCase (`LogNormal`). Pre-computed table distributions extend `PreComputed` from `_pre-computed.js`.
 
+## Return Value and Error Conventions
+
+Every public function and method signals "no ordinary result" through exactly one of four channels. Pick the channel by **what kind of situation occurred**, not by convenience. See `decisions/0015-return-value-and-error-conventions.md`.
+
+| Situation | Channel | Rationale |
+| --- | --- | --- |
+| **Caller/programming error** — invalid or missing parameters, failed constraint, wrong arity, dimension mismatch, structurally impossible input (e.g. negative count) | **`throw Error(...)`** | Fail fast and loud. The caller has a bug that must be fixed, not handled at runtime. Matches the constructor contract (ADR-0004). |
+| **Valid in-domain query, but the answer is mathematically indeterminate / does not exist** — mean of Cauchy, skewness of a point mass, `0/0` | **`NaN`** | Keeps numeric methods typed `number` (the `.d.ts` are generated from JSDoc). Matches SciPy/R and JS-native math (`Math.sqrt(-1)`). |
+| **Valid query, but the answer diverges** — variance of Pareto with α ≤ 2, every moment of Lévy | **`Infinity` / `-Infinity`** | Carries strictly more information than `NaN`: "grows without bound" ≠ "no value at all". Never collapse divergence to `NaN`. |
+| **The mathematically correct value happens to be zero** — pdf/cdf/pmf evaluated outside the support | **`0`** | Not an error: probability really is zero there. Do not throw or return `NaN`. |
+
+**`undefined` is not an error sentinel.** Do not return `undefined` to mean "computation failed" or "value does not exist". It breaks generated TypeScript types (forces `number | undefined` across the whole numeric API), is silently dropped by `JSON.stringify`, and is foreign to the numerical-computing idiom. `undefined` is acceptable *only* for a genuinely optional/absent value where the caller is expected to branch on presence — never as a stand-in for `NaN`, `Infinity`, or a thrown error.
+
+**Applies everywhere, not just distributions.** `ran.core`, `ran.special`, `ran.algorithms`, and `ran.la` follow the same split: `throw` for contract violations (wrong arity, dimension mismatch, impossible input); `NaN`/`±Infinity` for out-of-domain or divergent math. **Never wrap hot numeric loops in `throw`/`try` for ordinary out-of-domain inputs** — let the math produce `NaN`/`Infinity`.
+
+**Known deviation:** `Distribution.q(p)` returns `undefined` for `p ∉ [0, 1]`. This predates the convention and is a caller error that *should* throw; correcting it is a breaking change tracked for a major release. Do not copy this pattern into new code.
+
 ## Testing Conventions
 
 - Tests live in `test/` and mirror `src/` module structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Every public function and method signals "no ordinary result" through exactly on
 
 **Applies everywhere, not just distributions.** `ran.core`, `ran.special`, `ran.algorithms`, and `ran.la` follow the same split: `throw` for contract violations (wrong arity, dimension mismatch, impossible input); `NaN`/`±Infinity` for out-of-domain or divergent math. **Never wrap hot numeric loops in `throw`/`try` for ordinary out-of-domain inputs** — let the math produce `NaN`/`Infinity`.
 
-**Known deviation:** `Distribution.q(p)` returns `undefined` for `p ∉ [0, 1]`. This predates the convention and is a caller error that *should* throw; correcting it is a breaking change tracked for a major release. Do not copy this pattern into new code.
+**Known deviation:** `Distribution.q(p)` returns `undefined` for `p ∉ [0, 1]`. This predates the convention and is a caller error that *should* throw; correcting it is a breaking change that ships through the standard deprecation cycle in an ordinary minor release (see "Versioning and Changelog"). Do not copy this pattern into new code.
 
 ## Testing Conventions
 
@@ -88,8 +88,9 @@ Every public function and method signals "no ordinary result" through exactly on
 
 - **Always use the `ops-issue` agent** when creating GitHub issues. Never call `gh issue create` directly.
 - Every issue must have a **priority** label (`high`, `medium`, `low`) and a **difficulty** label (`difficult`, `moderate`, `trivial`).
-- Breaking-change issues also get a **`major`** label. Breaking means: constructor or public-method rename/removal, or intentional parameter convention changes. Bug fixes — including wrong-formula corrections — are not major even if they change computed values; document them in the changelog instead. Everything else gets no semver label.
-- Every issue must be assigned to a **milestone**: `v2.0.0` for `major` issues, `v1.25.0` for everything else. The `ops-issue` agent sets this automatically. A GitHub Actions workflow (`.github/workflows/require-milestone.yml`) flags any issue opened without a milestone.
+- Breaking-change issues also get a **`breaking`** label. Breaking means: constructor or public-method rename/removal, intentional parameter convention changes, or changed return shapes. Bug fixes — including wrong-formula corrections — are not breaking even if they change computed values; document them in the changelog instead. The `breaking` label is a **severity/communication marker**, not a milestone router — breaking changes ship in ordinary minor releases (see "Versioning"), so they get the same milestone as everything else.
+- A breaking change must first ship a **deprecation cycle** before the old behavior is removed. The issue that *introduces the deprecation warning* gets the `breaking` label; a separate follow-up issue (one release later) does the actual removal. See "Versioning and Changelog" for the cycle rules.
+- Every issue must be assigned to the **current next-release milestone** (the lowest open `vX.Y.0`). There is no separate breaking-change milestone. The `ops-issue` agent sets this automatically. A GitHub Actions workflow (`.github/workflows/require-milestone.yml`) flags any issue opened without a milestone.
 - **One concern per issue.** Reject titles that contain `+`, "and", or comma-separated lists of changes.
 - **PR size cap is enforced via the issue template.** Production-code diff must stay under ~400 lines (tests excluded). If a feature can't fit, decompose before filing.
 - **Mandatory bug triage on every fix/hotfix/build.** `/hotfix`, `/fix`, and `/build` each have a dedicated **Bug Triage** stage that invokes the `ops-triage` agent to classify observations into `definite` / `ambiguous` / `not_a_bug`. `definite` bugs are auto-filed via `ops-issue` in a batch; `ambiguous` cases are escalated to the user in a single prompt; `not_a_bug` is silent. Do not skip the stage even if the session feels clean — the agent will skim the diff for red flags as a safety net.
@@ -119,10 +120,19 @@ When a change touches many files (new base class method, convention rename acros
 
 **Release model: batched.** PRs are merged without bumping the version. When enough changes have accumulated, a dedicated release PR bumps the version, promotes `[Unreleased]` to the new version, and triggers the npm publish.
 
+**Versioning policy: numpy/scipy-style (NEP 23 / SPEC 0).** Breaking API changes are allowed in **minor** releases — we do **not** reserve a `vX.0.0` bump for each breaking change. The cost of doing so safely is a mandatory deprecation cycle (below). A major bump is reserved for rare, sweeping overhauls (the way numpy went 1.x → 2.0 once in ~18 years), not for individual breaking changes.
+
 **Semver tiers:**
 - **Patch** (`x.y.Z`): dependency updates, bug fixes, internal refactors with no API change.
-- **Minor** (`x.Y.0`): new distributions, new public methods, additive API changes.
-- **Major** (`X.0.0`): breaking API changes (parameter renames, removed methods, changed return shapes).
+- **Minor** (`x.Y.0`): new distributions, new public methods, additive API changes, **and breaking changes that have completed their deprecation cycle.**
+- **Major** (`X.0.0`): reserved for a sweeping, library-wide overhaul. Individual breaking changes do **not** trigger a major bump.
+
+**Deprecation cycle (required before any breaking removal):**
+1. **Introduce the warning.** In one minor release, keep the old behavior working but emit a `console.warn('[ranjs] <thing> is deprecated and will be removed in vX.Y.0; use <replacement>.')` on first use. Add a `### Deprecated` bullet to `CHANGELOG.md` naming the target removal version. The issue doing this carries the `breaking` label.
+2. **Hold.** The warning must remain for **at least one** released minor version so downstream users see it before the behavior changes.
+3. **Remove.** In a later minor release, a separate follow-up issue removes the old behavior. Add a `### Removed` changelog bullet referencing the deprecation. Never collapse steps 1 and 3 into a single release.
+
+Truly unavoidable immediate breaks (e.g. a security fix with no compatible path) may skip the cycle, but must be called out explicitly in the changelog with the rationale.
 
 **Per-PR changelog rule:** If a PR makes a user-visible change (bug fix, new feature, dependency security fix, removed dead code), add a bullet to the `## [Unreleased]` section of `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Pure refactors, test-only changes, and doc-only changes do not need a changelog entry.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,27 @@ d.load(state)     // restore from a saved state; returns the instance
 ran.dist.Gamma.fit(data)  // static — MLE fit; returns a new instance
 ```
 
+## Return values and errors
+
+`ranjs` signals an unusual result through one of four channels, chosen by the *kind* of situation:
+
+| Situation | What you get |
+| --- | --- |
+| Invalid input — missing/NaN parameters, broken constraints, wrong arity, mismatched dimensions | a **thrown `Error`** |
+| A valid query whose answer is mathematically undefined (e.g. the mean of a Cauchy distribution) | **`NaN`** |
+| A valid query whose answer diverges (e.g. the variance of a Pareto with shape ≤ 2, any moment of a Lévy) | **`Infinity`** (or `-Infinity`) |
+| A correct value that simply equals zero (e.g. a density evaluated outside the support) | **`0`** |
+
+Functions never return `undefined` to mean "failed" or "does not exist" — numeric results stay numbers (`NaN`/`Infinity`), and genuine misuse throws. `NaN` and `Infinity` are kept distinct on purpose: `NaN` means *no value exists*, `Infinity` means *the value grows without bound*. This mirrors the conventions of SciPy and R.
+
+```javascript
+const ran = require('ranjs')
+
+new ran.dist.Cauchy(0, 1).mean()       // => NaN       (undefined moment)
+new ran.dist.Pareto(1, 2).variance()   // => Infinity  (divergent moment)
+new ran.dist.Normal(0, 1).pdf(-Infinity) // => 0       (outside support)
+```
+
 ## Documentation
 
 Full API reference and distribution catalogue: [https://synesenom.github.io/ran/](https://synesenom.github.io/ran/)

--- a/decisions/0015-return-value-and-error-conventions.md
+++ b/decisions/0015-return-value-and-error-conventions.md
@@ -1,0 +1,99 @@
+# ADR-0015: Return-value and error conventions (0 / NaN / Infinity / throw)
+
+**Date**: 2026-05-31
+**Status**: Accepted
+
+## Context
+
+The library signals "no ordinary result" inconsistently. A survey of the
+codebase found four different channels in use with no written rule governing
+which to pick:
+
+- Constructors **throw** on invalid parameters (ADR-0004).
+- `Distribution.q(p)` returns **`undefined`** for `p ∉ [0, 1]`.
+- `pdf`/`cdf` return **`0`** outside the support.
+- `_pre-computed.js` returns **`undefined`** when a sampler exhausts its tables.
+- `core`, `special`, and `algorithms` have essentially no input guards — they
+  rely on IEEE-754 to produce `NaN`/`Infinity` implicitly.
+
+The trigger was the v1.29.0 theoretical-moments work (#403 and its
+per-distribution follow-ups), which introduced `mean()`/`variance()`/
+`skewness()`/`kurtosis()` returning `NaN` for undefined moments (Cauchy) and
+`Infinity` for divergent ones (Lévy, Pareto with α ≤ 2). Reviewers asked
+whether `NaN` was arbitrary and whether the whole library should instead
+standardise on `undefined`, or alternatively always `throw`.
+
+Returning `undefined` as a failure sentinel is actively harmful in this
+codebase specifically:
+
+- TypeScript declarations are **generated** from JSDoc (ADR-0010, ADR-0003).
+  A numeric method that can return `undefined` is typed `number | undefined`,
+  forcing null-checks across an otherwise purely numeric API.
+- `JSON.stringify` **drops** `undefined`-valued keys and turns `undefined`
+  array elements into `null`, corrupting any serialized moment vector or
+  saved state.
+- It is foreign to the numerical-computing idiom. `Math.sqrt(-1)` is `NaN`,
+  `Math.log(0)` is `-Infinity`; SciPy returns `nan`, R returns `NaN`. #403
+  explicitly models SciPy/R behaviour.
+
+Collapsing everything to `throw` is equally wrong: wrapping hot numeric
+kernels in exceptions for ordinary out-of-domain inputs is slow, breaks
+vectorised use, and is not how `Math.*`/NumPy/SciPy behave.
+
+The information distinction between `NaN` and `Infinity` is real and worth
+preserving: an *indeterminate* moment (Cauchy mean) is `NaN` — no value
+exists — whereas a *divergent* moment (Lévy mean) is `Infinity` — the value
+grows without bound. Collapsing both to one sentinel discards information a
+caller may legitimately branch on.
+
+## Decision
+
+Adopt a four-channel convention, applied across **all** modules (`dist`,
+`core`, `special`, `algorithms`, `la`, …). The channel is chosen by the
+*kind* of situation, never by convenience:
+
+1. **`throw Error(...)`** — caller/programming errors: invalid or missing
+   parameters, failed constraints, wrong arity, dimension mismatch,
+   structurally impossible input (e.g. a negative count). Fail fast and loud.
+
+2. **`NaN`** — a valid in-domain query whose answer is mathematically
+   indeterminate / does not exist (mean of Cauchy, skewness of a point mass,
+   `0/0`).
+
+3. **`Infinity` / `-Infinity`** — a valid query whose answer diverges
+   (variance of Pareto with α ≤ 2, every moment of Lévy). Never collapse
+   divergence to `NaN`.
+
+4. **`0`** — when the mathematically correct value is zero (pdf/cdf/pmf
+   outside the support). Not an error.
+
+`undefined` is **not** an error sentinel. It is permitted only for a
+genuinely optional/absent value where the caller is expected to branch on
+presence — never as a stand-in for `NaN`, `Infinity`, or a thrown error.
+
+Hot numeric loops must not be wrapped in `throw`/`try` for ordinary
+out-of-domain inputs; let the arithmetic yield `NaN`/`Infinity`.
+
+This convention is documented user-facing in `README.md` and for
+contributors in `CLAUDE.md`.
+
+## Consequences
+
+**Easier**:
+- One rule covers every module; reviewers and contributors have an objective
+  test for which channel to use.
+- Generated `.d.ts` stay clean (`number`, not `number | undefined`).
+- Behaviour matches SciPy/R, lowering surprise for users porting code.
+- `NaN` vs `Infinity` preserves the indeterminate-vs-divergent distinction.
+
+**Harder**:
+- Existing deviations must be migrated. Known cases: `Distribution.q(p)` and
+  `_pre-computed.js` return `undefined`; `core`/`special`/`algorithms` lack
+  explicit input guards. These are filed as follow-up issues.
+
+**Risk**:
+- Changing `q(p)` from `undefined` to a thrown error (or to `NaN`) is a
+  **breaking change** and must be routed to a major release (v2.0.0), not
+  bundled with the additive v1.26.0 cleanups. Non-breaking guard additions
+  (where the function currently produces a silently-wrong number) are not
+  breaking and land in v1.26.0.

--- a/decisions/0015-return-value-and-error-conventions.md
+++ b/decisions/0015-return-value-and-error-conventions.md
@@ -92,8 +92,9 @@ contributors in `CLAUDE.md`.
   explicit input guards. These are filed as follow-up issues.
 
 **Risk**:
-- Changing `q(p)` from `undefined` to a thrown error (or to `NaN`) is a
-  **breaking change** and must be routed to a major release (v2.0.0), not
-  bundled with the additive v1.26.0 cleanups. Non-breaking guard additions
-  (where the function currently produces a silently-wrong number) are not
-  breaking and land in v1.26.0.
+- Changing `q(p)` from `undefined` to a thrown error is a **breaking change**.
+  Per the project's numpy/scipy-style versioning policy it ships in an ordinary
+  minor release behind a deprecation cycle (warn first, remove a release later),
+  carrying the `breaking` label — not a `v2.0.0` major bump. Non-breaking guard
+  additions (where the function currently produces a silently-wrong number) are
+  not breaking and need no deprecation cycle.

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -546,7 +546,7 @@ class Distribution {
    */
   q (p) {
     if (p < 0 || p > 1) {
-      // Known deviation from decisions/0015-return-value-and-error-conventions.md — an out-of-range p is a caller error that should throw; kept as undefined for backward compatibility until a major release.
+      // Known deviation from decisions/0015-return-value-and-error-conventions.md — an out-of-range p is a caller error that should throw; deprecation+removal tracked in #592/#594.
       return undefined
     } else if (p === 0) {
       // If zero, return lower support boundary

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -546,7 +546,7 @@ class Distribution {
    */
   q (p) {
     if (p < 0 || p > 1) {
-      // If out of bounds, return undefined
+      // Known deviation from decisions/0015-return-value-and-error-conventions.md — an out-of-range p is a caller error that should throw; kept as undefined for backward compatibility until a major release.
       return undefined
     } else if (p === 0) {
       // If zero, return lower support boundary


### PR DESCRIPTION
## Summary
- Codify a single, library-wide rule for how `ranjs` signals "no ordinary result": `throw` for caller errors, `NaN` for indeterminate values, `Infinity`/`-Infinity` for divergent values, `0` for genuine zeros — and `undefined` is never an error sentinel. Documented user-facing in `README.md`, for contributors in `CLAUDE.md`, with rationale in **ADR-0015**.
- Adopt numpy/scipy-style versioning: breaking API changes ship in **minor** releases behind a mandatory deprecation cycle (warn → hold ≥1 release → remove), instead of forcing a major bump. The `major` label/`v2.0.0` routing is replaced with a `breaking` severity marker.
- Propagate the policy through the tooling that encoded the old rule: the `ops-issue` agent, the `/release` skill's auto-bump logic, and the `require-milestone` workflow.

## Design decisions
- [ADR-0015: Return-value and error conventions](decisions/0015-return-value-and-error-conventions.md) — four-channel rule (0/NaN/Infinity/throw), `undefined` banned as a failure sentinel, applied across all modules; the `q(p)` deviation now ships through a deprecation cycle.

## Non-trivial changes
- **`CLAUDE.md`**: New "Return Value and Error Conventions" section (four-channel table keyed by situation kind). Rewrote the Versioning section to scipy-style minor-release breaking changes + a 3-step deprecation cycle, and the GitHub Issues section so `breaking` is a severity marker that no longer routes to a special milestone.
- **`README.md`**: New user-facing "Return values and errors" section with a table and runnable examples (Cauchy→`NaN`, Pareto→`Infinity`, outside-support→`0`).
- **`.claude/agents/ops-issue.md`**: `breaking` label is severity-only; milestone is resolved from the current next-release milestone instead of a hardcoded `v1.25.0`/`v2.0.0` map; `major` → `breaking` throughout.
- **`.claude/skills/release/SKILL.md`**: Release defaults to a minor bump and never auto-infers a major bump from labels; closed `breaking` issues are surfaced informationally only.
- **`.github/workflows/require-milestone.yml`**: Dropped the breaking→`v2.0.0` milestone table from the bot comment.
- **`src/dist/_distribution.js`**: Annotated the pre-existing `q(p)` `undefined` return as a known deviation, pointing at the #592 (deprecate) / #594 (remove) cycle. No behavior change.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

> Note: This PR is documentation/policy + a one-line WHY comment — no functional code or tests change. The behavioral follow-ups it sets up are tracked as separate issues (#589, #590, #591, #592, #593, #594).

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01AirtnakdhcembgdQP735GZ)_