### PR TITLE
Add deprecation warning to Distribution.q(p) for out-of-range p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- `Distribution.q(p)` called with `p` outside `[0, 1]` now emits a one-time `console.warn`; the current behavior (returning `undefined`) is unchanged this release. The method will **throw** in v1.27.0 (see #594).
+
 ### Fixed
 
 - `Davis._cdf(x)` now uses a dual Bose-Einstein series (upper incomplete gamma series for x near μ, Bernoulli/Laurent series for large x) instead of Romberg integration; per-call cost drops from ~100ms to ~10µs, enabling full goodness-of-fit coverage with the standard sample size (#451).

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -15,6 +15,9 @@ import { MAX_ITER } from '../core/constants'
  * @class Distribution
  * @memberof ran.dist
  */
+// Warn once when q(p) is called with p outside [0,1]; removal tracked in #594
+let _qOutOfRangeWarned = false
+
 class Distribution {
   constructor (type, k) {
     // decisions/0009-rename-single-letter-instance-fields.md — descriptive names replace single-letter abbreviations
@@ -546,7 +549,10 @@ class Distribution {
    */
   q (p) {
     if (p < 0 || p > 1) {
-      // Known deviation from decisions/0015-return-value-and-error-conventions.md — an out-of-range p is a caller error that should throw; deprecation+removal tracked in #592/#594.
+      if (!_qOutOfRangeWarned) {
+        _qOutOfRangeWarned = true
+        console.warn('[ranjs] Distribution.q(p) with p outside [0,1] is deprecated and will throw in v1.27.0; currently returns undefined.')
+      }
       return undefined
     } else if (p === 0) {
       // If zero, return lower support boundary


### PR DESCRIPTION
Closes #592

## Summary
- `Distribution.q(p)` now emits a one-time `console.warn` when `p` is outside `[0, 1]`, signalling that this currently-`undefined` return will become a `throw` in v1.27.0.
- Behavior is unchanged this release — still returns `undefined` for out-of-range `p`.
- `CHANGELOG.md` `### Deprecated` entry added under `## [Unreleased]`, naming v1.27.0 and #594 as the removal target.

## Non-trivial changes
- **`src/dist/_distribution.js`**: Added module-level `_qOutOfRangeWarned` flag and `console.warn` inside `q(p)`'s `p < 0 || p > 1` branch. The flag is module-scoped so the warning fires at most once per process (idiomatic Node.js deprecation pattern — avoids log spam across many distribution instances).

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `### Deprecated` bullet under `## [Unreleased]`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQuGnEyKmh8LJJHW6DfPqG)_