### PR TITLE
Release v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-05-31
+
 ### Added
 
 - `Distribution.params()` public method returning the natural parameters of a distribution (#516). All nine `Categorical` subclasses (`Bernoulli`, `Binomial`, `Hypergeometric`, `Soliton`, `Zipf`, `ZipfMandelbrot`, `BetaBinomial`, `NegativeHypergeometric`, `Rademacher`) now expose their own named parameters (e.g. `new Bernoulli(0.7).params()` → `{ p: 0.7 }`) instead of inheriting the internal lookup state from `Categorical`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ranjs",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ranjs",
-      "version": "1.25.0",
+      "version": "1.26.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranjs",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Library for generating various random variables.",
   "keywords": [
     "random",


### PR DESCRIPTION
## Release v1.26.0

### Changes since v1.25.0

56b7a128 Reduce chart height by 20% (380 → 304px)
21430b34 Fix chart sample visibility, add legends, clip data, cap x-range
0263360d Fix CDF samples visibility; add fit overlay on both charts
b457c643 Replace dalian with d3 for demo page charts
ffff8b00 Fix demo page ranjs.min.js not found on GitHub Pages
3d1e3cd5 Add stale workflow: close idle PRs after 30+14 days
a35297bd Throw descriptions moved to @throws tags in JSDoc
1251a364 JSDoc updated to reflect ADR-0015 return values in statistics modules
d25342d8 Update CONTRIBUTING.md: fix stale references, add code conventions
0eb3204a ADR-0015 compliance applied to la, location, dispersion, shape, dependence, and ts modules
22b306f4 Solution compounded for #593 — adr0015-la-stats-undefined-sentinel-audit
94a45e38 review-pr: check out PR branch and run npm test before code-quality agents
cf8b0ef2 Disambiguate /review-pr from /review and review-* agents
46481531 Add /review-pr skill: review GitHub PR and approve+merge or request changes
fe81ff79 docs(CLAUDE.md): add changelog placement rule for grouped entries
9455e318 compress changelog: group _fitInit, refVals, and cancellation-fix bullets
2e479254 Davis._cdf below-support NaN fixed; _qEstimateTable undefined eliminated (#601)
def538c2 Undefined replaced with NaN in algorithm failure paths (#589)
b7115a0c Implicit undefined replaced with NaN in quantile estimators and pre-computed sampler
3a70f228 lambertW0 and lambertW1m NaN guard added for out-of-domain inputs
77e594fa Deprecation warning added to Distribution.q(p) for out-of-range p
76c82d16 docs: correct q(p) deviation comment to reference deprecation cycle
3f2f1a61 docs: adopt numpy/scipy-style versioning for breaking changes
d9c64190 docs: document return-value conventions in README
f46fc25c docs: codify 0/NaN/Infinity/throw return-value conventions
9be6774a Davis._cdf Romberg replaced with dual Bose-Einstein series (#451)
1ab04f76 Solution compounded for #451 — davis-bose-einstein-cdf-series
c45edc33 docs: add seed() to Distribution API in README
3fd5b081 docs: add lnPdf, save, load to Distribution API in README
3cd45e86 docs: fix Distribution API table in README
65725ca5 test: remove vacuous Exponential.fit instanceof-only assertion
f0e22ba7 Speed up Bates.fit 5x via warm-start + tighter inner loop
ce86779b Bates.fit test: N=1000 seed=1, n=1..3 only (n>=4 Gaussian-like)
da0895fd Add JSDoc to Bates.fit() override to satisfy jsdoclint
1cf25c8e Bates.fit() integer n recovery via profile likelihood grid search (#481)
dd61d65e npm test coverage-threshold caveat documented in CLAUDE.md
fe8241f7 Test for DoublyNoncentralChi2.fit kTot<2 constraint path added
02588fd9 Retrigger CI after flaky statistical test on Node 22
3f1f8c91 Retrigger CI after flaky statistical test on Node 22
fe08b190 DoublyNoncentralChi2 fit non-identifiability documented and fixed
bc1bf4d6 Changelog entry added for Bradford._fitInit coefficient fix (#498)
7aaeb662 Retrigger CI after flaky statistical test on Node 20
2920e61b Anonymous class declaration in BetaGeometric fixed
c77ad9ff SkewNormal positional speed-up array replaced with named this.c keys
7f7bd928 Real output numbers used in parameter estimation docs page and README
6e216b55 Retrigger CI after flaky statistical test on Node 20
de0cc7b0 Real output numbers used in parameter estimation README example
801188e9 Hypergeometric wrong support when lower bound > 0 fixed
bf050e01 .param-name class removed from Name column header in parameters table
e0c71b5f Duplicate section headings in CHANGELOG consolidated
6d01cbc6 Fix TS2416 typecheck errors and enable Zipf fit display in demo
a2b06a77 Add Distribution.params() and expose natural parameters for Categorical subclasses
ecbcc22a Changelog entry added for NoncentralChi p.lambda fix (#491)
1c089a9d Wrong parameter count in multi-level distribution subclasses fixed
c8ffdda3 NoncentralChi p.lambda corrected to store user-facing lambda not lambda²
101f8a5d /pull-request skill renamed to /pr
80cbba5f Hyperexponential weight and rate validation fixed
e11e676d Ensure dist/ exists before generating docs
f0ac5c6b Fix four demo page issues: discrete CDF shift, sample size range, controls top, local ranjs import
eacb6ceb Add interactive distribution demo page (#504)
c0b59987 Solution compounded for #504 — this-p-subclass-pkey-fit-display
3eaed718 parameter-estimation.html added to .gitignore
3c537136 Distribution.fit() showcased in README, docs, and CHANGELOG
4cbc7f16 Solution compounded for #503 — test-return-shape-statistic-plural
ea063ef2 Mielke parameter count corrected to 2 for accurate AIC/BIC
666512cd Dagum.p widened to index signature to fix Mielke typecheck
254ede42 Mielke.p fixed to expose k and s instead of Dagum aliases
4ab1837d BaldingNichols F and p exposed on this.p
0233a0c5 Bates scale/shift constants corrected to use rounded ni
6d9d7f1a Restore Distribution._fitInit base-class coverage
03b36ac5 Fix Standard.js trailing-space violations in test comments
f4fc3448 Add _fitInit to ZipfMandelbrot with Hill+PMF-ratio estimators
d53dd8bd Add _fitInit overrides for specialty no-closed-form distributions (#488)
d8da451d skill(pull-request): merge main before opening PR to avoid conflicts
35958df5 _fitInit MOM overrides added for bounded-support and directional distributions
056f4316 _fitInit MOM overrides added for 7 positive-support continuous distributions
331e2d08 Pull-request skill extended to watch CI and review activity
8f1da693 Branch-coverage tests added for _fitInit fallback paths
636f1d7d Solution compounded for #439 — noncentral-fitinit-mom-stability
f25dbaec Review fixes: isFinite guard for d1formula, NoncentralChi test comment
1254c2ca _fitInit MOM overrides added for 9 noncentral distributions
ae13f274 Base-class _fitInit fallback test switched from Burr to Alpha
09366424 _fitInit overrides added for 9 distributions, fixing broken Beta inheritance
6c73e2be Solution compounded for #441 — reparametrizing-subclass-inherits-wrong-fitinit
f180d4e4 Slifker-Shapiro _fitInit overrides added for JohnsonSU and JohnsonSB, closes #440
3fda39f9 _fitInit overrides added for 7 Pareto-family distributions
3ccb92c3 Add branch-coverage tests for Weibull-family _fitInit edge cases
2d413b47 _fitInit MOM overrides added for 7 Weibull/extreme-value distributions
1d24df78 _fitInit overrides added for 10 bounded-support distributions
1dfdfb81 _fitInit MOM overrides added for 6 Beta-family distributions
1142118b _fitInit MOM overrides added for 9 Gamma-family distributions
17d36496 Branch coverage threshold lowered to 90% to give headroom for new distributions
12c1929c Constructor JSDoc moved below _fitInit to fix jsdoclint misattribution
42f6c9e9 _fitInit MOM overrides added for 10 location-scale continuous distributions
99aee225 _fitInit MOM overrides added for 22 compound discrete distributions
7d8099b2 Solution compounded for #438 — log-series-fitinit-asymptotic-inversion
e2fb89ea _fitInit and fit overrides added for Categorical and Hyperexponential, closes #428
41252706 Slash positional-array constant replaced with named this.c property
5340e46c Base-class _fitInit fallback test added to restore coverage
2a22afba _fitInit closed-form MLE added for Exponential, Rayleigh, MaxwellBoltzmann, HalfNormal, Levy, Chi
9f0f35ea Branch coverage tests added for _fitInit edge cases
08ac44d4 fit() on zero-parameter distributions returns fresh instance, closes #427
adbb94e6 _fitInit MOM overrides added for log-transform distributions
5fbd5c1b WHY comments added to _fitInit MLE formulas
79f29547 fit test sample size reduced to 200 to keep suite fast at scale
29f7145f fit test tolerances tightened to match actual MLE convergence errors
1a2e64fb fit tests updated to use seeded 1000-sample data
cfb72c65 _fitInit closed-form MLE added for Bernoulli, Poisson, Geometric, DiscreteUniform
b7b68bf6 besselISpherical small-x Taylor series added, closes #425
7d736999 ConwayMaxwellPoisson Z overflow fixed with log-space recurrence, closes #420
e6bd3a8f gaussLegendre algorithm added, closes #402
ab2468fa Solution compounded for #402 — gl-n20-node-transcription-error
08905daf IrwinHall and Bates this.c converted to named-object form, closes #456
5d56eb5a Symmetry tests for symmetric discrete distributions added
e527b3f0 Symmetry tests added to remaining 14 symmetric continuous distributions, closes #411
e6039ca2 Remove blue highlight from parameter name column in docs tables
572ef869 Build artifact integrity check added to CI build job, closes #401
fe5e884f nyc coverage thresholds added to npm test
7f4a70cc Silent undefined return from capped rejection loops fixed
ef5f1f5f JSDoc phrasing split into "Probability density function" (continuous) and "Probability mass function" (discrete)
80bf7e9d "Generator for the" renamed to "Probability function for the" in all JSDoc
8f139d94 Prevention updated in compound: package.json export step added
58bc46db Davis subpath export added to package.json
fbcf90fc Solution compounded for #447 — davis-romberg-boundary-guard-and-constant-cache
0d6586d5 review fixes: cache PDF constants, class JSDoc, expm1, boundary refVal, README count
0d4f8a9c fix(davis): reduce sampleSize and skip testSeeds to avoid test timeouts
f6ec51e6 Increase Mocha timeout to 120s for Romberg-CDF distributions
1d75b459 Fix Davis distribution: real _generator, n > 1 constraint, _pdf NaN guard, tests
feb7889b Class-level JSDoc block added to Davis distribution, closes #415
8ced4a2a digamma special function activated and exported, closes #399
5fa9d219 ZipfMandelbrot subpath export added to package.json
144a14f9 ZipfMandelbrot distribution added, closes #398
153ea05c Solution compounded for #398 — categorical-subclass-k-override
7dfe06b6 neumaier() NaN-on-infinity bug fixed, closes #442
d13ac5a3 Pareto._fitInit added, lnPdf support-check fixed, closes #423
0ac38f54 Distribution.fit(data) static method added via Nelder-Mead MLE, closes #404
a3f79796 PreComputed._cdf cache-hit path clamped to 1, redundant ConwayMaxwellPoisson override removed, closes #419
997db94a ConwayMaxwellPoisson subpath export added to package.json
4376b25f ConwayMaxwellPoisson distribution added, closes #397
7b72f96b Solution compounded for #397 — precomputed-cdf-asymmetric-clamping
824c9d1b Bulk refVals added for GeneralizedExponential(2,2,2) at mid-range and tail x values
62f9c601 Class name and JSDoc added to BetaNegativeBinomial
9b27ac01 Constructor JSDoc enforced in jsdoclint for all distributions, closes #395
a024b252 Replace logo image with plain text tagline in README
0e4770e6 Move description below logo in README
9d65c9fa Add grey logo variant and use it in README
90f92250 Remove center alignment from logo/description header
8e8d1b7c Shrink logo and place description inline to its right
03b48382 Add Chinese character meaning below logo in README
69f28b39 Add library logo to README
6e3d56e9 Symmetry tests added for 8 symmetric distributions, closes #394
81fb8098 Fix release workflow: use --generate-notes instead of --notes-from-tag
021d7bb8 Create GitHub release after npm publish
f7e77cf1 Include README.md in npm package files

---
*Automated release PR — do not add commits to this branch.*