### PR TITLE
Add NaN domain guard to lambertW0 and lambertW1m

### DIFF
--- a/src/special/lambert-w.js
+++ b/src/special/lambert-w.js
@@ -18,13 +18,16 @@ function _halley (z, w0) {
  * Computes the Lambert W function (branch -1) using Halley's method.
  * Source: Corless et al: On the Lambert W Function (https://cs.uwaterloo.ca/research/tr/1993/03/W.pdf)
  *
- * @method lamberW1m
+ * @method lambertW1m
  * @memberof ran.special
- * @param z {number} Value to evaluate the Lambert W function at.
- * @returns {number} Value of the Lambert W function.
+ * @param {number} z Value to evaluate the Lambert W function at. Valid range: [-1/e, 0).
+ * @returns {number} Value of the Lambert W function, or NaN if z is outside [-1/e, 0).
  * @private
  */
 export function lambertW1m (z) {
+  if (z < -Math.exp(-1) || z >= 0) {
+    return NaN
+  }
   // TODO Find better w0
   return _halley(z, -2)
 }
@@ -36,10 +39,13 @@ export function lambertW1m (z) {
  *
  * @method lambertW0
  * @memberof ran.special
- * @param {number} z Value to evaluate the Lambert W function at.
- * @returns {number} Value of the Lambert W function.
+ * @param {number} z Value to evaluate the Lambert W function at. Valid range: [-1/e, ∞).
+ * @returns {number} Value of the Lambert W function, or NaN if z < -1/e.
  * @private
  */
 export function lambertW0 (z) {
+  if (z < -Math.exp(-1)) {
+    return NaN
+  }
   return _halley(z, z < 1 ? 0 : Math.log(z))
 }

--- a/test/special.js
+++ b/test/special.js
@@ -444,9 +444,35 @@ describe('special', () => {
   })
 
   describe('.lambertW0()', () => {
-    it('should satisfy the W * exp(W) = x equation', () => {
+    it('should return NaN for z < -1/e', () => {
+      assert(isNaN(special.lambertW0(-1)))
+      assert(isNaN(special.lambertW0(-0.5)))
+      assert(isNaN(special.lambertW0(-Math.exp(-1) - 1e-10)))
+    })
+
+    it('should return -1 at the branch point z = -1/e', () => {
+      assert(Math.abs(special.lambertW0(-Math.exp(-1)) + 1) < 1e-6)
+    })
+
+    it('should return 0 at z = 0', () => {
+      assert(special.lambertW0(0) === 0)
+    })
+
+    it('should return 1 at z = e', () => {
+      assert(equal(special.lambertW0(Math.E), 1))
+    })
+
+    it('should satisfy the W * exp(W) = x equation for x >= 0', () => {
       repeat(() => {
         const x = Math.random() * 10
+        const w = special.lambertW0(x)
+        assert(equal(w * Math.exp(w), x))
+      }, LAPS)
+    })
+
+    it('should satisfy the W * exp(W) = x equation for x in [-1/e, 0)', () => {
+      repeat(() => {
+        const x = -(Math.random() * (1 / Math.E - 1e-9) + 1e-9)
         const w = special.lambertW0(x)
         assert(equal(w * Math.exp(w), x))
       }, LAPS)
@@ -454,9 +480,29 @@ describe('special', () => {
   })
 
   describe('.lambertW1m()', () => {
+    it('should return NaN for z < -1/e', () => {
+      assert(isNaN(special.lambertW1m(-1)))
+      assert(isNaN(special.lambertW1m(-0.5)))
+      assert(isNaN(special.lambertW1m(-Math.exp(-1) - 1e-10)))
+    })
+
+    it('should return NaN for z >= 0', () => {
+      assert(isNaN(special.lambertW1m(0)))
+      assert(isNaN(special.lambertW1m(1)))
+      assert(isNaN(special.lambertW1m(0.1)))
+    })
+
+    it('should return -1 at the branch point z = -1/e', () => {
+      assert(Math.abs(special.lambertW1m(-Math.exp(-1)) + 1) < 1e-6)
+    })
+
+    it('should return known value at z = -0.1', () => {
+      assert(equal(special.lambertW1m(-0.1), -3.577152063957297))
+    })
+
     it('should satisfy the W * exp(W) = x equation', () => {
       repeat(() => {
-        const x = -1 * Math.random() / Math.E
+        const x = -(Math.random() * (1 / Math.E - 1e-9) + 1e-9)
         const w = special.lambertW1m(x)
         assert(equal(w * Math.exp(w), x))
       }, LAPS)


### PR DESCRIPTION
Closes #591

## Summary
- `lambertW0` and `lambertW1m` previously fed out-of-domain arguments straight into the Halley iteration, returning a garbage real number instead of `NaN`. This adds explicit guards that return `NaN` immediately for any `z < -1/e`, aligning both functions with ADR-0015.
- `lambertW1m` (branch W₋₁) gets an additional guard for `z >= 0`, since the W₋₁ branch is only real on `[-1/e, 0)`.
- JSDoc updated: typo `@method lamberW1m` fixed; `@param` and `@returns` now document the valid domain and NaN semantics.

## Design decisions
- [ADR-0015: Return-value and error conventions](decisions/0015-return-value-and-error-conventions.md) — out-of-domain math returns `NaN`; this PR brings `lambertW0`/`lambertW1m` into compliance.

## Non-trivial changes
- **`src/special/lambert-w.js`**: Behavioral change — inputs below `-1/e` (and `>= 0` for `lambertW1m`) now return `NaN` instead of a convergence artifact from the Halley iteration. `Math.exp(-1)` is used for `-1/e` (no `EXP_M1` constant existed in `src/core/constants.js`).

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/special.js`**: New tests for NaN on out-of-domain inputs, branch-point value (`W(-1/e) = -1`), known reference value (`lambertW1m(-0.1) ≈ -3.5772`), and identity `W·eᵂ = z` coverage for the negative sub-domain `[-1/e, 0)` (previously untested).
- **`src/special/lambert-w.js`** (JSDoc only): Typo fix and domain/NaN documentation in `@param`/`@returns`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_015Gn6GgP5rrs5sGemMh4uqg)_