### PR TITLE
Apply ADR-0015 return-value compliance to la, statistics, and ts modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `bracket`, `brent`, and `newton` in `src/algorithms/` now return `NaN` (instead of `undefined`) on failure paths; `quickselect` now throws for an out-of-range index. `Distribution._qEstimateRoot` propagates `NaN` on bracket failure (#589).
+- All statistics modules (`location`, `dispersion`, `shape`, `dependence`, `ts`) now comply with ADR-0015: mismatched-length array arguments throw `Error` (caller error), indeterminate results (empty sample, zero-variance) return `NaN`, divergent results (KL divergence with `Q=0,P>0`, zero-denominator odds ratio) return `Infinity`. `undefined` is no longer returned as a failure sentinel from any public function (#593).
 - `Davis._cdf(x)` now uses a dual Bose-Einstein series (upper incomplete gamma series for x near μ, Bernoulli/Laurent series for large x) instead of Romberg integration; per-call cost drops from ~100ms to ~10µs, enabling full goodness-of-fit coverage with the standard sample size (#451).
 - `Bates.fit()` now uses a profile likelihood grid search over integer `n` instead of the inherited 3-parameter Nelder-Mead, which stalled on the staircase likelihood surface caused by integer rounding; `n` is now reliably recovered (#481).
 - `Bradford._fitInit`: small-`c` mean approximation coefficient corrected from `3·(1−2·mean)` to `6·(1−2·mean)`, matching the correct first-order expansion `E[X] ≈ ½ − c/12`; the previous coefficient underestimated the starting value by a factor of 2 (#498).

--- a/solutions/correctness/2026-05-31-1200-adr0015-la-stats-undefined-sentinel-audit.md
+++ b/solutions/correctness/2026-05-31-1200-adr0015-la-stats-undefined-sentinel-audit.md
@@ -1,0 +1,63 @@
+---
+date: 2026-05-31T12:00:00Z
+category: "correctness"
+problem: "Six modules used `undefined` as a uniform failure sentinel instead of the ADR-0015 four-channel return-value convention"
+status: complete
+related_issue: "#593"
+related_plan: "thoughts/plans/2026-05-31-1010-adr0015-la-stats-audit.md"
+tags: [adr-0015, return-value, NaN, undefined, throw, Infinity, la, location, dispersion, shape, dependence, ts]
+---
+
+# Solution: ADR-0015 audit — la and statistics modules
+
+**Date**: 2026-05-31
+**Category**: correctness
+**Related Issue**: #593
+
+## Problem
+
+Six modules (`src/la/`, `src/location/`, `src/dispersion/`, `src/shape/`, `src/dependence/`, `src/ts/`) predated ADR-0015 and used `undefined` as a uniform failure sentinel for every abnormal result. This produced wrong TypeScript declarations (`number | undefined` across a numeric API), silently corrupted `JSON.stringify` output (undefined keys are dropped; undefined array elements become `null`), and made it impossible for callers to distinguish a programming error (mismatched dimensions) from a mathematically indeterminate result (empty input, zero variance) or a divergent result (KL divergence with Q=0, P>0).
+
+## Root Cause
+
+The modules were written before ADR-0015 codified the four-channel return-value convention. A single `return undefined` was used for situations that actually fall into three distinct categories:
+1. **Caller/programming errors** that should terminate with a thrown `Error`
+2. **Valid queries with no finite answer** → `NaN`
+3. **Valid queries whose answer diverges** → `Infinity`
+
+Because all three looked the same at the call site, callers had no way to distinguish them, and tests asserted `typeof result === 'undefined'` — a predicate that passes for both `undefined` and implicit function fall-off, masking the underlying misclassification.
+
+A hidden aggravating factor: `isNaN(undefined) === true` in JavaScript. Any test written as `assert(isNaN(f([])))` would pass whether `f` returned `NaN` or `undefined`, so converting `undefined` to `NaN` in the source would NOT make those tests start failing — they had to be migrated to `Number.isNaN()` simultaneously.
+
+## Fix
+
+Each `undefined`-returning site was reclassified into the correct ADR-0015 channel:
+
+- **Dimension or length mismatch** (`la/` binary operations, `dependence/` mismatched-array-length guards) → `throw Error('...')`. These are caller errors.
+- **Valid but indeterminate query** (empty array, single-element array, zero variance, zero spread, `0/0`) → `return NaN`.
+- **Divergent result** (KL divergence with `q[i]=0, p[i]>0`; zero-denominator odds ratio) → `Infinity`, produced naturally by IEEE-754 arithmetic once the explicit `undefined` guard was removed.
+- **Array-returning functions** (`mode`, `rank`) with empty input → `return []`, keeping the return type consistent (`number[]`, not a scalar sentinel).
+- `OnlineCovariance.compute()` before any updates → `this.cov.scale(NaN)` (NaN-filled `Matrix`), keeping the return type uniformly `Matrix`.
+
+Tests were updated in parallel:
+- Length-mismatch cases: `typeof result === 'undefined'` → `assert.throws`
+- Degenerate-input cases: `typeof result === 'undefined'` → `assert(Number.isNaN(result))`
+
+## Prevention Strategy
+
+1. **Always use `Number.isNaN(result)`** (not the global `isNaN()`) in tests that assert degenerate numeric output. `isNaN(undefined) === true` in JavaScript, so `isNaN()`-based tests pass silently whether the function returns `NaN` or `undefined`.
+
+2. **Treat any `return undefined` in a numeric function as a blocking code-review comment** requiring explicit reclassification against the ADR-0015 table.
+
+3. **Watch for implicit fall-off-end**: a function body that reaches its closing brace without a `return` statement silently returns `undefined` in JavaScript. This was the case in `variance.js`, `max.js`, and `min.js` — they had `if (condition) { ... }` with no `else`, so the empty-input path fell through.
+
+4. **Separate the two kinds of bad input before writing a guard**: length/dimension mismatch (caller error → `throw`) vs. empty/degenerate input (valid query, indeterminate result → `NaN`). The original `isInvalidInput` helpers combined both into one predicate, erasing this distinction.
+
+## Related Solutions
+
+- [`solutions/correctness/2026-05-17-0847-validate-rejects-missing-params.md`](../correctness/2026-05-17-0847-validate-rejects-missing-params.md) — Distribution.validate() throw-for-caller-error pattern; the same ADR-0015 principle applied to constructor validation.
+- [`solutions/algorithm/2026-05-20-0647-q-estimate-walk-infinite-support-discrete.md`](../algorithm/2026-05-20-0647-q-estimate-walk-infinite-support-discrete.md) — `undefined` escaping from `_qEstimateRoot` and converting to `NaN` via `Math.floor`; another pre-ADR-0015 undefined-sentinel bug.
+
+## Key Insight
+
+`undefined` as a numeric failure sentinel is undetectable by `isNaN()` tests, invisible to `JSON.stringify`, and forces `number | undefined` into generated TypeScript — all three problems vanish at once by distinguishing the two fundamentally different failure kinds: **throw** for caller errors (dimension mismatch), **`NaN`** for indeterminate math, and **`Infinity`** for divergent math.

--- a/src/dependence/covariance.js
+++ b/src/dependence/covariance.js
@@ -8,8 +8,8 @@ import { mean } from '../location'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number} The sample covariance, or NaN if either array has fewer than 2 elements. Throws if arrays have
- * different lengths.
+ * @throws {Error} If the arrays have different lengths.
+ * @returns {number} The sample covariance, or NaN if either array has fewer than 2 elements.
  * @example
  *
  * ran.dependence.covariance([], [])

--- a/src/dependence/covariance.js
+++ b/src/dependence/covariance.js
@@ -8,18 +8,15 @@ import { mean } from '../location'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number|undefined} The sample covariance if both arrays have more than one element and they have the same
- * length, undefined otherwise.
+ * @returns {number} The sample covariance, or NaN if either array has fewer than 2 elements. Throws if arrays have
+ * different lengths.
  * @example
  *
  * ran.dependence.covariance([], [])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.covariance([1], [2])
- * // => undefined
- *
- * ran.dependence.covariance([1, 2, 3], [1, 2, 3, 4])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.covariance([1, 2, 3], [4, 5, 6])
  * // => 1

--- a/src/dependence/covariance.js
+++ b/src/dependence/covariance.js
@@ -28,15 +28,15 @@ import { mean } from '../location'
  * // => 16.166666666666668
  */
 export default function (x, y) {
-  if (isInvalidInput(x, y)) {
-    return undefined
+  // Length mismatch = caller error (throw); degenerate input = indeterminate (NaN). See solutions/correctness/2026-05-31-1200-adr0015-la-stats-undefined-sentinel-audit.md
+  if (x.length !== y.length) {
+    throw Error('Arrays must have the same length')
+  }
+  if (x.length < 2) {
+    return NaN
   }
 
   const mx = mean(x)
   const my = mean(y)
   return x.length * mean(x.map((d, i) => (d - mx) * (y[i] - my))) / (x.length - 1)
-}
-
-function isInvalidInput (x, y) {
-  return x.length < 2 || y.length < 2 || x.length !== y.length
 }

--- a/src/dependence/distance-correlation.js
+++ b/src/dependence/distance-correlation.js
@@ -9,8 +9,8 @@ import mean from '../location/mean'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number} The distance correlation, or NaN for empty or constant arrays. Throws if arrays have different
- * lengths.
+ * @throws {Error} If the arrays have different lengths.
+ * @returns {number} The distance correlation, or NaN for empty or constant arrays.
  * @example
  *
  * ran.dependence.dCor([], [])

--- a/src/dependence/distance-correlation.js
+++ b/src/dependence/distance-correlation.js
@@ -9,12 +9,12 @@ import mean from '../location/mean'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number|undefined} The distance correlation if none of the arrays are empty and they have the same length,
- * undefined otherwise.
+ * @returns {number} The distance correlation, or NaN for empty or constant arrays. Throws if arrays have different
+ * lengths.
  * @example
  *
- * ran.dependence.dCor([1, 2, 3], [])
- * // => undefined
+ * ran.dependence.dCor([], [])
+ * // => NaN
  *
  * ran.dependence.dCor([1, 2, 3], [2, 1, 2])
  * // => 0.5623413251903491

--- a/src/dependence/distance-correlation.js
+++ b/src/dependence/distance-correlation.js
@@ -20,6 +20,13 @@ import mean from '../location/mean'
  * // => 0.5623413251903491
  */
 export default function (x, y) {
+  if (x.length !== y.length) {
+    throw Error('Arrays must have the same length')
+  }
+  if (x.length === 0) {
+    return NaN
+  }
+
   const a = distanceMatrix(x)
   const b = distanceMatrix(y)
   const dVarX = Math.sqrt(mean([].concat(...a.hadamard(a).m())))
@@ -28,5 +35,5 @@ export default function (x, y) {
     const dCov = Math.sqrt(mean([].concat(...a.hadamard(b).m())))
     return dCov / Math.sqrt(dVarX * dVarY)
   }
-  return undefined
+  return NaN
 }

--- a/src/dependence/distance-covariance.js
+++ b/src/dependence/distance-covariance.js
@@ -9,12 +9,11 @@ import distanceMatrix from '../utils/distance-matrix'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number|undefined} The distance covariance if none of the arrays are empty and they have the same length,
- * undefined otherwise.
+ * @returns {number} The distance covariance, or NaN for empty arrays. Throws if arrays have different lengths.
  * @example
  *
- * ran.dependence.dCov([1, 2, 3], [])
- * // => undefined
+ * ran.dependence.dCov([], [])
+ * // => NaN
  *
  * ran.dependence.dCov([1, 2, 3], [2, 1, 2])
  * // => 0.31426968052735443

--- a/src/dependence/distance-covariance.js
+++ b/src/dependence/distance-covariance.js
@@ -9,7 +9,8 @@ import distanceMatrix from '../utils/distance-matrix'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number} The distance covariance, or NaN for empty arrays. Throws if arrays have different lengths.
+ * @throws {Error} If the arrays have different lengths.
+ * @returns {number} The distance covariance, or NaN for empty arrays.
  * @example
  *
  * ran.dependence.dCov([], [])

--- a/src/dependence/distance-covariance.js
+++ b/src/dependence/distance-covariance.js
@@ -20,8 +20,11 @@ import distanceMatrix from '../utils/distance-matrix'
  * // => 0.31426968052735443
  */
 export default function (x, y) {
-  if (x.length * y.length === 0 || x.length !== y.length) {
-    return undefined
+  if (x.length !== y.length) {
+    throw Error('Arrays must have the same length')
+  }
+  if (x.length === 0) {
+    return NaN
   }
 
   const a = distanceMatrix(x)

--- a/src/dependence/kendall.js
+++ b/src/dependence/kendall.js
@@ -32,8 +32,11 @@ function nTies (values) {
  * // => 0.3333333333333333
  */
 export default function (x, y) {
-  if (invalidInput(x, y)) {
-    return undefined
+  if (x.length !== y.length) {
+    throw Error('Arrays must have the same length')
+  }
+  if (x.length === 0) {
+    return NaN
   }
 
   // Numerator.
@@ -46,8 +49,4 @@ export default function (x, y) {
 
   // Return the final value.
   return num / Math.sqrt((n0 - n1) * (n0 - n2))
-}
-
-function invalidInput (x, y) {
-  return x.length === 0 || y.length === 0 || x.length !== y.length
 }

--- a/src/dependence/kendall.js
+++ b/src/dependence/kendall.js
@@ -15,15 +15,12 @@ function nTies (values) {
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number|undefined} Kendall's correlation coefficient if none of the arrays are empty and they have the
- * same length, undefined otherwise.
+ * @returns {number} Kendall's correlation coefficient, or NaN for empty arrays. Throws if arrays have different
+ * lengths.
  * @example
  *
  * ran.dependence.kendall([], [])
- * // => undefined
- *
- * ran.dependence.kendall([1, 2, 3], [1, 2, 3, 4])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.kendall([1, 2, 3], [4, 5, 6])
  * // => 1

--- a/src/dependence/kendall.js
+++ b/src/dependence/kendall.js
@@ -15,8 +15,8 @@ function nTies (values) {
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number} Kendall's correlation coefficient, or NaN for empty arrays. Throws if arrays have different
- * lengths.
+ * @throws {Error} If the arrays have different lengths.
+ * @returns {number} Kendall's correlation coefficient, or NaN for empty arrays.
  * @example
  *
  * ran.dependence.kendall([], [])

--- a/src/dependence/kullback-leibler.js
+++ b/src/dependence/kullback-leibler.js
@@ -10,15 +10,15 @@ import neumaier from '../algorithms/neumaier'
  * @memberof ran.dependence
  * @param {number[]} p Array representing the probabilities for the i-th value in the base distribution (P).
  * @param {number[]} q Array representing the probabilities for the i-th value in compared distribution (Q).
- * @returns {number|undefined} The Kullback-Leibler divergence if none of the distributions are empty and Q(x) = 0
- * implies that P(x) = 0 for all x, otherwise undefined.
+ * @returns {number} The Kullback-Leibler divergence, NaN for empty input, Infinity if Q(x) = 0 and P(x) > 0 for
+ * some x. Throws if arrays have different lengths.
  * @example
  *
- * ran.dependence.kullbackLeibler([0.1, 0.2, 0.7], [])
- * // => undefined
+ * ran.dependence.kullbackLeibler([], [])
+ * // => NaN
  *
- * ran.dependence.kullbackLeibler([0.1, 0.2, 0.7], [0.1, 0.2, 0.3, 0.4])
- * // => undefined
+ * ran.dependence.kullbackLeibler([0.1, 0.2, 0.7], [0, 0.3, 0.7])
+ * // => Infinity
  *
  * ran.dependence.kullbackLeibler([0.1, 0.3, 0.6], [0.333, 0.333, 0.334])
  * // => 0.19986796234715937
@@ -27,21 +27,20 @@ import neumaier from '../algorithms/neumaier'
  * // => 0.2396882491444514
  */
 export default function (p, q) {
-  if (!isValid(p, q)) {
-    return undefined
+  if (p.length !== q.length) {
+    throw Error('Arrays must have the same length')
+  }
+  if (p.length === 0) {
+    return NaN
   }
 
-  // Check Q(x) = 0 => P(x) = 0 implication.
+  // Q(x) = 0 with P(x) > 0 causes a term to diverge.
   if (hasZeroQWithNonZeroP(p, q)) {
-    return undefined
+    return Infinity
   }
 
   // Calculate sum over all P(x) > 0 elements.
   return neumaier(p.filter(d => d > 0).map((pi, i) => pi * Math.log(pi / q[i])))
-}
-
-function isValid (p, q) {
-  return p.length !== 0 && q.length !== 0 && p.length === q.length
 }
 
 function hasZeroQWithNonZeroP (p, q) {

--- a/src/dependence/kullback-leibler.js
+++ b/src/dependence/kullback-leibler.js
@@ -10,8 +10,9 @@ import neumaier from '../algorithms/neumaier'
  * @memberof ran.dependence
  * @param {number[]} p Array representing the probabilities for the i-th value in the base distribution (P).
  * @param {number[]} q Array representing the probabilities for the i-th value in compared distribution (Q).
+ * @throws {Error} If the arrays have different lengths.
  * @returns {number} The Kullback-Leibler divergence, NaN for empty input, Infinity if Q(x) = 0 and P(x) > 0 for
- * some x. Throws if arrays have different lengths.
+ * some x.
  * @example
  *
  * ran.dependence.kullbackLeibler([], [])

--- a/src/dependence/odds-ratio.js
+++ b/src/dependence/odds-ratio.js
@@ -10,19 +10,18 @@
  * @param {number} p01 The probability of X = 0 and Y = 1.
  * @param {number} p10 The probability of X = 1 and Y = 0.
  * @param {number} p11 The probability of X = 1 and Y = 1.
- * @returns {number|undefined} The odds ratio if p01 and p10 are positive, undefined otherwise.
+ * @returns {number} The odds ratio. Returns Infinity when p01 or p10 is zero and the numerator is non-zero.
  * @example
  *
  * ran.dependence.oddsRatio(0.3, 0, 0.3, 0.4)
- * // => undefined
+ * // => Infinity
  *
  * ran.dependence.oddsRatio(0.3, 0.3, 0, 0.4)
- * // => undefined
+ * // => Infinity
  *
  * ran.dependence.oddsRatio(0.1, 0.2, 0.3, 0.4)
  * // => 0.6666666666666669
  */
 export default function (p00, p01, p10, p11) {
-  const denominator = p01 * p10
-  return denominator === 0 ? undefined : p00 * p11 / denominator
+  return p00 * p11 / (p01 * p10)
 }

--- a/src/dependence/pearson.js
+++ b/src/dependence/pearson.js
@@ -9,8 +9,8 @@ import covariance from './covariance'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
+ * @throws {Error} If the arrays have different lengths.
  * @returns {number} The Pearson correlation coefficient, or NaN if arrays have fewer than two elements or zero variance.
- * Throws if arrays have different lengths.
  * @example
  *
  * ran.dependence.pearson([], [])

--- a/src/dependence/pearson.js
+++ b/src/dependence/pearson.js
@@ -9,18 +9,15 @@ import covariance from './covariance'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number|undefined} The Pearson correlation coefficient if none of the arrays are empty, they have the
- * same length and each has a positive variance, undefined otherwise.
+ * @returns {number} The Pearson correlation coefficient, or NaN if arrays have fewer than two elements or zero variance.
+ * Throws if arrays have different lengths.
  * @example
  *
  * ran.dependence.pearson([], [])
- * // => undefined
- *
- * ran.dependence.pearson([1, 2, 3], [1, 2, 3, 4])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.pearson([1, 2, 3], [1, 1, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.pearson([1, 2, 3], [4, 5, 6])
  * // => 1
@@ -29,9 +26,8 @@ import covariance from './covariance'
  * // => 0.6643835616438358
  */
 export default function (x, y) {
-  // TODO Check if length is below 2.
   const cov = covariance(x, y)
   const sx = stdev(x)
   const sy = stdev(y)
-  return typeof cov === 'undefined' || sx * sy === 0 ? undefined : cov / (sx * sy)
+  return Number.isNaN(cov) || sx * sy === 0 ? NaN : cov / (sx * sy)
 }

--- a/src/dependence/point-biserial.js
+++ b/src/dependence/point-biserial.js
@@ -9,8 +9,9 @@ import mean from '../location/mean'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values. Must contain 0s and 1s only.
+ * @throws {Error} If the arrays have different lengths.
  * @returns {number} The point-biserial correlation coefficient, or NaN if arrays have fewer than 2 elements or
- * zero variance. Throws if arrays have different lengths.
+ * zero variance.
  * @example
  *
  * ran.dependence.pointBiserial([], [])

--- a/src/dependence/point-biserial.js
+++ b/src/dependence/point-biserial.js
@@ -26,13 +26,16 @@ import mean from '../location/mean'
  * // => 0.8660254037844386
  */
 export default function (x, y) {
-  if (!validInputs(x, y)) {
-    return undefined
+  if (x.length !== y.length) {
+    throw Error('Arrays must have the same length')
+  }
+  if (x.length < 2) {
+    return NaN
   }
 
   const s = stdev(x)
   if (s === 0) {
-    return undefined
+    return NaN
   }
 
   const x0 = x.filter((d, i) => y[i] === 0)
@@ -42,10 +45,4 @@ export default function (x, y) {
   const m0 = mean(x0)
   const m1 = mean(x1)
   return (m1 - m0) * Math.sqrt(n0 * n1 / (x.length * (x.length - 1))) / s
-}
-
-function validInputs (x, y) {
-  return (x.length !== 0 &&
-    y.length !== 0 &&
-    x.length === y.length)
 }

--- a/src/dependence/point-biserial.js
+++ b/src/dependence/point-biserial.js
@@ -9,18 +9,15 @@ import mean from '../location/mean'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values. Must contain 0s and 1s only.
- * @returns {number|undefined} The point-biserial correlation coefficient if none of the arrays are empty, they have
- * the same length and each has a positive variance, undefined otherwise.
+ * @returns {number} The point-biserial correlation coefficient, or NaN if arrays have fewer than 2 elements or
+ * zero variance. Throws if arrays have different lengths.
  * @example
  *
  * ran.dependence.pointBiserial([], [])
- * // => undefined
- *
- * ran.dependence.pointBiserial([1, 2, 3], [0, 0, 1, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.pointBiserial([2, 2, 2], [0, 0, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.pointBiserial([1, 2, 3], [4, 5, 6])
  * // => 0.8660254037844386

--- a/src/dependence/somers-d.js
+++ b/src/dependence/somers-d.js
@@ -12,7 +12,8 @@ function tau (a, b) {
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number} Somers' D, or NaN for empty arrays. Throws if arrays have different lengths.
+ * @throws {Error} If the arrays have different lengths.
+ * @returns {number} Somers' D, or NaN for empty arrays.
  * @example
  *
  * ran.dependence.somersD([], [])

--- a/src/dependence/somers-d.js
+++ b/src/dependence/somers-d.js
@@ -12,15 +12,11 @@ function tau (a, b) {
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number|undefined} Somers' D if none of the arrays are empty, they have the same length, undefined
- * otherwise.
+ * @returns {number} Somers' D, or NaN for empty arrays. Throws if arrays have different lengths.
  * @example
  *
  * ran.dependence.somersD([], [])
- * // => undefined
- *
- * ran.dependence.somersD([1, 2, 3], [1, 2, 3, 4])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.somersD([1, 2, 3], [4, 6, 6])
  * // => 0.6666666666666666

--- a/src/dependence/somers-d.js
+++ b/src/dependence/somers-d.js
@@ -29,13 +29,12 @@ function tau (a, b) {
  * // => -1
  */
 export default function (x, y) {
-  if (isInvalidInput(x, y)) {
-    return undefined
+  if (x.length !== y.length) {
+    throw Error('Arrays must have the same length')
+  }
+  if (x.length === 0) {
+    return NaN
   }
 
   return tau(x, y) / tau(x, x)
-}
-
-function isInvalidInput (x, y) {
-  return x.length === 0 || y.length === 0 || x.length !== y.length
 }

--- a/src/dependence/spearman.js
+++ b/src/dependence/spearman.js
@@ -9,8 +9,8 @@ import pearson from './pearson'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number} Spearman's rank correlation coefficient, or NaN for empty arrays. Throws if arrays have
- * different lengths.
+ * @throws {Error} If the arrays have different lengths.
+ * @returns {number} Spearman's rank correlation coefficient, or NaN for empty arrays.
  * @example
  *
  * ran.dependence.spearman([], [])

--- a/src/dependence/spearman.js
+++ b/src/dependence/spearman.js
@@ -9,15 +9,12 @@ import pearson from './pearson'
  * @memberof ran.dependence
  * @param {number[]} x First array of values.
  * @param {number[]} y Second array of values.
- * @returns {number|undefined} Spearman's rank correlation coefficient if none of the arrays are empty and they have
- * the same length, undefined otherwise.
+ * @returns {number} Spearman's rank correlation coefficient, or NaN for empty arrays. Throws if arrays have
+ * different lengths.
  * @example
  *
  * ran.dependence.spearman([], [])
- * // => undefined
- *
- * ran.dependence.spearman([1, 2, 3], [1, 2, 3, 4])
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.spearman([1, 2, 3], [1, 4, 2])
  * // => 0.5

--- a/src/dependence/spearman.js
+++ b/src/dependence/spearman.js
@@ -26,13 +26,12 @@ import pearson from './pearson'
  * // => 1
  */
 export default function (x, y) {
-  if (!isValidInput(x, y)) {
-    return undefined
+  if (x.length !== y.length) {
+    throw Error('Arrays must have the same length')
+  }
+  if (x.length === 0) {
+    return NaN
   }
 
   return pearson(rank(x), rank(y))
-}
-
-function isValidInput (x, y) {
-  return x.length !== 0 && y.length !== 0 && x.length === y.length
 }

--- a/src/dependence/yule-q.js
+++ b/src/dependence/yule-q.js
@@ -26,9 +26,5 @@ import oddsRatio from '../dependence/odds-ratio'
  */
 export default function (p00, p01, p10, p11) {
   const or = oddsRatio(p00, p01, p10, p11)
-  if (typeof or === 'undefined') {
-    return undefined
-  }
-
   return (or - 1) / (or + 1)
 }

--- a/src/dependence/yule-q.js
+++ b/src/dependence/yule-q.js
@@ -12,14 +12,15 @@ import oddsRatio from '../dependence/odds-ratio'
  * @param {number} p01 The probability of X = 0 and Y = 1.
  * @param {number} p10 The probability of X = 1 and Y = 0.
  * @param {number} p11 The probability of X = 1 and Y = 1.
- * @returns {number|undefined} Yule's Q if p01 and p10 are positive, undefined otherwise.
+ * @returns {number} Yule's Q, or NaN when p01 or p10 is zero (the odds ratio diverges, making the formula
+ * indeterminate).
  * @example
  *
  * ran.dependence.yuleQ(0.3, 0, 0.3, 0.4)
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.yuleQ(0.3, 0.3, 0, 0.4)
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.yuleQ(0.1, 0.2, 0.3, 0.4)
  * // => -0.19999999999999984

--- a/src/dependence/yule-y.js
+++ b/src/dependence/yule-y.js
@@ -12,14 +12,15 @@ import oddsRatio from '../dependence/odds-ratio'
  * @param {number} p01 The probability of X = 0 and Y = 1.
  * @param {number} p10 The probability of X = 1 and Y = 0.
  * @param {number} p11 The probability of X = 1 and Y = 1.
- * @returns {number|undefined} Yule's Y if p01 and p10 are positive, undefined otherwise.
+ * @returns {number} Yule's Y, or NaN when p01 or p10 is zero (the odds ratio diverges, making the formula
+ * indeterminate).
  * @example
  *
  * ran.dependence.yuleY(0.3, 0, 0.3, 0.4)
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.yuleY(0.3, 0.3, 0, 0.4)
- * // => undefined
+ * // => NaN
  *
  * ran.dependence.yuleY(0.1, 0.2, 0.3, 0.4)
  * // => -0.10102051443364372

--- a/src/dependence/yule-y.js
+++ b/src/dependence/yule-y.js
@@ -26,10 +26,6 @@ import oddsRatio from '../dependence/odds-ratio'
  */
 export default function (p00, p01, p10, p11) {
   const or = oddsRatio(p00, p01, p10, p11)
-  if (typeof or === 'undefined') {
-    return undefined
-  }
-
   const sqrtOr = Math.sqrt(or)
   return (sqrtOr - 1) / (sqrtOr + 1)
 }

--- a/src/dispersion/cv.js
+++ b/src/dispersion/cv.js
@@ -27,5 +27,5 @@ import mean from '../location/mean'
 export default function (values) {
   const s = stdev(values)
   const m = mean(values)
-  return m === 0 ? undefined : s && s / m
+  return m === 0 ? NaN : s && s / m
 }

--- a/src/dispersion/cv.js
+++ b/src/dispersion/cv.js
@@ -8,18 +8,17 @@ import mean from '../location/mean'
  * @method cv
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate coefficient of variation for.
- * @returns {number|undefined} Coefficient of variation of the values if there are more than two and the mean is not
- * zero, undefined otherwise.
+ * @returns {number} Coefficient of variation, or NaN for fewer than 2 elements, zero mean, or zero variance.
  * @example
  *
  * ran.dispersion.cv([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.cv([1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.cv([-1, 0, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.cv([1, 2, 3, 4, 5])
  * // => 0.5270462766947299

--- a/src/dispersion/distance-variance.js
+++ b/src/dispersion/distance-variance.js
@@ -19,7 +19,7 @@ import mean from '../location/mean'
  */
 export default function (x) {
   if (x.length === 0) {
-    return undefined
+    return NaN
   }
 
   // Calculate distance matrix.

--- a/src/dispersion/distance-variance.js
+++ b/src/dispersion/distance-variance.js
@@ -8,13 +8,13 @@ import mean from '../location/mean'
  * @method dVar
  * @memberof ran.dispersion
  * @param {number[]} x Array of values.
- * @returns {number|undefined} The distance variance if the array os not empty, undefined otherwise.
+ * @returns {number} The distance variance, or NaN for an empty array.
  * @example
  *
- * ran.dependence.dVar([])
- * // => undefined
+ * ran.dispersion.dVar([])
+ * // => NaN
  *
- * ran.dependence.dVar([1, 2, 3])
+ * ran.dispersion.dVar([1, 2, 3])
  * // => 0.7027283689263066
  */
 export default function (x) {

--- a/src/dispersion/entropy.js
+++ b/src/dispersion/entropy.js
@@ -13,11 +13,11 @@ function _log (base) {
  * @memberof ran.dispersion
  * @param {number[]} probabilities Array representing the probabilities for the i-th value.
  * @param {number=} base Base for the logarithm. If not specified, natural logarithm is used.
- * @returns {number|undefined} Entropy of the probabilities if there are any, undefined otherwise.
+ * @returns {number} Entropy of the probabilities, or NaN for empty input.
  * @example
  *
  * ran.dispersion.entropy([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.entropy([0.1, 0.1, 0.8])
  * // => 0.639031859650177

--- a/src/dispersion/entropy.js
+++ b/src/dispersion/entropy.js
@@ -27,7 +27,7 @@ function _log (base) {
  */
 export default function (probabilities, base) {
   if (probabilities.length === 0) {
-    return undefined
+    return NaN
   }
 
   // Create logarithm using the specified base.

--- a/src/dispersion/gini.js
+++ b/src/dispersion/gini.js
@@ -6,17 +6,17 @@ import rmd from './rmd'
  * @method gini
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate the Gini coefficient for.
- * @returns {number|undefined} The Gini coefficient of the values if there are more than one, undefined otherwise.
+ * @returns {number} The Gini coefficient, or NaN for fewer than 2 elements or zero mean.
  * @example
  *
  * ran.dispersion.gini([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.gini([1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.gini([-1, 0, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.gini([1, 2, 3, 4])
  * // => 0.25

--- a/src/dispersion/iqr.js
+++ b/src/dispersion/iqr.js
@@ -17,7 +17,7 @@ import quantile from '../shape/quantile'
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return NaN
   }
 
   return quantile(values, 0.75) - quantile(values, 0.25)

--- a/src/dispersion/iqr.js
+++ b/src/dispersion/iqr.js
@@ -6,11 +6,11 @@ import quantile from '../shape/quantile'
  * @method iqr
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate the interquartile range for.
- * @returns {number|undefined} The interquartile range of the values if there is any, undefined otherwise.
+ * @returns {number} The interquartile range, or NaN for an empty array.
  * @example
  *
  * ran.dispersion.iqr([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.iqr([1, 1, 2, 3, 3])
  * // => 2

--- a/src/dispersion/md.js
+++ b/src/dispersion/md.js
@@ -5,14 +5,14 @@
  * @method md
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate mean absolute difference for.
- * @returns {number|undefined} Mean absolute difference of the values if there are more than two, undefined otherwise.
+ * @returns {number} Mean absolute difference, or NaN for fewer than 2 elements.
  * @example
  *
  * ran.dispersion.md([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.md([1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.md([1, 2, 3, 4])
  * // => 1.25

--- a/src/dispersion/md.js
+++ b/src/dispersion/md.js
@@ -19,7 +19,7 @@
  */
 export default function (values) {
   if (values.length < 2) {
-    return undefined
+    return NaN
   }
 
   let sum = 0

--- a/src/dispersion/midhinge.js
+++ b/src/dispersion/midhinge.js
@@ -6,11 +6,11 @@ import quantile from '../shape/quantile'
  * @method midhinge
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate midhinge for.
- * @returns {number|undefined} The midhinge of the values if there is any, undefined otherwise.
+ * @returns {number} The midhinge, or NaN for an empty array.
  * @example
  *
  * ran.dispersion.midhinge([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.midhinge([1, 1, 1, 2, 3])
  * // => 1.5

--- a/src/dispersion/midhinge.js
+++ b/src/dispersion/midhinge.js
@@ -17,7 +17,7 @@ import quantile from '../shape/quantile'
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return NaN
   }
 
   return (quantile(values, 0.25) + quantile(values, 0.75)) / 2

--- a/src/dispersion/qcd.js
+++ b/src/dispersion/qcd.js
@@ -19,7 +19,7 @@ import quantile from '../shape/quantile'
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return NaN
   }
 
   const q1 = quantile(values, 0.25)

--- a/src/dispersion/qcd.js
+++ b/src/dispersion/qcd.js
@@ -7,12 +7,11 @@ import quantile from '../shape/quantile'
  * @method qcd
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate quartile coefficient of dispersion for.
- * @returns {number|undefined} The quartile coefficient of dispersion of the values if there is any, undefined
- * otherwise.
+ * @returns {number} The quartile coefficient of dispersion, or NaN for an empty array.
  * @example
  *
  * ran.dispersion.qcd([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.qcd([1, 2, 3])
  * // => 0.25

--- a/src/dispersion/range.js
+++ b/src/dispersion/range.js
@@ -7,11 +7,11 @@ import min from '../shape/min'
  * @method range
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate range for.
- * @returns {number|undefined} The range of the values if there is any, undefined otherwise.
+ * @returns {number} The range of the values, or NaN for an empty array.
  * @example
  *
  * ran.dispersion.range([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.range([0, 1, 2, 2])
  * // => 2

--- a/src/dispersion/range.js
+++ b/src/dispersion/range.js
@@ -18,7 +18,7 @@ import min from '../shape/min'
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return NaN
   }
 
   return max(values) - min(values)

--- a/src/dispersion/rmd.js
+++ b/src/dispersion/rmd.js
@@ -7,18 +7,17 @@ import mean from '../location/mean'
  * @method rmd
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate relative mean absolute difference for.
- * @returns {number|undefined} Relative mean absolute difference of the values if there are more than two, undefined
- * otherwise.
+ * @returns {number} Relative mean absolute difference, or NaN for fewer than 2 elements or zero mean.
  * @example
  *
  * ran.dispersion.rmd([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.rmd([1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.rmd([-1, 0, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.rmd([1, 2, 3, 4])
  * // => 0.5

--- a/src/dispersion/rmd.js
+++ b/src/dispersion/rmd.js
@@ -26,5 +26,5 @@ import mean from '../location/mean'
 export default function (values) {
   const mad = md(values)
   const m = mean(values)
-  return m === 0 ? undefined : mad && mad / m
+  return m === 0 ? NaN : mad && mad / m
 }

--- a/src/dispersion/stdev.js
+++ b/src/dispersion/stdev.js
@@ -6,14 +6,14 @@ import variance from './variance'
  * @method stdev
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate standard deviation for.
- * @returns {number|undefined} Standard deviation of the values if there are more than two, undefined otherwise.
+ * @returns {number} Standard deviation of the values, NaN for fewer than 2 elements.
  * @example
  *
  * ran.dispersion.stdev([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.stdev([1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.stdev([1, 2, 3, 4, 5])
  * // => 1.5811388300841898

--- a/src/dispersion/stdev.js
+++ b/src/dispersion/stdev.js
@@ -19,7 +19,6 @@ import variance from './variance'
  * // => 1.5811388300841898
  */
 export default function (values) {
-  // TODO Check for undefined in unit test.
   const v = variance(values)
   return v && Math.abs(Math.sqrt(v))
 }

--- a/src/dispersion/variance.js
+++ b/src/dispersion/variance.js
@@ -4,14 +4,14 @@
  * @method variance
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate variance for.
- * @returns {number|undefined} Variance of the values if there are more than two, undefined otherwise.
+ * @returns {number} Variance of the values, NaN for fewer than 2 elements.
  * @example
  *
  * ran.dispersion.variance([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.variance([1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.variance([1, 2, 3])
  * // => 2.5
@@ -29,4 +29,5 @@ export default function (values) {
     }
     return M / (n - 1)
   }
+  return NaN
 }

--- a/src/dispersion/vmr.js
+++ b/src/dispersion/vmr.js
@@ -27,5 +27,5 @@ import mean from '../location/mean'
 export default function (values) {
   const v = variance(values)
   const m = mean(values)
-  return m === 0 ? undefined : v && v / m
+  return m === 0 ? NaN : v && v / m
 }

--- a/src/dispersion/vmr.js
+++ b/src/dispersion/vmr.js
@@ -8,18 +8,17 @@ import mean from '../location/mean'
  * @method vmr
  * @memberof ran.dispersion
  * @param {number[]} values Array of values to calculate variance-to-mean ratio for.
- * @returns {number|undefined} Variance-to-mean ratio of the values if there are more than two and the mean is not
- * zero, undefined otherwise.
+ * @returns {number} Variance-to-mean ratio, or NaN for fewer than 2 elements or zero mean.
  * @example
  *
  * ran.dispersion.vmr([])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.vmr([1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.vmr([-1, 0, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.dispersion.vmr([1, 2, 3, 4, 5])
  * // => 0.8333333333333334

--- a/src/la/matrix.js
+++ b/src/la/matrix.js
@@ -157,6 +157,9 @@ class Matrix {
    */
   add (mat) {
     const m = mat.m()
+    if (m.length !== this._m.length) {
+      throw Error('Matrix dimensions must match')
+    }
     return new Matrix(this._m.map((row, i) => row.map((d, j) => d + m[i][j])))
   }
 
@@ -180,6 +183,9 @@ class Matrix {
    */
   sub (mat) {
     const m = mat.m()
+    if (m.length !== this._m.length) {
+      throw Error('Matrix dimensions must match')
+    }
     return new Matrix(this._m.map((row, i) => row.map((d, j) => d - m[i][j])))
   }
 
@@ -203,6 +209,9 @@ class Matrix {
    */
   mult (mat) {
     const m = mat.m()
+    if (m.length !== this._m.length) {
+      throw Error('Matrix dimensions must match')
+    }
     const n = this._m.length
     const r = new Matrix(n)
     for (let i = 0; i < n; i++) {
@@ -253,6 +262,9 @@ class Matrix {
    *
    */
   apply (vec) {
+    if (vec.dim() !== this._m.length) {
+      throw Error('Vector dimension must match matrix row count')
+    }
     return new Vector(this._m.map(d => vec.dot(new Vector(d))))
   }
 
@@ -326,6 +338,9 @@ class Matrix {
    */
   hadamard (mat) {
     const m = mat.m()
+    if (m.length !== this._m.length) {
+      throw Error('Matrix dimensions must match')
+    }
     return this.f((d, i, j) => d * m[i][j])
   }
 

--- a/src/la/matrix.js
+++ b/src/la/matrix.js
@@ -143,6 +143,7 @@ class Matrix {
    * @method add
    * @memberof ran.la.Matrix
    * @param {ran.la.Matrix} mat The matrix to add.
+   * @throws {Error} If the matrix dimensions do not match.
    * @returns {ran.la.Matrix} The sum of the two matrices.
    * @example
    *
@@ -169,6 +170,7 @@ class Matrix {
    * @method sub
    * @memberof ran.la.Matrix
    * @param {ran.la.Matrix} mat The matrix to subtract.
+   * @throws {Error} If the matrix dimensions do not match.
    * @returns {ran.la.Matrix} The difference of the two matrices.
    * @example
    *
@@ -195,6 +197,7 @@ class Matrix {
    * @method mult
    * @memberof ran.la.Matrix
    * @param {Matrix} mat Matrix to multiply current matrix with.
+   * @throws {Error} If the matrix dimensions do not match.
    * @returns {Matrix} The product matrix.
    * @example
    *
@@ -252,6 +255,7 @@ class Matrix {
    * @method apply
    * @memberof ran.la.Matrix
    * @param {ran.la.Vector} vec Vector to apply matrix on.
+   * @throws {Error} If the vector dimension does not match the matrix row count.
    * @returns {ran.la.Vector} The mapped vector.
    * @example
    *
@@ -334,6 +338,7 @@ class Matrix {
    * @method hadamard
    * @memberof ran.la.Matrix
    * @param {ran.la.Matrix} mat Matrix to calculate element-wise product with.
+   * @throws {Error} If the matrix dimensions do not match.
    * @return {ran.la.Matrix} The result matrix.
    */
   hadamard (mat) {

--- a/src/la/vector.js
+++ b/src/la/vector.js
@@ -139,6 +139,7 @@ class Vector {
    * @method add
    * @memberof ran.la.Vector
    * @param {ran.la.Vector} vec The vector to add.
+   * @throws {Error} If the vector dimensions do not match.
    * @returns {ran.la.Vector} The sum vector.
    * @example
    *
@@ -162,6 +163,7 @@ class Vector {
    * @method sub
    * @memberof ran.la.Vector
    * @param {ran.la.Vector} vec The vector to subtract.
+   * @throws {Error} If the vector dimensions do not match.
    * @returns {ran.la.Vector} The difference vector.
    * @example
    *
@@ -185,6 +187,7 @@ class Vector {
    * @method dot
    * @memberof ran.la.Vector
    * @param {ran.la.Vector} vec Vector to multiply with.
+   * @throws {Error} If the vector dimensions do not match.
    * @returns {number} The dot product.
    * @example
    *

--- a/src/la/vector.js
+++ b/src/la/vector.js
@@ -149,6 +149,9 @@ class Vector {
    *
    */
   add (vec) {
+    if (vec.dim() !== this._v.length) {
+      throw Error('Vector dimensions must match')
+    }
     const v = vec.v()
     return new Vector(this._v.map((d, i) => d + v[i]))
   }
@@ -169,6 +172,9 @@ class Vector {
    *
    */
   sub (vec) {
+    if (vec.dim() !== this._v.length) {
+      throw Error('Vector dimensions must match')
+    }
     const v = vec.v()
     return new Vector(this._v.map((d, i) => d - v[i]))
   }
@@ -189,6 +195,9 @@ class Vector {
    *
    */
   dot (vec) {
+    if (vec.dim() !== this._v.length) {
+      throw Error('Vector dimensions must match')
+    }
     const v = vec.v()
     return this._v.reduce((sum, d, i) => sum + d * v[i], 0)
   }

--- a/src/location/geometric-mean.js
+++ b/src/location/geometric-mean.js
@@ -6,11 +6,11 @@ import mean from './mean'
  * @method geometricMean
  * @memberof ran.location
  * @param {number[]} values Array of values to calculate geometric mean for.
- * @returns {number|undefined} Gemoetric mean of the values if there are any, undefined otherwise.
+ * @returns {number} Geometric mean of the values, NaN for empty input.
  * @example
  *
  * ran.location.geometricMean([])
- * // => undefined
+ * // => NaN
  *
  * ran.location.geometricMean([1, 2, 3])
  * // => 1.8171205928321394

--- a/src/location/harmonic-mean.js
+++ b/src/location/harmonic-mean.js
@@ -6,17 +6,17 @@ import mean from './mean'
  * @method harmonicMean
  * @memberof ran.location
  * @param {number[]} values Array of values to calculate harmonic mean for.
- * @returns {number|undefined} Harmonic mean of the values if there are any, undefined otherwise.
+ * @returns {number} Harmonic mean of the values, NaN if any value is non-positive.
  * @example
  *
  * ran.location.harmonicMean([])
- * // => undefined
+ * // => NaN
  *
  * ran.location.harmonicMean([0, 1, 2])
- * // => undefined
+ * // => NaN
  *
- * run.location.harmonicMean([-1, 2, 3])
- * // => undefined
+ * ran.location.harmonicMean([-1, 2, 3])
+ * // => NaN
  *
  * ran.location.harmonicMean([1, 2, 3])
  * // => 1.6363636363636365
@@ -25,6 +25,6 @@ export default function (values) {
   if (values.reduce((acc, d) => acc && (d > 0), true)) {
     return 1 / mean(values.map(d => 1 / d))
   } else {
-    return undefined
+    return NaN
   }
 }

--- a/src/location/mean.js
+++ b/src/location/mean.js
@@ -4,15 +4,15 @@
  * @method mean
  * @memberof ran.location
  * @param {number[]} values Array of values to calculate mean for.
- * @returns {number|undefined} Mean of the values if there are any, undefined otherwise.
+ * @returns {number} Mean of the values, NaN for empty input.
  * @example
  *
  * ran.location.mean([])
- * // => undefined
+ * // => NaN
  *
  * ran.location.mean([1, 2, 3])
  * // => 2
  */
 export default function (values) {
-  return values.length > 0 ? values.reduce((acc, d) => acc + d, 0) / values.length : undefined
+  return values.length > 0 ? values.reduce((acc, d) => acc + d, 0) / values.length : NaN
 }

--- a/src/location/median.js
+++ b/src/location/median.js
@@ -6,18 +6,18 @@ import { quickselect } from '../algorithms'
  * @method median
  * @memberof ran.location
  * @param {number[]} values Array of values to calculate median for.
- * @returns {number} Median of the values if there are any, undefined otherwise.
+ * @returns {number} Median of the values, NaN for empty input.
  * @example
  *
  * ran.location.median([])
- * // => undefined
+ * // => NaN
  *
  * ran.location.median([1, 2, 3, 4])
  * // => 2.5
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return NaN
   }
 
   const n = values.length

--- a/src/location/midrange.js
+++ b/src/location/midrange.js
@@ -4,18 +4,18 @@
  * @method midrange
  * @memberof ran.location
  * @param {number[]} values Array of values to calculate mid-range for.
- * @returns {number|undefined} The mid-range of the values if there is any, undefined otherwise.
+ * @returns {number} The mid-range of the values, NaN for empty input.
  * @example
  *
  * ran.location.midrange([])
- * // => undefined
+ * // => NaN
  *
  * ran.location.midrange([0, 0, 0, 1, 2])
  * // => 1
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return NaN
   }
 
   let min = values[0]

--- a/src/location/mode.js
+++ b/src/location/mode.js
@@ -71,12 +71,12 @@ function continuousMode (values) {
  * @method mode
  * @memberof ran.location
  * @param {number[]} values Array of values to calculate mode for.
- * @returns {number|number[]|undefined} The estimated mode (continuous sample), an array of modes (discrete sample) or
- * undefined (empty sample).
+ * @returns {number|number[]} The estimated mode (continuous sample) or an array of modes (discrete sample).
+ * Returns an empty array for empty input.
  * @example
  *
  * ran.location.mode([])
- * // => undefined
+ * // => []
  *
  * ran.location.mode([1])
  * // => [1]
@@ -92,7 +92,7 @@ function continuousMode (values) {
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return []
   }
 
   if (values.reduce((int, d) => int && Number.isInteger(d), true)) {

--- a/src/location/trimean.js
+++ b/src/location/trimean.js
@@ -7,18 +7,18 @@ import median from './median'
  * @method trimean
  * @memberof ran.location
  * @param {number[]} values Array of values to calculate trimean for.
- * @returns {number|undefined} The trimean of the values if there is any, undefined otherwise.
+ * @returns {number} The trimean of the values, NaN for empty input.
  * @example
  *
  * ran.location.trimean([])
- * // => undefined
+ * // => NaN
  *
  * ran.location.trimean([1, 1, 1, 2, 3])
  * // => 1.25
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return NaN
   }
 
   return (quantile(values, 0.25) + 2 * median(values) + quantile(values, 0.75)) / 4

--- a/src/shape/kurtosis.js
+++ b/src/shape/kurtosis.js
@@ -29,12 +29,12 @@ import moment from './moment'
  */
 export default function (values) {
   if (values.length < 3) {
-    return undefined
+    return NaN
   }
 
   const n = values.length
   const m = mean(values)
   const m2 = moment(values, 2, m)
   const m4 = moment(values, 4, m)
-  return m2 === 0 ? undefined : (n - 1) * ((n + 1) * m4 / (m2 * m2) - 3 * (n - 1)) / ((n - 2) * (n - 3))
+  return m2 === 0 ? NaN : (n - 1) * ((n + 1) * m4 / (m2 * m2) - 3 * (n - 1)) / ((n - 2) * (n - 3))
 }

--- a/src/shape/kurtosis.js
+++ b/src/shape/kurtosis.js
@@ -8,18 +8,17 @@ import moment from './moment'
  * @method kurtosis
  * @memberof ran.shape
  * @param {number[]} values Array of values to calculate kurtosis for.
- * @returns {number|undefined} The sample kurtosis of values if there are more than two and their variance is nonzero,
- * undefined otherwise.
+ * @returns {number} The sample excess kurtosis, or NaN for fewer than 3 elements or zero variance.
  * @example
  *
  * ran.shape.kurtosis([])
- * // => undefined
+ * // => NaN
  *
  * ran.shape.kurtosis([1, 2])
- * // => undefined
+ * // => NaN
  *
  * ran.shape.kurtosis([1, 1, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.shape.kurtosis([1, 1, 3, 1, 1])
  * // => 5.000000000000003

--- a/src/shape/max.js
+++ b/src/shape/max.js
@@ -7,6 +7,9 @@
  * @returns {number} The maximum of the values.
  */
 export default function (values) {
+  if (values.length === 0) {
+    return NaN
+  }
   let max = values[0]
   for (const x of values) {
     max = Math.max(x, max)

--- a/src/shape/max.js
+++ b/src/shape/max.js
@@ -4,7 +4,14 @@
  * @method max
  * @memberof ran.shape
  * @param {number[]} values Array of values to find the maximum for.
- * @returns {number} The maximum of the values.
+ * @returns {number} The maximum of the values, or NaN for an empty array.
+ * @example
+ *
+ * ran.shape.max([])
+ * // => NaN
+ *
+ * ran.shape.max([3, 1, 4, 1, 5, 9])
+ * // => 9
  */
 export default function (values) {
   if (values.length === 0) {

--- a/src/shape/min.js
+++ b/src/shape/min.js
@@ -4,7 +4,14 @@
  * @method min
  * @memberof ran.shape
  * @param {number[]} values Array of values to find the minimum for.
- * @returns {number} The minimum of the values.
+ * @returns {number} The minimum of the values, or NaN for an empty array.
+ * @example
+ *
+ * ran.shape.min([])
+ * // => NaN
+ *
+ * ran.shape.min([3, 1, 4, 1, 5, 9])
+ * // => 1
  */
 export default function (values) {
   if (values.length === 0) {

--- a/src/shape/min.js
+++ b/src/shape/min.js
@@ -7,6 +7,9 @@
  * @returns {number} The minimum of the values.
  */
 export default function (values) {
+  if (values.length === 0) {
+    return NaN
+  }
   let min = values[0]
   for (const x of values) {
     min = Math.min(x, min)

--- a/src/shape/moment.js
+++ b/src/shape/moment.js
@@ -8,11 +8,11 @@ import mean from '../location/mean'
  * @param {number[]} values Array of values to calculate moment for.
  * @param {number} k Order of the moment.
  * @param {number} [c = 0] Value to shift the distribution by before calculating the moment.
- * @returns {number|undefined} The k-th moment of the values if there is any, undefined otherwise.
+ * @returns {number} The k-th moment, or NaN for an empty array.
  * @example
  *
  * ran.shape.moment([], 2)
- * // => undefined
+ * // => NaN
  *
  * ran.shape.moment([1, 2, 3], 0)
  * // => 1

--- a/src/shape/moment.js
+++ b/src/shape/moment.js
@@ -21,5 +21,5 @@ import mean from '../location/mean'
  * // => 4.666666666666667
  */
 export default function (values, k, c = 0) {
-  return values.length > 0 ? mean(values.map(d => Math.pow(d - c, k))) : undefined
+  return values.length > 0 ? mean(values.map(d => Math.pow(d - c, k))) : NaN
 }

--- a/src/shape/quantile.js
+++ b/src/shape/quantile.js
@@ -11,7 +11,7 @@ import quickselect from '../algorithms/quickselect'
  */
 export default function (values, p) {
   if (values.length === 0) {
-    return undefined
+    return NaN
   }
 
   const h = (values.length - 1) * p

--- a/src/shape/quantile.js
+++ b/src/shape/quantile.js
@@ -7,7 +7,7 @@ import quickselect from '../algorithms/quickselect'
  * @memberof ran.shape
  * @param {number[]} values Array of values to calculate quantile for.
  * @param {number} p Value to calculate quantile at.
- * @returns {number|undefined} The quantile of the sample if there is any, undefined otherwise.
+ * @returns {number} The quantile of the sample, or NaN for an empty array.
  */
 export default function (values, p) {
   if (values.length === 0) {

--- a/src/shape/rank.js
+++ b/src/shape/rank.js
@@ -4,11 +4,11 @@
  * @method rank
  * @memberof ran.shape
  * @param {number[]} values Array of values to calculate ranks for.
- * @returns {number|undefined} The ranks of the values if there are any, undefined otherwise.
+ * @returns {number[]} The ranks of the values, or an empty array for empty input.
  * @example
  *
  * ran.shape.rank([])
- * // => undefined
+ * // => []
  *
  * ran.shape.rank([1, 2, 2, 3])
  * // => [1, 2.5, 2.5, 4]

--- a/src/shape/rank.js
+++ b/src/shape/rank.js
@@ -15,7 +15,7 @@
  */
 export default function (values) {
   if (values.length === 0) {
-    return undefined
+    return []
   }
 
   const sorted = values.slice().sort((a, b) => a - b)

--- a/src/shape/skewness.js
+++ b/src/shape/skewness.js
@@ -29,12 +29,12 @@ import moment from './moment'
  */
 export default function (values) {
   if (values.length < 3) {
-    return undefined
+    return NaN
   }
 
   const n = values.length
   const m = mean(values)
   const m2 = moment(values, 2, m)
   const m3 = moment(values, 3, m)
-  return m2 === 0 ? undefined : Math.sqrt(n * (n - 1)) * m3 / ((n - 2) * Math.pow(m2, 1.5))
+  return m2 === 0 ? NaN : Math.sqrt(n * (n - 1)) * m3 / ((n - 2) * Math.pow(m2, 1.5))
 }

--- a/src/shape/skewness.js
+++ b/src/shape/skewness.js
@@ -8,18 +8,17 @@ import moment from './moment'
  * @method skewness
  * @memberof ran.shape
  * @param {number[]} values Array of values to calculate skewness for.
- * @returns {number|undefined} The sample skewness of values if there are more than two and their variance is nonzero,
- * undefined otherwise.
+ * @returns {number} The sample skewness, or NaN for fewer than 3 elements or zero variance.
  * @example
  *
  * ran.shape.skewness([])
- * // => undefined
+ * // => NaN
  *
  * ran.shape.skewness([1, 2])
- * // => undefined
+ * // => NaN
  *
  * ran.shape.skewness([1, 1, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.shape.skewness([1, 1, 1, 2])
  * // => 2

--- a/src/shape/yule.js
+++ b/src/shape/yule.js
@@ -8,15 +8,14 @@ import median from '../location/median'
  * @method yule
  * @memberof ran.shape
  * @param {number[]} values Array of values to calculate Yule's coefficient for.
- * @returns {number|undefined} Yule's coefficient of the values if the lower and upper quartiles differ, undefined
- * otherwise.
+ * @returns {number} Yule's coefficient, or NaN for an empty array or when the lower and upper quartiles are equal.
  * @example
  *
  * ran.shape.yule([])
- * // => undefined
+ * // => NaN
  *
  * ran.shape.yule([1, 1, 1])
- * // => undefined
+ * // => NaN
  *
  * ran.shape.yule([1, 1, 1, 2])
  * // => 1

--- a/src/shape/yule.js
+++ b/src/shape/yule.js
@@ -28,5 +28,5 @@ export default function (values) {
   const q1 = quantile(values, 0.25)
   const q3 = quantile(values, 0.75)
 
-  return q1 === q3 ? undefined : (q1 + q3 - 2 * median(values)) / (q3 - q1)
+  return q1 === q3 ? NaN : (q1 + q3 - 2 * median(values)) / (q3 - q1)
 }

--- a/src/ts/online-covariance.js
+++ b/src/ts/online-covariance.js
@@ -42,9 +42,9 @@ export default class {
    *
    * @method compute
    * @memberof ran.ts.OnlineCovariance
-   * @returns {(ran.la.Matrix | undefined)} The current covariance matrix if there was any update already, undefined otherwise.
+   * @returns {ran.la.Matrix} The current covariance matrix, or a NaN-filled matrix if no updates have been made yet.
    */
   compute () {
-    return this.n > 0 ? this.cov.scale(1 / this.n) : undefined
+    return this.n > 0 ? this.cov.scale(1 / this.n) : this.cov.scale(NaN)
   }
 }

--- a/test/dependence.js
+++ b/test/dependence.js
@@ -5,15 +5,15 @@ import * as dependence from '../src/dependence'
 
 describe('dependence', () => {
   describe('.covariance()', () => {
-    it('should return undefined if any of the arrays has fewer than two elements', () => {
-      assert(typeof dependence.covariance([], [1, 2, 3]) === 'undefined')
-      assert(typeof dependence.covariance([1], [1, 2, 3]) === 'undefined')
-      assert(typeof dependence.covariance([1, 2, 3], []) === 'undefined')
-      assert(typeof dependence.covariance([1, 2, 3], [1]) === 'undefined')
+    it('should throw if arrays have different length', () => {
+      assert.throws(() => dependence.covariance([1, 2, 3], [4, 5]))
+      assert.throws(() => dependence.covariance([], [1, 2, 3]))
+      assert.throws(() => dependence.covariance([1, 2, 3], []))
     })
 
-    it('should return undefined if arrays have different length', () => {
-      assert(typeof dependence.covariance([1, 2, 3], [4, 5]) === 'undefined')
+    it('should return NaN if any of the arrays has fewer than two elements', () => {
+      assert(Number.isNaN(dependence.covariance([], [])))
+      assert(Number.isNaN(dependence.covariance([1], [1])))
     })
 
     it('should return the covariance of two arrays', () => {
@@ -46,9 +46,13 @@ describe('dependence', () => {
   })
 
   describe('.dCov()', () => {
-    it('should return undefined if any array is empty', () => {
-      assert(typeof dependence.dCov([], [1, 2, 3]) === 'undefined')
-      assert(typeof dependence.dCov([1, 2, 3], []) === 'undefined')
+    it('should throw if arrays have different length', () => {
+      assert.throws(() => dependence.dCov([], [1, 2, 3]))
+      assert.throws(() => dependence.dCov([1, 2, 3], []))
+    })
+
+    it('should return NaN for empty arrays', () => {
+      assert(Number.isNaN(dependence.dCov([], [])))
     })
 
     it('should return the distance covariance of two arrays', () => {
@@ -70,9 +74,17 @@ describe('dependence', () => {
   })
 
   describe('.dCor()', () => {
-    it('should return undefined if any array is empty', () => {
-      assert(typeof dependence.dCor([], [1, 2, 3]) === 'undefined')
-      assert(typeof dependence.dCor([1, 2, 3], []) === 'undefined')
+    it('should throw if arrays have different length', () => {
+      assert.throws(() => dependence.dCor([], [1, 2, 3]))
+      assert.throws(() => dependence.dCor([1, 2, 3], []))
+    })
+
+    it('should return NaN for empty arrays', () => {
+      assert(Number.isNaN(dependence.dCor([], [])))
+    })
+
+    it('should return NaN if one array is constant', () => {
+      assert(Number.isNaN(dependence.dCor([1, 1, 1], [1, 2, 3])))
     })
 
     it('should return the distance correlation of two arrays', () => {
@@ -94,13 +106,14 @@ describe('dependence', () => {
   })
 
   describe('.kendall()', () => {
-    it('should return undefined if any array is empty', () => {
-      assert(typeof dependence.kendall([], [1, 2, 3]) === 'undefined')
-      assert(typeof dependence.kendall([1, 2, 3], []) === 'undefined')
+    it('should throw if arrays have different length', () => {
+      assert.throws(() => dependence.kendall([], [1, 2, 3]))
+      assert.throws(() => dependence.kendall([1, 2, 3], []))
+      assert.throws(() => dependence.kendall([1, 2, 3], [4, 5]))
     })
 
-    it('should return undefined if arrays have different length', () => {
-      assert(typeof dependence.kendall([1, 2, 3], [4, 5]) === 'undefined')
+    it('should return NaN for empty arrays', () => {
+      assert(Number.isNaN(dependence.kendall([], [])))
     })
 
     it('should return Kendall\'s tau of two arrays', () => {
@@ -122,17 +135,18 @@ describe('dependence', () => {
   })
 
   describe('.kullbackLeibler()', () => {
-    it('should return undefined if any array is empty', () => {
-      assert(typeof dependence.kullbackLeibler([], [0.1, 0.2, 0.7]) === 'undefined')
-      assert(typeof dependence.kullbackLeibler([0.1, 0.2, 0.7], []) === 'undefined')
+    it('should throw if arrays have different length', () => {
+      assert.throws(() => dependence.kullbackLeibler([], [0.1, 0.2, 0.7]))
+      assert.throws(() => dependence.kullbackLeibler([0.1, 0.2, 0.7], []))
+      assert.throws(() => dependence.kullbackLeibler([0.1, 0.2, 0.7], [0.3, 0.7]))
     })
 
-    it('should return undefined if arrays have different length', () => {
-      assert(typeof dependence.kullbackLeibler([0.1, 0.2, 0.7], [0.3, 0.7]) === 'undefined')
+    it('should return NaN for empty input', () => {
+      assert(Number.isNaN(dependence.kullbackLeibler([], [])))
     })
 
-    it('should return undefined if Q(x) = 0 and P(x) > 0 for some x', () => {
-      assert(typeof dependence.kullbackLeibler([0.1, 0.2, 0.7], [0, 0.3, 0.7]) === 'undefined')
+    it('should return Infinity if Q(x) = 0 and P(x) > 0 for some x', () => {
+      assert(dependence.kullbackLeibler([0.1, 0.2, 0.7], [0, 0.3, 0.7]) === Infinity)
     })
 
     it('should return the Kullback-Leibler divergence of two arrays of probabilities', () => {
@@ -159,9 +173,9 @@ describe('dependence', () => {
   })
 
   describe('.oddsRatio()', () => {
-    it('should return undefined if any of p01 and p10 is zero', () => {
-      assert(typeof dependence.oddsRatio(0.1, 0, 0.3, 0.4) === 'undefined')
-      assert(typeof dependence.oddsRatio(0.1, 0.2, 0, 0.4) === 'undefined')
+    it('should return Infinity if p01 or p10 is zero', () => {
+      assert(dependence.oddsRatio(0.1, 0, 0.3, 0.4) === Infinity)
+      assert(dependence.oddsRatio(0.1, 0.2, 0, 0.4) === Infinity)
     })
 
     it('should return the odds ratio for contingency table of joint probabilities', () => {
@@ -176,13 +190,15 @@ describe('dependence', () => {
   })
 
   describe('.pearson()', () => {
-    it('should return undefined if any array is empty', () => {
-      assert(typeof dependence.pearson([], [1, 2, 3]) === 'undefined')
-      assert(typeof dependence.pearson([1, 2, 3], []) === 'undefined')
+    it('should throw if arrays have different length', () => {
+      assert.throws(() => dependence.pearson([], [1, 2, 3]))
+      assert.throws(() => dependence.pearson([1, 2, 3], []))
+      assert.throws(() => dependence.pearson([1, 2, 3], [4, 5]))
     })
 
-    it('should return undefined if arrays have different length', () => {
-      assert(typeof dependence.pearson([1, 2, 3], [4, 5]) === 'undefined')
+    it('should return NaN if any of the arrays has fewer than two elements', () => {
+      assert(Number.isNaN(dependence.pearson([], [])))
+      assert(Number.isNaN(dependence.pearson([1], [1])))
     })
 
     it('should return the Pearson correlation of two arrays', () => {
@@ -215,17 +231,19 @@ describe('dependence', () => {
   })
 
   describe('.pointBiserial()', () => {
-    it('should return undefined if any array is empty', () => {
-      assert(typeof dependence.pointBiserial([], [1, 2, 3]) === 'undefined')
-      assert(typeof dependence.pointBiserial([1, 2, 3], []) === 'undefined')
+    it('should throw if arrays have different length', () => {
+      assert.throws(() => dependence.pointBiserial([], [1, 2, 3]))
+      assert.throws(() => dependence.pointBiserial([1, 2, 3], []))
+      assert.throws(() => dependence.pointBiserial([1, 2, 3], [0, 1]))
     })
 
-    it('should return undefined if arrays have different length', () => {
-      assert(typeof dependence.pointBiserial([1, 2, 3], [0, 1]) === 'undefined')
+    it('should return NaN if any of the arrays has fewer than two elements', () => {
+      assert(Number.isNaN(dependence.pointBiserial([], [])))
+      assert(Number.isNaN(dependence.pointBiserial([1], [0])))
     })
 
-    it('should return undefined if standard deviation of x is 0', () => {
-      assert(typeof dependence.pointBiserial([1, 1, 1], [0, 0, 1]) === 'undefined')
+    it('should return NaN if standard deviation of x is 0', () => {
+      assert(Number.isNaN(dependence.pointBiserial([1, 1, 1], [0, 0, 1])))
     })
 
     it('should return the point-biserial correlation of two arrays', () => {
@@ -246,12 +264,13 @@ describe('dependence', () => {
   })
 
   describe('.somersD()', () => {
-    it('should return undefined if any of the samples is empty', () => {
-      assert(typeof dependence.somersD([], [1, 2, 3]) === 'undefined')
+    it('should throw if samples have different length', () => {
+      assert.throws(() => dependence.somersD([], [1, 2, 3]))
+      assert.throws(() => dependence.somersD([1, 2, 3], [1, 2, 3, 4]))
     })
 
-    it('should return undefined if samples have different sizes', () => {
-      assert(typeof dependence.somersD([1, 2, 3], [1, 2, 3, 4]) === 'undefined')
+    it('should return NaN for empty samples', () => {
+      assert(Number.isNaN(dependence.somersD([], [])))
     })
 
     it('should return Somers\' D', () => {
@@ -273,13 +292,14 @@ describe('dependence', () => {
   })
 
   describe('.spearman()', () => {
-    it('should return undefined if any array is empty', () => {
-      assert(typeof dependence.spearman([], [1, 2, 3]) === 'undefined')
-      assert(typeof dependence.spearman([1, 2, 3], []) === 'undefined')
+    it('should throw if arrays have different length', () => {
+      assert.throws(() => dependence.spearman([], [1, 2, 3]))
+      assert.throws(() => dependence.spearman([1, 2, 3], []))
+      assert.throws(() => dependence.spearman([1, 2, 3], [4, 5]))
     })
 
-    it('should return undefined if arrays have different length', () => {
-      assert(typeof dependence.spearman([1, 2, 3], [4, 5]) === 'undefined')
+    it('should return NaN for empty arrays', () => {
+      assert(Number.isNaN(dependence.spearman([], [])))
     })
 
     it('should return Spearman\'s rank correlation of two arrays', () => {
@@ -310,9 +330,9 @@ describe('dependence', () => {
   })
 
   describe('.yuleQ()', () => {
-    it('should return undefined if any of p01 and p10 is zero', () => {
-      assert(typeof dependence.yuleQ(0.1, 0, 0.3, 0.4) === 'undefined')
-      assert(typeof dependence.yuleQ(0.1, 0.2, 0, 0.4) === 'undefined')
+    it('should return NaN if p01 or p10 is zero', () => {
+      assert(Number.isNaN(dependence.yuleQ(0.1, 0, 0.3, 0.4)))
+      assert(Number.isNaN(dependence.yuleQ(0.1, 0.2, 0, 0.4)))
     })
 
     it('should return Yule\'s Q for a contingency table of joint probabilities', () => {
@@ -328,9 +348,9 @@ describe('dependence', () => {
   })
 
   describe('.yuleY()', () => {
-    it('should return undefined if any of p01 and p10 is zero', () => {
-      assert(typeof dependence.yuleY(0.1, 0, 0.3, 0.4) === 'undefined')
-      assert(typeof dependence.yuleY(0.1, 0.2, 0, 0.4) === 'undefined')
+    it('should return NaN if p01 or p10 is zero', () => {
+      assert(Number.isNaN(dependence.yuleY(0.1, 0, 0.3, 0.4)))
+      assert(Number.isNaN(dependence.yuleY(0.1, 0.2, 0, 0.4)))
     })
 
     it('should return Yule\'s Y for a contingency table of joint probabilities', () => {

--- a/test/dispersion.js
+++ b/test/dispersion.js
@@ -5,16 +5,15 @@ import * as dispersion from '../src/dispersion'
 
 const SAMPLE_SIZE = 100
 
-// TODO Go through methods and check input conditions.
 describe('dispersion', () => {
   describe('.cv()', () => {
-    it('should return undefined if sample size is less than 2', () => {
-      assert(typeof dispersion.cv([]) === 'undefined')
-      assert(typeof dispersion.cv([1]) === 'undefined')
+    it('should return NaN if sample size is less than 2', () => {
+      assert(Number.isNaN(dispersion.cv([])))
+      assert(Number.isNaN(dispersion.cv([1])))
     })
 
-    it('should return undefined if mean is 0', () => {
-      assert(typeof dispersion.cv([-1, 0, 1]) === 'undefined')
+    it('should return NaN if mean is 0', () => {
+      assert(Number.isNaN(dispersion.cv([-1, 0, 1])))
     })
 
     it('should return the coefficient of variation', () => {
@@ -28,8 +27,8 @@ describe('dispersion', () => {
   })
 
   describe('.dVar()', () => {
-    it('should return undefined for empty array', () => {
-      assert(typeof dispersion.dVar([]) === 'undefined')
+    it('should return NaN for empty array', () => {
+      assert(Number.isNaN(dispersion.dVar([])))
     })
 
     it('should return the distance variance of an array', () => {
@@ -45,8 +44,8 @@ describe('dispersion', () => {
   })
 
   describe('.entropy()', () => {
-    it('should return undefined if sample is empty', () => {
-      assert(typeof dispersion.entropy([]) === 'undefined')
+    it('should return NaN for empty array', () => {
+      assert(Number.isNaN(dispersion.entropy([])))
     })
 
     it('should return the Shannon entropy of the probabilities using natural logarithm', () => {
@@ -106,13 +105,13 @@ describe('dispersion', () => {
   })
 
   describe('.gini()', () => {
-    it('should return undefined if sample size is less than 2', () => {
-      assert(typeof dispersion.gini([]) === 'undefined')
-      assert(typeof dispersion.gini([1]) === 'undefined')
+    it('should return NaN if sample size is less than 2', () => {
+      assert(Number.isNaN(dispersion.gini([])))
+      assert(Number.isNaN(dispersion.gini([1])))
     })
 
-    it('should return undefined if mean is zero', () => {
-      assert(typeof dispersion.gini([-1, 0, 1]) === 'undefined')
+    it('should return NaN if mean is zero', () => {
+      assert(Number.isNaN(dispersion.gini([-1, 0, 1])))
     })
 
     it('should return the relative mean absolute difference', () => {
@@ -134,8 +133,8 @@ describe('dispersion', () => {
   })
 
   describe('.iqr()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof dispersion.iqr([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(dispersion.iqr([])))
     })
 
     it('should return 0 for a sample of a single element', () => {
@@ -165,9 +164,9 @@ describe('dispersion', () => {
   })
 
   describe('.md()', () => {
-    it('should return undefined if sample size is less than 2', () => {
-      assert(typeof dispersion.md([]) === 'undefined')
-      assert(typeof dispersion.md([1]) === 'undefined')
+    it('should return NaN if sample size is less than 2', () => {
+      assert(Number.isNaN(dispersion.md([])))
+      assert(Number.isNaN(dispersion.md([1])))
     })
 
     it('should return the mean absolute difference', () => {
@@ -186,8 +185,8 @@ describe('dispersion', () => {
   })
 
   describe('.midhinge()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof dispersion.midhinge([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(dispersion.midhinge([])))
     })
 
     it('should return the midhinge for a finite sample', () => {
@@ -213,8 +212,8 @@ describe('dispersion', () => {
   })
 
   describe('.range()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof dispersion.range([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(dispersion.range([])))
     })
 
     it('should return the range for a finite sample', () => {
@@ -229,13 +228,13 @@ describe('dispersion', () => {
   })
 
   describe('.rmd()', () => {
-    it('should return undefined if sample size is less than 2', () => {
-      assert(typeof dispersion.rmd([]) === 'undefined')
-      assert(typeof dispersion.rmd([1]) === 'undefined')
+    it('should return NaN if sample size is less than 2', () => {
+      assert(Number.isNaN(dispersion.rmd([])))
+      assert(Number.isNaN(dispersion.rmd([1])))
     })
 
-    it('should return undefined if mean is zero', () => {
-      assert(typeof dispersion.rmd([-1, 0, 1]) === 'undefined')
+    it('should return NaN if mean is zero', () => {
+      assert(Number.isNaN(dispersion.rmd([-1, 0, 1])))
     })
 
     it('should return the relative mean absolute difference', () => {
@@ -257,8 +256,8 @@ describe('dispersion', () => {
   })
 
   describe('.qcd()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof dispersion.qcd([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(dispersion.qcd([])))
     })
 
     it('should return 0 for a sample of a single element', () => {
@@ -288,9 +287,9 @@ describe('dispersion', () => {
   })
 
   describe('.stdev()', () => {
-    it('should return undefined if sample size is less than 2', () => {
-      assert(typeof dispersion.stdev([]) === 'undefined')
-      assert(typeof dispersion.stdev([1]) === 'undefined')
+    it('should return NaN if sample size is less than 2', () => {
+      assert(Number.isNaN(dispersion.stdev([])))
+      assert(Number.isNaN(dispersion.stdev([1])))
     })
 
     it('should return the unbiased standard deviation', () => {
@@ -304,9 +303,9 @@ describe('dispersion', () => {
   })
 
   describe('.variance()', () => {
-    it('should return undefined if sample size is less than 2', () => {
-      assert(typeof dispersion.variance([]) === 'undefined')
-      assert(typeof dispersion.variance([1]) === 'undefined')
+    it('should return NaN if sample size is less than 2', () => {
+      assert(Number.isNaN(dispersion.variance([])))
+      assert(Number.isNaN(dispersion.variance([1])))
     })
 
     it('should return the unbiased variance', () => {
@@ -320,13 +319,13 @@ describe('dispersion', () => {
   })
 
   describe('.vmr()', () => {
-    it('should return undefined if sample size is less than 2', () => {
-      assert(typeof dispersion.vmr([]) === 'undefined')
-      assert(typeof dispersion.vmr([1]) === 'undefined')
+    it('should return NaN if sample size is less than 2', () => {
+      assert(Number.isNaN(dispersion.vmr([])))
+      assert(Number.isNaN(dispersion.vmr([1])))
     })
 
-    it('should return undefined if mean is 0', () => {
-      assert(typeof dispersion.vmr([-1, 0, 1]) === 'undefined')
+    it('should return NaN if mean is 0', () => {
+      assert(Number.isNaN(dispersion.vmr([-1, 0, 1])))
     })
 
     it('should return the coefficient of variation', () => {

--- a/test/la.js
+++ b/test/la.js
@@ -55,17 +55,29 @@ describe('la', () => {
       it('should add two vectors', () => {
         assert.deepEqual(new la.Vector([1, 2, 3]).add(new la.Vector([6, 7, 8])), new la.Vector([7, 9, 11]))
       })
+
+      it('should throw on dimension mismatch', () => {
+        assert.throws(() => new la.Vector([1, 2, 3]).add(new la.Vector([1, 2])))
+      })
     })
 
     describe('.sub()', () => {
       it('should subtract two vectors', () => {
         assert.deepEqual(new la.Vector([1, 2, 3]).sub(new la.Vector([6, 7, 8])), new la.Vector([-5, -5, -5]))
       })
+
+      it('should throw on dimension mismatch', () => {
+        assert.throws(() => new la.Vector([1, 2, 3]).sub(new la.Vector([1, 2])))
+      })
     })
 
     describe('.dot()', () => {
       it('should compute the dot product of two vectors', () => {
         assert.deepEqual(new la.Vector([1.2, 3.4, 5.6, 7.8]).dot(new la.Vector([1, 2, 3, 4])), 56)
+      })
+
+      it('should throw on dimension mismatch', () => {
+        assert.throws(() => new la.Vector([1, 2, 3]).dot(new la.Vector([1, 2])))
       })
     })
 
@@ -204,6 +216,10 @@ describe('la', () => {
           )
         }, 100)
       })
+
+      it('should throw on dimension mismatch', () => {
+        assert.throws(() => new la.Matrix(3).add(new la.Matrix(4)))
+      })
     })
 
     describe('.sub()', () => {
@@ -217,6 +233,10 @@ describe('la', () => {
             new la.Matrix(arr1.map((d, i) => d.map((dd, j) => dd - arr2[i][j])))
           )
         }, 100)
+      })
+
+      it('should throw on dimension mismatch', () => {
+        assert.throws(() => new la.Matrix(3).sub(new la.Matrix(4)))
       })
     })
 
@@ -232,9 +252,17 @@ describe('la', () => {
           )
         }, 100)
       })
+
+      it('should throw on dimension mismatch', () => {
+        assert.throws(() => new la.Matrix(3).apply(new la.Vector(4)))
+      })
     })
 
     describe('.mult()', () => {
+      it('should throw on dimension mismatch', () => {
+        assert.throws(() => new la.Matrix(3).mult(new la.Matrix(4)))
+      })
+
       it('should multiply two matrices', () => {
         // Test uses the Freivalds algorithm
         const n = 10
@@ -340,6 +368,10 @@ describe('la', () => {
             new la.Matrix(arr1.map((row, i) => row.map((d, j) => d * arr2[i][j])))
           )
         }, 100)
+      })
+
+      it('should throw on dimension mismatch', () => {
+        assert.throws(() => new la.Matrix(3).hadamard(new la.Matrix(4)))
       })
     })
   })

--- a/test/location.js
+++ b/test/location.js
@@ -7,8 +7,13 @@ import * as dist from '../src/dist'
 
 const SAMPLE_SIZE = 100
 
-// TODO Go through methods and check input conditions.
 describe('location', () => {
+  describe('.mean()', () => {
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(location.mean([])))
+    })
+  })
+
   describe('.geometricMean()', () => {
     it('should return zero for sample containing zero', () => {
       repeat(() => {
@@ -28,19 +33,19 @@ describe('location', () => {
   })
 
   describe('.harmonicMean()', () => {
-    it('should return undefined for sample containing zero', () => {
+    it('should return NaN for sample containing zero', () => {
       repeat(() => {
         const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
           .concat([0])
-        assert(typeof location.harmonicMean(values) === 'undefined')
+        assert(Number.isNaN(location.harmonicMean(values)))
       })
     })
 
-    it('should return undefined for sample containing negative values', () => {
+    it('should return NaN for sample containing negative values', () => {
       repeat(() => {
         const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
           .concat([-1])
-        assert(typeof location.harmonicMean(values) === 'undefined')
+        assert(Number.isNaN(location.harmonicMean(values)))
       })
     })
 
@@ -54,8 +59,8 @@ describe('location', () => {
   })
 
   describe('.median()', () => {
-    it('should return undefined for a sample size less than 1', () => {
-      assert(typeof location.median([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(location.median([])))
     })
 
     it('should return the median for odd sample size', () => {
@@ -78,8 +83,8 @@ describe('location', () => {
   })
 
   describe('.midrange()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof location.midrange([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(location.midrange([])))
     })
 
     it('should return the midrange for a finite sample', () => {
@@ -94,8 +99,8 @@ describe('location', () => {
   })
 
   describe('.mode()', () => {
-    it('should return undefined for a sample size less than 1', () => {
-      assert(typeof location.mode([]) === 'undefined')
+    it('should return empty array for an empty sample', () => {
+      assert.deepEqual(location.mode([]), [])
     })
 
     describe('discrete sample', () => {
@@ -143,8 +148,8 @@ describe('location', () => {
   })
 
   describe('.trimean()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof location.trimean([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(location.trimean([])))
     })
 
     it('should return the trimean for a finite sample', () => {

--- a/test/shape.js
+++ b/test/shape.js
@@ -6,17 +6,16 @@ import * as shape from '../src/shape'
 
 const SAMPLE_SIZE = 100
 
-// TODO Go through methods and check input conditions.
 describe('dispersion', () => {
   describe('.kurtosis()', () => {
-    it('should return undefined if sample size is less than 3', () => {
-      assert(typeof shape.kurtosis([]) === 'undefined')
-      assert(typeof shape.kurtosis([1]) === 'undefined')
-      assert(typeof shape.kurtosis([1, 2]) === 'undefined')
+    it('should return NaN if sample size is less than 3', () => {
+      assert(Number.isNaN(shape.kurtosis([])))
+      assert(Number.isNaN(shape.kurtosis([1])))
+      assert(Number.isNaN(shape.kurtosis([1, 2])))
     })
 
-    it('should return undefined if the variance is 0', () => {
-      assert(typeof shape.kurtosis([1, 1, 1]) === 'undefined')
+    it('should return NaN if the variance is 0', () => {
+      assert(Number.isNaN(shape.kurtosis([1, 1, 1])))
     })
 
     it('should return the kurtosis', () => {
@@ -42,8 +41,8 @@ describe('dispersion', () => {
   })
 
   describe('.moment()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof shape.moment([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(shape.moment([], 2)))
     })
 
     it('should return the moment for finite sample for c = 0', () => {
@@ -79,8 +78,8 @@ describe('dispersion', () => {
   })
 
   describe('.quantile()', () => {
-    it('should return undefined for empty sample', () => {
-      assert(typeof shape.quantile([], 0.5) === 'undefined')
+    it('should return NaN for empty sample', () => {
+      assert(Number.isNaN(shape.quantile([], 0.5)))
     })
 
     it('should return quantile for finite sample', () => {
@@ -98,8 +97,8 @@ describe('dispersion', () => {
   })
 
   describe('.rank()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof shape.rank([]) === 'undefined')
+    it('should return empty array for an empty sample', () => {
+      assert.deepEqual(shape.rank([]), [])
     })
 
     it('.should rank values using fractional rank', () => {
@@ -120,14 +119,14 @@ describe('dispersion', () => {
   })
 
   describe('.skewness()', () => {
-    it('should return undefined if sample size is less than 3', () => {
-      assert(typeof shape.skewness([]) === 'undefined')
-      assert(typeof shape.skewness([1]) === 'undefined')
-      assert(typeof shape.skewness([1, 2]) === 'undefined')
+    it('should return NaN if sample size is less than 3', () => {
+      assert(Number.isNaN(shape.skewness([])))
+      assert(Number.isNaN(shape.skewness([1])))
+      assert(Number.isNaN(shape.skewness([1, 2])))
     })
 
-    it('should return undefined if the variance is 0', () => {
-      assert(typeof shape.skewness([1, 1, 1]) === 'undefined')
+    it('should return NaN if the variance is 0', () => {
+      assert(Number.isNaN(shape.skewness([1, 1, 1])))
     })
 
     it('should return the skewness', () => {
@@ -155,12 +154,12 @@ describe('dispersion', () => {
   })
 
   describe('.yule()', () => {
-    it('should return undefined for an empty sample', () => {
-      assert(typeof shape.yule([]) === 'undefined')
+    it('should return NaN for an empty sample', () => {
+      assert(Number.isNaN(shape.yule([])))
     })
 
-    it('should return undefined if lower and upper quartiles are the same', () => {
-      assert(typeof shape.yule([1, 1, 1]) === 'undefined')
+    it('should return NaN if lower and upper quartiles are the same', () => {
+      assert(Number.isNaN(shape.yule([1, 1, 1])))
     })
 
     it('should return Yule\'s coefficient for a finite sample', () => {

--- a/test/ts.js
+++ b/test/ts.js
@@ -1,0 +1,35 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+import * as ts from '../src/ts'
+
+describe('ts', () => {
+  describe('.OnlineCovariance', () => {
+    it('should default to dimension 1', () => {
+      const oc = new ts.OnlineCovariance()
+      oc.update([5])
+      const m = oc.compute().m()
+      assert.strictEqual(m[0][0], 0)
+    })
+
+    describe('.compute()', () => {
+      it('should return a NaN-filled matrix when no updates have been made', () => {
+        const oc = new ts.OnlineCovariance(2)
+        const m = oc.compute().m()
+        assert(Number.isNaN(m[0][0]))
+        assert(Number.isNaN(m[0][1]))
+        assert(Number.isNaN(m[1][0]))
+        assert(Number.isNaN(m[1][1]))
+      })
+
+      it('should return the covariance matrix after updates', () => {
+        const oc = new ts.OnlineCovariance(1)
+        oc.update([1])
+        oc.update([2])
+        oc.update([3])
+        const m = oc.compute().m()
+        // Population covariance: sum of squared deviations / n = 2/3
+        assert(Math.abs(m[0][0] - 2 / 3) < 1e-10)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #593

## Summary
- Audited all modules in `src/la/`, `src/location/`, `src/dispersion/`, `src/shape/`, `src/dependence/`, and `src/ts/` against ADR-0015's four-channel return-value convention
- Dimension/length mismatches now `throw Error(...)` (caller error); degenerate inputs (empty array, too-few elements, zero variance) now return `NaN`; divergent results (KL divergence with Q=0/P>0, zero-denominator odds ratio) return `Infinity` via natural IEEE-754 arithmetic
- Tests updated from `typeof result === 'undefined'` assertions to `assert.throws` for mismatch cases and `Number.isNaN()` for degenerate cases; `test/ts.js` added for `OnlineCovariance`

## Design decisions
- [ADR-0015: Return-value and error conventions](decisions/0015-return-value-and-error-conventions.md) — four-channel convention: `throw` / `NaN` / `±Infinity` / `0`; `undefined` is not an error sentinel

## Non-trivial changes
- **`src/dependence/covariance.js`**: Split single `isInvalidInput` guard into two: `x.length !== y.length` → `throw`, `x.length < 2` → `return NaN`. Previously both returned `undefined`.
- **`src/dependence/kullback-leibler.js`**: Removed `undefined` guards; `Q[i]=0, P[i]>0` now reaches `pi * Math.log(pi / 0)` = `Infinity` naturally (IEEE-754 `log(x/0) = Infinity`). Added explicit early-return `Infinity` guard for clarity.
- **`src/dependence/pearson.js`**: Changed `typeof cov === 'undefined'` check to `Number.isNaN(cov)`, propagating NaN from `covariance()` correctly. Zero-stdev guard returns `NaN` instead of `undefined`.
- **`src/dependence/yule-q.js`, `yule-y.js`**: Removed explicit `undefined` guard; when `oddsRatio = Infinity`, `(∞−1)/(∞+1)` and `(√∞−1)/(√∞+1)` are `NaN` via IEEE-754 `∞/∞`, which is the correct indeterminate-form sentinel.
- **`src/la/matrix.js`, `src/la/vector.js`**: Dimension-mismatch checks added to binary operations (`add`, `sub`, `hadamard`, `outer`) — they now `throw` instead of silently producing wrong-shaped results.
- **`src/ts/online-covariance.js`**: `compute()` before any updates now returns `this.cov.scale(NaN)` (a NaN-filled Matrix) instead of `undefined`, keeping the return type uniformly `ran.la.Matrix`.
- **`test/dependence.js`**: All mismatch assertions migrated from `typeof ... === 'undefined'` to `assert.throws`; degenerate-input assertions migrated to `Number.isNaN()`; constant-array test added for `dCor` to cover the `dVarX * dVarY = 0` branch.
- **`test/ts.js`**: New file. Covers the NaN-filled matrix path (no updates) and the population covariance path (3 updates).

<details>
<summary>Trivial changes</summary>

- **`src/dispersion/*.js`** (11 files): `return undefined` → `return NaN` on degenerate input (empty array, single element)
- **`src/location/*.js`** (7 files): same pattern; `mode([])` → `return []`; `rank([])` → `return []`
- **`src/shape/*.js`** (8 files): same pattern; `max([])` / `min([])` implicit fall-off → explicit `return NaN`
- **`test/dispersion.js`, `test/location.js`, `test/shape.js`, `test/la.js`**: `typeof result === 'undefined'` → `Number.isNaN(result)` or `assert.throws`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhMTdsJKbEgLDTwWD5HhKv)_