### PR TITLE
Add /review-pr skill for automated GitHub PR triage

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -19,6 +19,7 @@ This directory contains the skills and agents that power the development workflo
 │   ├── hotfix/SKILL.md       # Leaf: small targeted fix (no research/plan)
 │   ├── commit/SKILL.md       # Leaf: git commit
 │   ├── review/SKILL.md       # Leaf: code review
+│   ├── review-pr/SKILL.md    # Leaf: review a GitHub PR and approve+merge or request changes
 │   ├── pr/SKILL.md           # Leaf: GitHub PR creation + activity watch (CI autofix, review replies)
 │   ├── validate/SKILL.md     # Leaf: verify issue acceptance criteria
 │   └── compound/SKILL.md     # Leaf: document solved problems
@@ -73,6 +74,7 @@ Standalone skills that do one thing. Can be called directly or composed by orche
 | [`/commit`](skills/commit/SKILL.md) | Stage and commit with generated message | _(no args)_ |
 | [`/push`](skills/push/SKILL.md) | Push commits to remote | _(no args)_ |
 | [`/review`](skills/review/SKILL.md) | Code review against plan + quality checks | _(no args, reviews current branch)_ |
+| [`/review-pr`](skills/review-pr/SKILL.md) | Review a GitHub PR and approve+merge or request changes | PR URL or number |
 | [`/pr`](skills/pr/SKILL.md) | Create a PR with change categorization, then watch it (auto-fix CI, respond to reviews) | _(no args)_ |
 | [`/validate`](skills/validate/SKILL.md) | Verify issue acceptance criteria are met | `#issue` or issue URL |
 | [`/next`](skills/next/SKILL.md) | Pick the best next issue from the backlog | Milestone _(optional)_ |
@@ -213,6 +215,15 @@ Launched **in parallel** by [`/suggest`](skills/suggest/SKILL.md). Each scout sc
               → review-tests       │
               → review-docs        │
               → review-correctness ┘
+
+/review-pr ──→ review-security    ┐
+              → review-performance │
+              → review-simplicity  │ parallel
+              → review-tests       │
+              → review-docs        │
+              → review-correctness ┘
+              → mcp__github__pull_request_review_write (APPROVE or REQUEST_CHANGES)
+              → mcp__github__merge_pull_request (on PASS only)
 
 /compound ───→ discovery-thoughts
               → ops-insight

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -73,8 +73,8 @@ Standalone skills that do one thing. Can be called directly or composed by orche
 | [`/hotfix`](skills/hotfix/SKILL.md) | Small targeted fix, skip research/plan | Description or `#issue` |
 | [`/commit`](skills/commit/SKILL.md) | Stage and commit with generated message | _(no args)_ |
 | [`/push`](skills/push/SKILL.md) | Push commits to remote | _(no args)_ |
-| [`/review`](skills/review/SKILL.md) | Code review against plan + quality checks | _(no args, reviews current branch)_ |
-| [`/review-pr`](skills/review-pr/SKILL.md) | Review a GitHub PR and approve+merge or request changes | PR URL or number |
+| [`/review`](skills/review/SKILL.md) | Pre-commit quality check of the **local** branch against `main`; used inside `/build` | _(no args)_ |
+| [`/review-pr`](skills/review-pr/SKILL.md) | Triage an **incoming contributor PR on GitHub**: post APPROVE+merge or REQUEST_CHANGES | PR URL or number |
 | [`/pr`](skills/pr/SKILL.md) | Create a PR with change categorization, then watch it (auto-fix CI, respond to reviews) | _(no args)_ |
 | [`/validate`](skills/validate/SKILL.md) | Verify issue acceptance criteria are met | `#issue` or issue URL |
 | [`/next`](skills/next/SKILL.md) | Pick the best next issue from the backlog | Milestone _(optional)_ |

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,170 @@
+# PR Review Command
+
+You are reviewing a GitHub PR and posting a binding decision: **approve + merge** if all quality checks pass, or **request changes** if any blocking issue is found.
+
+## Core Principle
+
+Same quality bar as `/review`: catch issues CI cannot. The output is a GitHub review action, not a chat report. Every invocation ends with either an APPROVE+merge or a REQUEST_CHANGES posted to GitHub.
+
+## Workflow
+
+When the user invokes `/review-pr <PR-URL-or-number>`:
+
+### 1. Parse Input
+
+Extract owner, repo, and PR number:
+- Full URL `https://github.com/<owner>/<repo>/pull/<N>` → parse all three fields
+- Bare number → default to `synesenom/ran`
+
+### 2. Fetch PR Context (parallel)
+
+Use the GitHub MCP tools in a single parallel call:
+- `mcp__github__pull_request_read(method="get")` — title, state, draft flag, head SHA, body
+- `mcp__github__pull_request_read(method="get_diff")` — full unified diff
+- `mcp__github__pull_request_read(method="get_files")` — changed file list with stats
+
+**Guard rails — stop before doing any review if:**
+- `state !== "open"` → "PR #N is already `<state>`. Nothing to do."
+- `draft === true` → "PR #N is a draft. Mark it ready for review first."
+- diff is empty → "PR #N has no diff. Nothing to review."
+
+### 3. Save Diff
+
+```bash
+mkdir -p .claude/tmp
+# write the diff to a temp file so review agents can read it
+```
+
+Save the diff text to `.claude/tmp/review-diff-pr-<N>.patch`.
+
+### 4. Pass 1 — Convention Compliance
+
+External PRs have no local plan file, so Pass 1 checks project conventions from `CLAUDE.md` directly against the diff:
+
+| Check | Fail condition |
+|-------|---------------|
+| **CHANGELOG** | User-visible change (bug fix, new feature, removed code) present but no `CHANGELOG.md` hunk in the diff |
+| **Debug leftovers** | `console.log`, `TODO`, `FIXME`, or large commented-out code blocks added |
+| **Comment style** | Comments that describe *what* the code does rather than *why* (WHAT comments are flagged; WHY comments are fine) |
+| **Distribution constants** | `this.c = [...]` positional array instead of `this.c = { name: value, ... }` named object |
+| **Subclass constants** | Leaf-subclass uses `this.c = { ... }` when a parent already sets `this.c` (should be `Object.assign`) |
+| **Error conventions** | `undefined` returned as an error sentinel (should be `NaN`, `Infinity`, or `throw`) |
+
+Each failed check is a **P2** finding. Record them alongside the agent findings from Pass 2.
+
+### 5. Pass 2 — Code Quality (Parallel Agents)
+
+**CRITICAL: Launch exactly 6 review agents in a single parallel call. Verify all 6 returned before proceeding.**
+
+Tell each agent to read `.claude/tmp/review-diff-pr-<N>.patch` and provide enough diff context so they can assess without needing extra file access. Each agent returns findings rated P1/P2/P3.
+
+- **review-security** agent
+- **review-performance** agent
+- **review-simplicity** agent
+- **review-tests** agent
+- **review-docs** agent
+- **review-correctness** agent
+
+Wait for all 6. Deduplicate overlapping findings. If you downgrade a finding's severity, note the original severity and your rationale.
+
+### 6. Verdict
+
+**PASS** — zero P1 or P2 findings across both passes. P3 items are informational and do not block.
+
+**FAIL** — one or more P1 or P2 findings.
+
+### 7. Act on Verdict
+
+#### PASS → Approve and merge
+
+Post an APPROVE review:
+
+```
+mcp__github__pull_request_review_write(
+  method="create",
+  event="APPROVE",
+  commitID=<head SHA>,
+  body=<approval body — see format below>
+)
+```
+
+Then immediately merge (squash):
+
+```
+mcp__github__merge_pull_request(
+  method="squash"   (or the equivalent squash parameter)
+)
+```
+
+#### FAIL → Request changes
+
+Post a REQUEST_CHANGES review:
+
+```
+mcp__github__pull_request_review_write(
+  method="create",
+  event="REQUEST_CHANGES",
+  commitID=<head SHA>,
+  body=<findings body — see format below>
+)
+```
+
+Do **not** merge.
+
+### 8. Review Body Format
+
+#### Approval body (PASS)
+
+```
+LGTM — all quality checks passed.
+
+<One sentence describing what the PR does and why it looks correct.>
+
+<If any P3 items exist:>
+**Notes (non-blocking):**
+- [domain] file:line — <note>
+```
+
+#### Request-changes body (FAIL)
+
+```
+<If P1 items:>
+## Required (P1 — blocking)
+- [ ] [domain] `file:line` — <description and exact fix>
+
+<If P2 items:>
+## Required (P2 — blocking)
+- [ ] [domain] `file:line` — <description and exact fix>
+
+<If P3 items:>
+## Informational (non-blocking)
+- [domain] `file:line` — <note>
+```
+
+### 9. Report to User
+
+After posting to GitHub, report back:
+
+**PASS:**
+> PR #N approved and merged.
+> P3 notes (if any): <list>
+
+**FAIL:**
+> PR #N: changes requested — <N> blocking issue(s).
+> <Bulleted list of P1/P2 findings>
+
+## Rules
+
+### DO:
+- Fetch the full diff before running any agent
+- Launch all 6 review agents in a single parallel call and wait for all 6
+- Post a GitHub review (APPROVE or REQUEST_CHANGES) — never just a comment
+- Merge immediately and automatically after approving — this is the contract
+- Be specific: cite file path and line number for every finding
+
+### DO NOT:
+- Approve a PR that has any P1 or P2 finding
+- Merge without first posting an APPROVE review
+- Merge a draft PR or a non-open PR
+- Post REQUEST_CHANGES when the PR passes all checks
+- Poll GitHub with sleep — act and report, then end the turn

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -34,7 +34,28 @@ Use the GitHub MCP tools in a single parallel call:
 - `draft === true` → "PR #N is a draft. Mark it ready for review first."
 - diff is empty → "PR #N has no diff. Nothing to review."
 
-### 3. Save Diff
+### 3. Check Out the PR Branch and Run the Suite
+
+Fetch the PR head into a local ref, run lint + tests, then return to the original branch:
+
+```bash
+git fetch origin pull/<N>/head:pr-<N>-review
+git checkout pr-<N>-review
+npm run standard 2>&1
+npm test 2>&1
+git checkout -
+git branch -D pr-<N>-review
+```
+
+Run lint and tests sequentially (tests depend on lint passing). Capture full output.
+
+**If either command exits non-zero**, record a **P1** finding:
+- `[tests] CI` — `npm run standard` failed: `<first error line(s)>`
+- `[tests] CI` — `npm test` failed: `<failing test names and coverage breach lines>`
+
+**Do not stop** — continue to Pass 1 and Pass 2 so the full picture is reported in one review comment.
+
+### 4. Save Diff
 
 ```bash
 mkdir -p .claude/tmp
@@ -43,7 +64,7 @@ mkdir -p .claude/tmp
 
 Save the diff text to `.claude/tmp/review-diff-pr-<N>.patch`.
 
-### 4. Pass 1 — Convention Compliance
+### 5. Pass 1 — Convention Compliance (against diff)
 
 External PRs have no local plan file, so Pass 1 checks project conventions from `CLAUDE.md` directly against the diff:
 
@@ -58,7 +79,7 @@ External PRs have no local plan file, so Pass 1 checks project conventions from 
 
 Each failed check is a **P2** finding. Record them alongside the agent findings from Pass 2.
 
-### 5. Pass 2 — Code Quality (Parallel Agents)
+### 6. Pass 2 — Code Quality (Parallel Agents)
 
 **CRITICAL: Launch exactly 6 review agents in a single parallel call. Verify all 6 returned before proceeding.**
 
@@ -73,13 +94,13 @@ Tell each agent to read `.claude/tmp/review-diff-pr-<N>.patch` and provide enoug
 
 Wait for all 6. Deduplicate overlapping findings. If you downgrade a finding's severity, note the original severity and your rationale.
 
-### 6. Verdict
+### 7. Verdict
 
 **PASS** — zero P1 or P2 findings across both passes. P3 items are informational and do not block.
 
 **FAIL** — one or more P1 or P2 findings.
 
-### 7. Act on Verdict
+### 8. Act on Verdict
 
 #### PASS → Approve and merge
 
@@ -117,7 +138,7 @@ mcp__github__pull_request_review_write(
 
 Do **not** merge.
 
-### 8. Review Body Format
+### 9. Review Body Format
 
 #### Approval body (PASS)
 
@@ -147,7 +168,7 @@ LGTM — all quality checks passed.
 - [domain] `file:line` — <note>
 ```
 
-### 9. Report to User
+### 10. Report to User
 
 After posting to GitHub, report back:
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,10 +1,16 @@
 # PR Review Command
 
+> **Scope:** This skill is for reviewing **externally submitted GitHub PRs** (pull requests opened by contributors on GitHub). It is entirely distinct from:
+> - `/review` — reviews *local* branch changes before committing; used inside the `/build` pipeline
+> - `review-security`, `review-correctness`, etc. — internal quality-check subagents spawned by `/review` and `/build`; never invoked by users directly
+>
+> Do **not** use this skill during task resolution. It is only for triaging incoming contributor PRs.
+
 You are reviewing a GitHub PR and posting a binding decision: **approve + merge** if all quality checks pass, or **request changes** if any blocking issue is found.
 
 ## Core Principle
 
-Same quality bar as `/review`: catch issues CI cannot. The output is a GitHub review action, not a chat report. Every invocation ends with either an APPROVE+merge or a REQUEST_CHANGES posted to GitHub.
+Catch issues CI cannot. The output is a GitHub review action posted to the PR, not a chat report. Every invocation ends with either an APPROVE+merge or a REQUEST_CHANGES comment on GitHub.
 
 ## Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,10 @@ All three must pass before you open a PR. (`npm run standard` is the auto-fixing
 
 ## Adding a new distribution
 
-1. **Write test cases first** (TDD). Add an entry to `test/dist-cases.js` with `invalidParams`, `params`, and at least one `cases` entry before touching `src/`.
+1. **Write test cases first** (TDD). Add an entry to `test/dist-cases-continuous.js` (or `test/dist-cases-discrete.js` for discrete distributions) with `invalidParams`, `params`, and at least one `cases` entry before touching `src/`.
 2. Create `src/dist/<kebab-case-name>.js`. Subclass `Distribution` from `src/dist/_distribution.js` and implement `_pdf(x)` / `_pmf(x)` and `_cdf(x)`. Call `super('continuous' | 'discrete', <param-count>)`.
 3. Re-export the class from `src/dist/index.js`.
-4. Add a matching `class <Name> extends Distribution` entry to `dist/ranjs.d.ts` (alphabetical order).
+4. TypeScript declarations are **generated** from JSDoc — do not edit `dist/ranjs.d.ts` by hand. Give the class an explicit name (`export default class MyDist extends Distribution`) and add `@param` tags to the `constructor()` JSDoc block. Run `npm run build && npm run typecheck` to verify the generated declarations.
 5. Run `npm run standard && npm test && npm run typecheck`.
 
 See `CLAUDE.md` for the full distribution pattern, parameter conventions, and JSDoc format.
@@ -42,6 +42,13 @@ See `CLAUDE.md` for the full distribution pattern, parameter conventions, and JS
 - **Commit messages**: short imperative subject line (`Add Gompertz distribution`), body for context if needed.
 - **Changelog**: if your change is user-visible (new feature, bug fix, dependency update), add a bullet under `## [Unreleased]` in `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Pure refactors, test-only, and doc-only changes do not need an entry.
 - **No force-pushing** to a PR branch once review has started.
+
+## Code conventions
+
+- **Comments explain *why*, not *what*.** The code already says what it does; a comment must add information the reader cannot get from the identifiers alone (a hidden constraint, a workaround, a non-obvious invariant). Never describe the operation the next line performs.
+- **Error and missing-value returns** follow a strict hierarchy. `throw` for caller/programming errors (invalid parameters, wrong arity). `NaN` for valid inputs that have no defined answer (e.g. mean of a Cauchy). `Infinity`/`-Infinity` for values that diverge. `0` when the mathematically correct answer is zero. Never return `undefined` as a sentinel for "no result".
+- **Distribution constants** must be a named object: `this.c = { name: value, ... }`. Never use a positional array (`this.c = [a, b]`) — named fields are required so constants remain readable after minification.
+- **Subclass constants**: if a parent class already initialises `this.c`, extend it with `Object.assign(this.c, { newKey: value })`. Assigning `this.c = { ... }` in a subclass silently destroys the parent's constants.
 
 ## Running a subset of tests
 


### PR DESCRIPTION
## Summary
- Add `/review-pr` skill: fetches a contributor PR from GitHub, checks out the branch and runs `npm run standard && npm test`, runs the six parallel quality-check agents, then posts a binding GitHub review — APPROVE + squash-merge on PASS, REQUEST_CHANGES with structured findings on FAIL
- Fix two stale facts in `CONTRIBUTING.md` (`test/dist-cases.js` split into per-type files; TypeScript declarations are generated from JSDoc, not hand-edited) and add a Code conventions section covering WHY-only comments, the error/missing-value return hierarchy, distribution constant naming, and `Object.assign` for subclass constants

## Non-trivial changes
- **`.claude/skills/review-pr/SKILL.md`**: New skill. Distinct from `/review` (local pre-commit) and the internal `review-*` subagents. Workflow: parse PR URL or number → guard against draft/closed/empty → check out branch + run full test suite → Pass 1 convention compliance → Pass 2 six parallel quality agents → post APPROVE+merge or REQUEST_CHANGES to GitHub in one round-trip.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`.claude/README.md`**: Added `/review-pr` to the skill registry, file tree, leaf-skill table, and agent dependency map. Tightened `/review` description to clarify it is the pre-commit local reviewer.
- **`CONTRIBUTING.md`**: Fixed `test/dist-cases.js` → split file names; replaced hand-edit TypeScript instruction with generated-from-JSDoc workflow; added Code conventions section.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsT7FHAJaLiTMKyD7Hxfvr)_