### PR TITLE
Fix bracket preserving zero boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `bracket()` now returns the caller-supplied initial `[a0, b0]` when no root is found and either boundary is `0` (#604).
 - `bracket`, `brent`, and `newton` in `src/algorithms/` now return `NaN` (instead of `undefined`) on failure paths; `quickselect` now throws for an out-of-range index. `Distribution._qEstimateRoot` propagates `NaN` on bracket failure (#589).
 - `Davis._cdf(x)` now uses a dual Bose-Einstein series (upper incomplete gamma series for x near μ, Bernoulli/Laurent series for large x) instead of Romberg integration; per-call cost drops from ~100ms to ~10µs, enabling full goodness-of-fit coverage with the standard sample size (#451).
 - `Bates.fit()` now uses a profile likelihood grid search over integer `n` instead of the inherited 3-parameter Nelder-Mead, which stalled on the staircase likelihood surface caused by integer rounding; `n` is now reliably recovered (#481).

--- a/src/algorithms/bracket.js
+++ b/src/algorithms/bracket.js
@@ -17,7 +17,9 @@ const SCALE = 1.618
  * @param {Object[]=} s Object containing the constraints on the lower and upper bracket. Each constraint has a
  * <code>closed</code> and <code>value</code> property denoting if the constraint is a closed interval and the value of
  * the boundaries. If not set, (-inf, inf) is applied.
- * @return {(number[]|number)} Array containing the bracket around the root if successful, NaN otherwise.
+ * @return {(number[]|number)} Array `[a, b]` containing a bracket around the root if a sign change is
+ *   found, the original `[a0, b0]` if the search exhausts MAX_ITER iterations without converging, or
+ *   NaN if `a0 === b0`.
  * @private
  */
 export default function (f, a0, b0, s) {

--- a/src/algorithms/bracket.js
+++ b/src/algorithms/bracket.js
@@ -66,5 +66,5 @@ export default function (f, a0, b0, s) {
   }
 
   // Return boundary anyway.
-  return [a0 || a, b0 || b]
+  return [a0, b0]
 }

--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -36,11 +36,18 @@ describe('algorithms', () => {
 
     it('should return the specified boundaries if root was not found', () => {
       const bracket = algorithms.bracket(
-        t => Math.exp(-t) + 1,
+        t => 1,
         0,
         2
       )
       assert(bracket[0] === 0 && bracket[1] === 2)
+
+      const reverseBracket = algorithms.bracket(
+        t => 1,
+        -2,
+        0
+      )
+      assert(reverseBracket[0] === -2 && reverseBracket[1] === 0)
     })
   })
 

--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -40,14 +40,16 @@ describe('algorithms', () => {
         0,
         2
       )
-      assert(bracket[0] === 0 && bracket[1] === 2)
+      assert.strictEqual(bracket[0], 0)
+      assert.strictEqual(bracket[1], 2)
 
       const reverseBracket = algorithms.bracket(
         t => 1,
         -2,
         0
       )
-      assert(reverseBracket[0] === -2 && reverseBracket[1] === 0)
+      assert.strictEqual(reverseBracket[0], -2)
+      assert.strictEqual(reverseBracket[1], 0)
     })
   })
 


### PR DESCRIPTION
## Summary
- preserve zero-valued initial boundaries when `bracket()` does not find a root
- add regression coverage for both `a0 === 0` and `b0 === 0` non-convergence cases

Closes #597

## Tests
- `./node_modules/.bin/cross-env NODE_ENV=test ./node_modules/.bin/_mocha --require @babel/register test/algorithms.js`