### PR TITLE
Return NaN instead of undefined from quantile estimators and pre-computed sampler

### DIFF
--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -151,7 +151,7 @@ class Distribution {
    * @method _qEstimateTable
    * @memberof ran.dist.Distribution
    * @param {number} p Probability to find value for.
-   * @returns {number} The lower boundary of the interval that satisfies F(x) = p if found, undefined otherwise.
+   * @returns {number} The lower boundary of the interval that satisfies F(x) = p if found, NaN otherwise.
    * @protected
    * @ignore
    */
@@ -185,6 +185,8 @@ class Distribution {
         k2 = k
       }
     }
+
+    return NaN
   }
 
   // _qEstimateTable is broken for negative-integer support (hardwired start at k=0); use this instead.
@@ -228,8 +230,7 @@ class Distribution {
    * @method _qEstimateRoot
    * @memberof ran.dist.Distribution
    * @param {number} p Probability to find value for.
-   * @returns {number|undefined} The value where the probability coincides with the specified value if found,
-   * undefined otherwise.
+   * @returns {number} The value where the probability coincides with the specified value if found, NaN otherwise.
    * @protected
    * @ignore
    */
@@ -263,6 +264,8 @@ class Distribution {
         brent(t => this.cdf(t) - p, ...bounds), this.s[0].value), this.s[1].value
       )
     }
+
+    return NaN
   }
 
   /**

--- a/src/dist/_pre-computed.js
+++ b/src/dist/_pre-computed.js
@@ -112,8 +112,7 @@ export default class PreComputed extends Distribution {
       }
     } while (tableIndex < this.MAX_NUMBER_OF_TABLES)
 
-    // TODO Should throw an error
-    // If did not find sample in max number of tables, return undefined
+    return NaN
   }
 
   _pdf (x) {

--- a/test/dist.js
+++ b/test/dist.js
@@ -315,6 +315,23 @@ describe('dist', () => {
       })
     })
 
+    describe('._qEstimateRoot()', () => {
+      it('returns NaN when bracket cannot be found (degenerate equal-bound open support)', () => {
+        // Support [5, 5] (both open, both equal) collapses delta to 0, so a0 === b0 and bracket() returns undefined.
+        class DegenerateContinuous extends Distribution {
+          constructor () {
+            super('continuous', 0)
+            this.s = [{ value: 5, closed: false }, { value: 5, closed: false }]
+          }
+
+          _pdf () { return 0 }
+          _cdf () { return 0.5 }
+        }
+        const d = new DegenerateContinuous()
+        assert(Number.isNaN(d.q(0.5)))
+      })
+    })
+
     describe('.survive()', () => {
       it('should throw not implemented error', () => {
         assert.throws(() => {
@@ -1987,6 +2004,16 @@ describe('dist', () => {
       // cdfTable[0] = 0.5+eps, cdfTable[1] ≈ 1 + 2eps > 1; re-reading from cache must still return ≤ 1
       assert.isAtMost(d._cdf(0), 1)
       assert.isAtMost(d._cdf(1), 1)
+    })
+
+    it('_generator returns NaN when all alias tables are exhausted (zero-probability PMF)', () => {
+      // _pk returns 0 for every k, so every alias table always routes to the overflow slot (TABLE_SIZE).
+      // After MAX_NUMBER_OF_TABLES tables the do-while exits without sampling, and must return NaN not undefined.
+      class ZeroMassDist extends PreComputed {
+        _pk () { return 0 }
+      }
+      const d = new ZeroMassDist()
+      assert(Number.isNaN(d._generator()))
     })
   })
 


### PR DESCRIPTION
Closes #590

## Summary
- `_qEstimateRoot`, `_qEstimateTable`, and `PreComputed._generator` previously fell off the end of their failure paths, implicitly returning `undefined`. Each now returns `NaN` explicitly, aligning with the return-value convention codified in ADR-0015.
- `q(p)` for valid `p ∈ (0, 1)` now propagates `NaN` when estimation fails, never `undefined`.
- Tests added for both the `_qEstimateRoot` failure path (degenerate equal-bound open support forces `bracket()` to return `undefined`) and the `PreComputed._generator` exhaustion path (zero-mass PMF exhausts all 100 alias tables).

## Design decisions
- [ADR-0015: Return value and error conventions](decisions/0015-return-value-and-error-conventions.md) — `NaN` is the correct channel for a valid in-domain query whose answer is mathematically indeterminate; `undefined` must never be used as a numeric error sentinel.

## Non-trivial changes
- **`src/dist/_distribution.js`**: `_qEstimateRoot` and `_qEstimateTable` now have explicit `return NaN` on their failure exits. JSDoc `@returns` tags updated from `{number|undefined}` to `{number}` to reflect that `NaN` is a `number`.
- **`src/dist/_pre-computed.js`**: `_generator()` returns `NaN` (not implicit `undefined`) when all `MAX_NUMBER_OF_TABLES` alias tables are exhausted without yielding a sample.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Two new test cases added for the NaN failure paths.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_019VKcWUvJm8D3sDmM9PF7Hn)_