### PR TITLE
Fix Davis._cdf boundary guard for survival/hazard/cHazard

### DIFF
--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -154,7 +154,7 @@ class Distribution {
    * @method _qEstimateTable
    * @memberof ran.dist.Distribution
    * @param {number} p Probability to find value for.
-   * @returns {number} The lower boundary of the interval that satisfies F(x) = p if found, undefined otherwise.
+   * @returns {number} The lower boundary of the interval that satisfies F(x) = p if found, NaN otherwise.
    * @protected
    * @ignore
    */
@@ -188,6 +188,8 @@ class Distribution {
         k2 = k
       }
     }
+
+    return NaN
   }
 
   // _qEstimateTable is broken for negative-integer support (hardwired start at k=0); use this instead.

--- a/src/dist/davis.js
+++ b/src/dist/davis.js
@@ -89,6 +89,7 @@ export default class Davis extends Distribution {
 
   // See solutions/distribution/2026-05-30-2141-davis-bose-einstein-cdf-series.md
   _cdf (x) {
+    if (x <= this.p.mu) return 0
     const T = this.p.b / (x - this.p.mu)
     const n = this.p.n
 

--- a/test/dist.js
+++ b/test/dist.js
@@ -2205,6 +2205,20 @@ describe('dist', () => {
     { name: 'HalfGeneralizedNormal', ctor: () => new dist.HalfGeneralizedNormal(1, 2), k: 2, inherited: '3 from GeneralizedNormal' },
     { name: 'LogGamma', ctor: () => new dist.LogGamma(1, 1, 0), k: 3, inherited: '2 from Gamma' }
   ]
+  describe('Davis', () => {
+    it('survival/hazard/cHazard below support return 1/0/0', () => {
+      const d = new dist.Davis(1, 1, 2.5)
+      // x well below support (tests the x < mu path)
+      assert.strictEqual(d.survival(0.5), 1)
+      assert.strictEqual(d.hazard(0.5), 0)
+      assert.strictEqual(d.cHazard(0.5), 0)
+      // x exactly at the open lower boundary mu (tests the x === mu path of x <= mu guard)
+      assert.strictEqual(d.survival(1), 1)
+      assert.strictEqual(d.hazard(1), 0)
+      assert.strictEqual(d.cHazard(1), 0)
+    })
+  })
+
   paramCountCases.forEach(({ name, ctor, k, inherited }) => {
     describe(`${name} parameter count`, () => {
       const sample = [0.1, 0.5, 1.0, 1.5, 2.0, 0.3, 0.8, 1.2, 2.5, 0.6]


### PR DESCRIPTION
Closes #601

## Summary
- `Davis._cdf` was missing an `if (x <= this.p.mu) return 0` guard, causing `survival()`, `hazard()`, and `cHazard()` to return `NaN` for inputs at or below the open lower boundary `mu`
- `Distribution._qEstimateTable` fell off the end of its binary-search loop without returning, producing an implicit `undefined` — replaced with an explicit `return NaN` per ADR-0015

## Non-trivial changes
- **`src/dist/davis.js`**: Added the missing open-boundary guard to `_cdf`. The `_pdf` method already had `if (y <= 0) return 0`, but `_cdf` was rewritten for the Bose-Einstein series (#451) and the guard was not carried over. Without it, `survival(x) = 1 - _cdf(x)` computes `1 - (b/(x-mu))` on a negative denominator and returns `NaN` instead of `1`.
- **`src/dist/_distribution.js`**: `_qEstimateTable` silently returned `undefined` after `MAX_ITER` binary-search iterations. This is a contract violation per ADR-0015 (`undefined` is never an error sentinel). Added `return NaN`.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_013YkQXeEgbgbKprQReS29Wc)_