### PR TITLE
Add stale workflow: auto-close idle PRs after 44 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: 'stale'
+          stale-pr-message: >
+            This PR has had no activity for 30 days and is marked stale.
+            It will be closed in 14 days if no further activity occurs.
+            Push a commit, leave a comment, or remove the `stale` label to keep it open.
+          close-pr-message: >
+            Closed due to 44 days of inactivity. Feel free to reopen if you resume work.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/stale.yml` using `actions/stale@v9`
- PRs with no activity for **30 days** are labelled `stale` with a warning comment
- Stale PRs with no activity for a further **14 days** are automatically closed
- Issue staling is disabled (`-1`) — this only affects PRs

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical (CI/workflow configuration only)._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WakvTZQPsrEd7WNUyN8ZDR)_