### PR TITLE
Fix recursiveSum stopping criterion to hybrid absolute/relative tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Root-finding in `src/algorithms/` now uses Chandrupatla (1997) instead of the previous incomplete Brent implementation. The new algorithm correctly handles roots near zero with a mixed absolute/relative stopping criterion (`|dx| < ε·max(|x|,1)`), throws on invalid brackets (same-sign endpoints) instead of silently returning `NaN`, and returns the best approximation after iteration budget exhaustion (#541).
 - Replaced adaptive trapezoidal doubling (`src/algorithms/trap.js`) with double-exponential (tanh-sinh) quadrature (`src/algorithms/tanh-sinh.js`). The new algorithm achieves machine-epsilon precision in ~7 refinement levels (≤500 evaluations) versus the trapezoidal method's worst-case 2^24 evaluations, and naturally handles endpoint singularities (#542).
+- `recursiveSum` stopping criterion changed from pure relative (`|Δ/sum| < ε`) to hybrid absolute/relative (`|Δ| < ε·max(|sum|, 1)`). The old criterion required terms to shrink to `ε·|sum|` before stopping, which stalls convergence when the series sum is near zero — as occurs in noncentral β, t, χ², Von Mises, and hypergeometric series at cancellation points (#543).
 
 ### Removed
 

--- a/src/algorithms/recursive-sum.js
+++ b/src/algorithms/recursive-sum.js
@@ -39,7 +39,7 @@ export default function (x0, preUpdate, termFn, postUpdate) {
     sum += delta
 
     // Check if accuracy has been reached.
-    if (Math.abs(delta / sum) < EPS) {
+    if (Math.abs(delta) < EPS * Math.max(Math.abs(sum), 1)) {
       break
     } else {
       // Otherwise update state.

--- a/src/special/hypergeometric.js
+++ b/src/special/hypergeometric.js
@@ -32,7 +32,7 @@ function _f11AsymptoticSeries (a, b, z) {
       if (Math.abs(next) >= Math.abs(term)) break
       term = next
       sum += term
-      if (Math.abs(term / sum) < Number.EPSILON) break
+      if (Math.abs(term) < Number.EPSILON * Math.max(Math.abs(sum), 1)) break
     }
     return prefactor * sum
   }

--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -273,4 +273,43 @@ describe('algorithms', () => {
       assert(Math.abs(forward + reversed) < PRECISION)
     })
   })
+
+  describe('.recursiveSum()', () => {
+    it('should sum a geometric series correctly', () => {
+      // Σ_{k=0}^∞ (0.5)^k = 1/(1-0.5) = 2
+      const result = algorithms.recursiveSum(
+        { term: 1 },
+        t => ({ term: t.term * 0.5 }),
+        t => t.term
+      )
+      assert(Math.abs(result - 2) < PRECISION)
+    })
+
+    it('should converge when the running sum is near zero due to alternating signs', () => {
+      // Alternating geometric series: Σ_{k=0}^∞ (-0.5)^k = 1/(1+0.5) = 2/3.
+      // Running partial sums oscillate through small values near the true limit 2/3.
+      // A pure relative criterion |delta/sum| < EPS can fire prematurely when sum
+      // passes near zero; the hybrid criterion |delta| < EPS*max(|sum|,1) is stable.
+      const result = algorithms.recursiveSum(
+        { term: 1 },
+        t => ({ term: -t.term * 0.5 }),
+        t => t.term
+      )
+      assert(Math.abs(result - 2 / 3) < PRECISION)
+    })
+
+    it('should converge for a series whose sum is far below 1', () => {
+      // Geometric series with a small initial term: Σ_{k=0}^∞ s*(0.5)^k = 2s.
+      // With |sum| < 1 the hybrid criterion uses EPS*1 as the absolute floor,
+      // so the loop exits once individual terms fall below machine epsilon,
+      // rather than requiring them to fall below EPS*sum (a far tighter demand).
+      const s = 1e-6
+      const result = algorithms.recursiveSum(
+        { term: s },
+        t => ({ term: t.term * 0.5 }),
+        t => t.term
+      )
+      assert(Math.abs(result - 2 * s) / (2 * s) < 1e-6)
+    })
+  })
 })


### PR DESCRIPTION
Closes #543

## Summary
- Replaced the pure-relative stopping criterion `|Δ/sum| < ε` in `recursiveSum` with the hybrid `|Δ| < ε·max(|sum|, 1)`. The old form required terms to shrink to `ε·|sum|` — an arbitrarily tight demand that stalls convergence whenever the series sum is near zero, as happens in noncentral β, t, χ², Von Mises, and hypergeometric series at cancellation points.
- Applied the same fix to the inner convergence check in `_f11AsymptoticSeries` (`src/special/hypergeometric.js:35`), which shared the same pure-relative pattern.

## Non-trivial changes
- **`src/algorithms/recursive-sum.js:42`**: `Math.abs(delta / sum) < EPS` → `Math.abs(delta) < EPS * Math.max(Math.abs(sum), 1)`. When `|sum| ≥ 1` both forms are equivalent; when `|sum| < 1` the old form's threshold `ε·|sum|` approaches zero, preventing termination even when terms are at machine-epsilon scale. The hybrid criterion uses `1` as a floor, so it always stops when `|Δ|` reaches machine precision.
- **`src/special/hypergeometric.js:35`**: Same criterion applied to the minimum-term inner loop of the asymptotic hypergeometric branch.

<details>
<summary>Trivial changes</summary>

- **`test/algorithms.js`**: New `describe('.recursiveSum()')` block with three correctness tests (geometric series, alternating series, small-value geometric series).
- **`CHANGELOG.md`**: One `### Changed` bullet added under `## [Unreleased]`.

</details>

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_019EMApWGjMSRQ7vx8nr5Uau)_