### PR TITLE
Add difficulty rating and inline-fix routing to ops-triage pipeline

### DIFF
--- a/.claude/agents/ops-triage.md
+++ b/.claude/agents/ops-triage.md
@@ -65,7 +65,12 @@ For each observation:
    - `title` — imperative, ≤70 chars, starts with a verb (e.g. "Fix off-by-one in DiscreteUniform CDF").
    - `body` — uses the standard `ops-issue` template (Goal / Scope / Acceptance Criteria / Out of Scope). The "Goal" should describe the bug as seen by a user. The "Scope" should name the file(s) suspected of containing the bug.
    - `priority` — one of `high`/`medium`/`low`. Default to `medium` unless the bug returns NaN, wrong support, or silently accepts invalid input (then `high`).
-   - `difficulty` — one of `difficult`/`moderate`/`trivial`. Default to `moderate`.
+   - `difficulty` — one of `difficult`/`moderate`/`trivial`. Use these precise criteria:
+     - `trivial` — 1–5 lines, fix is fully obvious from the evidence (wrong constant, missing constraint, off-by-one), no design decision needed, can be described as a concrete edit.
+     - `moderate` — up to ~20 lines, may require reading adjacent code or verifying a formula but no architectural choice.
+     - `difficult` — deeper investigation needed, algorithm change, or multi-file coordination required.
+   - `fix_inline` — `true` if `difficulty == "trivial"` **and** you can describe the fix precisely enough for the orchestrator to apply it without additional context-gathering; `false` otherwise.
+   - `fix_suggestion` — only present when `fix_inline: true`. A concrete one-line description of the edit: file path, line reference, and what to change (e.g., `"src/dist/foo.js:42 — change \`x < 0\` to \`x <= 0\`"`). Omit for `fix_inline: false`.
    - `extra_labels` — should always include `bug`.
 
 ## Output Format
@@ -82,6 +87,8 @@ Return JSON wrapped in a markdown code block. No prose outside the block.
       "body": "<full markdown body using ops-issue template>",
       "priority": "high|medium|low",
       "difficulty": "difficult|moderate|trivial",
+      "fix_inline": true,
+      "fix_suggestion": "<file:line — what to change; only present when fix_inline is true>",
       "extra_labels": ["bug"]
     }
   ],

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -135,13 +135,14 @@ The agent returns three buckets: `definite`, `ambiguous`, `not_a_bug`.
 
 **Step 4.5c — Act on the result.**
 
-- **`definite` (auto-file in batch)**: For each entry, invoke `ops-issue` with the drafted `title`/`body`/`priority`/`difficulty`/`extra_labels`. Collect the returned issue URLs.
+- **`definite` with `fix_inline: true`** (trivial): apply the fix on the fly using `fix_suggestion`, run `npm run standard && npm test`. Do **not** file an issue. Count as "fixed inline".
+- **`definite` with `fix_inline: false`** (non-trivial): invoke `ops-issue` once per entry with the drafted `title`/`body`/`priority`/`difficulty`/`extra_labels`. Collect the returned issue URLs.
 - **`ambiguous` (escalate in batch)**: Use a single `AskUserQuestion` with one question per entry, options "File issue" / "Skip", plus an "Other" fallback. For each "File issue" answer, invoke `ops-issue` using the `draft_title`. Skip the rest silently.
 - **`not_a_bug`**: silent.
 
 **Step 4.5d — Report.**
 
-> "Triage: <N> filed (<URLs>), <M> skipped, <K> not a bug."
+> "Triage: <N> fixed inline, <M> filed (<URLs>), <K> skipped, <L> not a bug."
 
 If all three buckets are empty: "Triage: clean."
 
@@ -194,7 +195,7 @@ c. **Pull Request** — invoke `/pr`
 > Implementation: <N> phases executed
 > Tests: All passing (lint + tests)
 > Validate: PASSED (<N> attempts) or SKIPPED
-> Triage: <N> filed / <M> skipped / clean
+> Triage: <N> fixed inline / <M> filed / <K> skipped / clean
 > Review: PASSED (<N> issues auto-fixed)
 > Compound: `<solution path>` (or SKIPPED)
 > Commit: `<hash>` <message>

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -58,11 +58,12 @@ Compile observations noticed during steps 3–4 (pre-existing NaN at a boundary,
 Spawn the `ops-triage` agent with `branch`, `session_kind: "fix"`, `target_issue`, the `observations` list, and a `diff_path` (write `git diff main...HEAD` to `.claude/tmp/triage-diff-<branch>.patch` if not already done).
 
 Act on the result:
-- **`definite`**: invoke `ops-issue` once per entry with the drafted fields. Collect URLs.
+- **`definite` with `fix_inline: true`** (trivial): apply the fix on the fly using `fix_suggestion`, run `npm run standard && npm test`. Do **not** file an issue. Count as "fixed inline".
+- **`definite` with `fix_inline: false`** (non-trivial): invoke `ops-issue` once per entry with the drafted fields. Collect URLs.
 - **`ambiguous`**: one batched `AskUserQuestion` (File issue / Skip / Other). For each "File issue", invoke `ops-issue`.
 - **`not_a_bug`**: silent.
 
-Report: `> "Triage: <N> filed (<URLs>), <M> skipped, <K> not a bug."` or `> "Triage: clean."`
+Report: `> "Triage: <N> fixed inline, <M> filed (<URLs>), <K> skipped, <L> not a bug."` or `> "Triage: clean."`
 
 ### 6. Review (conditional)
 

--- a/.claude/skills/hotfix/SKILL.md
+++ b/.claude/skills/hotfix/SKILL.md
@@ -66,11 +66,12 @@ Compile observations noticed during step 4 (a flaky test, a pre-existing NaN at 
 Spawn the `ops-triage` agent with `branch`, `session_kind: "hotfix"`, `target_issue`, the `observations` list, and a `diff_path` (write `git diff main...HEAD` to `.claude/tmp/triage-diff-<branch>.patch` first).
 
 Act on the result:
-- **`definite`**: invoke `ops-issue` once per entry with the drafted fields. Collect URLs.
+- **`definite` with `fix_inline: true`** (trivial): apply the fix on the fly using `fix_suggestion`, run `npm run standard && npm test`. Do **not** file an issue. Count as "fixed inline".
+- **`definite` with `fix_inline: false`** (non-trivial): invoke `ops-issue` once per entry with the drafted fields. Collect URLs.
 - **`ambiguous`**: one batched `AskUserQuestion` (File issue / Skip / Other). For each "File issue", invoke `ops-issue`.
 - **`not_a_bug`**: silent.
 
-Report: `> "Triage: <N> filed (<URLs>), <M> skipped, <K> not a bug."` or `> "Triage: clean."`
+Report: `> "Triage: <N> fixed inline, <M> filed (<URLs>), <K> skipped, <L> not a bug."` or `> "Triage: clean."`
 
 ### 6. Review + Auto-fix
 


### PR DESCRIPTION
## Summary
- `ops-triage` now rates each definite bug as `trivial` / `moderate` / `difficult` using precise size/complexity criteria and emits two new fields: `fix_inline` (bool) and `fix_suggestion` (concrete edit description for trivial bugs).
- The three pipeline orchestrators (`/hotfix`, `/fix`, `/build`) route on `fix_inline`: trivial bugs are applied immediately in the current session and tests are re-run; only non-trivial bugs are escalated to `ops-issue`.
- This keeps the tracker clean — boilerplate one-liners never become issues — while ensuring non-trivial bugs are still formally tracked.

## Non-trivial changes
- **`.claude/agents/ops-triage.md`**: Extended the `definite` output schema with `fix_inline` + `fix_suggestion` fields; replaced the vague `difficulty` default (`"moderate"`) with explicit size/complexity criteria for all three tiers.
- **`.claude/skills/build/SKILL.md`**: Triage step 4.5c now forks on `fix_inline` — inline-apply trivial bugs, file non-trivial ones; triage report line updated to include "fixed inline" count.
- **`.claude/skills/fix/SKILL.md`**: Same routing fork added to the triage step.
- **`.claude/skills/hotfix/SKILL.md`**: Same routing fork added to the triage step.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

_None._

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpYJJzd2hfmv5YJn1sfSAi)_