### PR TITLE
Add pole and domain guards to gamma, logGamma and digamma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `gamma`, `logGamma`, and `digamma` now return `Infinity` at their non-positive integer poles (previously a huge finite number, because the floating-point `sin(πz)` / `tan(πz)` evaluated to ~1e-16 instead of exactly 0) and stay full-precision within 1e-6 of a pole by reducing the trigonometric argument modulo its period before evaluation, so the tiny fractional offset the pole term depends on is no longer rounded away. `logGamma(z)` for `z ≤ 0` is now defined as `ln|Γ(z)|` via the log-reflection formula instead of returning a meaningless value (#555).
 - `riemannZeta` now uses a two-term Laurent expansion (`1/(s−1) + γ − γ₁·(s−1)`) when `|s−1| < 0.01`, eliminating 4-digit precision loss caused by catastrophic cancellation in the denominator `1−2^(1−s)` near the pole (#551).
 
 ### Changed

--- a/src/special/digamma.js
+++ b/src/special/digamma.js
@@ -32,13 +32,20 @@ function _psiSeries (z) {
  * @method digamma
  * @memberof ran.special
  * @param {number} z Value to evaluate digamma at.
- * @returns {number} The digamma function at the specified value.
+ * @returns {number} The digamma function value; Infinity at the non-positive integer poles.
  * @private
  */
 function digamma (z) {
-  // Reflection for z < 0
+  // Simple poles at the non-positive integers (ADR-0015 — divergence returns ±Infinity).
+  if (z <= 0 && Number.isInteger(z)) {
+    return Infinity
+  }
+
+  // Reflection for z < 0. tan is π-periodic, so tan(πz) == tan(π·(z − round(z))); reducing the
+  // argument first keeps full precision in cot(πz) near a negative-integer pole, where forming
+  // π·z directly would round away the fractional offset that the pole term 1/(z−n) depends on.
   if (z < 0) {
-    return digamma(1 - z) - Math.PI / Math.tan(Math.PI * z)
+    return digamma(1 - z) - Math.PI / Math.tan(Math.PI * (z - Math.round(z)))
   }
 
   // Shift z

--- a/src/special/gamma.js
+++ b/src/special/gamma.js
@@ -17,13 +17,24 @@ const SQRT_PI2 = Math.sqrt(2 * Math.PI)
    * @method gamma
    * @memberof ran.special
    * @param {number} z Value to evaluate Gamma function at.
-   * @returns {number} Gamma function value.
+   * @returns {number} Gamma function value; Infinity at the non-positive integer poles.
    * @private
    */
 function _gamma (z) {
+  // Simple poles at the non-positive integers: Γ diverges (ADR-0015 — divergence returns ±Infinity).
+  // Without this guard the reflection branch evaluates sin(πz) at a floating-point value that is
+  // ~1e-16 rather than exactly 0, yielding a huge finite number instead of Infinity.
+  if (z <= 0 && Number.isInteger(z)) {
+    return Infinity
+  }
+
   let y
   if (z < 0.5) {
-    y = Math.PI / (Math.sin(Math.PI * z) * _gamma(1 - z))
+    // Reduce sin(πz) modulo π and carry the (-1)^n sign separately: forming π·z directly rounds
+    // away the tiny fractional offset near a negative-integer pole, destroying precision there.
+    const n = Math.round(z)
+    const sign = n % 2 === 0 ? 1 : -1
+    y = Math.PI / (sign * Math.sin(Math.PI * (z - n)) * _gamma(1 - z))
   } else {
     z--
     let x = 0.99999999999980993

--- a/src/special/log-gamma.js
+++ b/src/special/log-gamma.js
@@ -11,15 +11,27 @@ const COEFFS = [
 ]
 
 /**
-   * Computes the logarithm of the gamma function for positive arguments.
+   * Computes the logarithm of the absolute value of the gamma function, ln|Γ(z)|.
    *
    * @method logGamma
    * @memberof ran.special
    * @param {number} z Value to evaluate log(gamma) at.
-   * @returns {number} The log(gamma) value.
+   * @returns {number} The ln|Γ(z)| value; Infinity at the non-positive integer poles.
    * @private
    */
-export default function (z) {
+export default function logGamma (z) {
+  if (z <= 0) {
+    // Poles at the non-positive integers (ADR-0015 — divergence returns Infinity).
+    if (Number.isInteger(z)) {
+      return Infinity
+    }
+    // Log-reflection from Γ(z)Γ(1−z) = π/sin(πz): ln|Γ(z)| = ln π − ln|sin πz| − ln Γ(1−z).
+    // |sin(πz)| is computed on the argument reduced modulo π (the sign dropped by abs is
+    // irrelevant) so precision survives near a negative-integer pole, where forming π·z
+    // directly would round away the tiny fractional offset.
+    return Math.log(Math.PI) - Math.log(Math.abs(Math.sin(Math.PI * (z - Math.round(z))))) - logGamma(1 - z)
+  }
+
   const x = z
 
   let y = z

--- a/test/special.js
+++ b/test/special.js
@@ -24,6 +24,23 @@ describe('special', () => {
       assert(equal(special.digamma(-0.5), 2 - EM - 2 * Math.log(2)))
       // ψ(-1.5) = ψ(2.5) = ψ(1.5) + 2/3
       assert(equal(special.digamma(-1.5), 2 - EM - 2 * Math.log(2) + 2 / 3))
+      // mpmath mp.dps=50: mp.digamma(-2.5)
+      assert(equal(special.digamma(-2.5), 1.103156640645243, 14))
+    })
+
+    it('should return Infinity at the non-positive integer poles', () => {
+      // ADR-0015: divergence returns Infinity specifically (not NaN, not a huge finite).
+      assert.strictEqual(special.digamma(0), Infinity)
+      assert.strictEqual(special.digamma(-1), Infinity)
+      assert.strictEqual(special.digamma(-2), Infinity)
+    })
+
+    it('should stay full-precision within 1e-6 of a negative integer pole', () => {
+      // mpmath mp.dps=60 evaluated at the exact double of (-1+1e-7) / (-2+1e-7): the input
+      // itself only pins the offset to ~1e-9, but the dominant pole term -1/(z+n) is otherwise
+      // carried at machine precision (no argument-reduction loss in cot(πz)).
+      assert(equal(special.digamma(-1 + 1e-7), -9999999.582479, 13))
+      assert(equal(special.digamma(-2 + 1e-7), -9999999.071376376, 13))
     })
 
     it('should satisfy the recurrence ψ(z+1) = ψ(z) + 1/z', () => {
@@ -354,6 +371,54 @@ describe('special', () => {
         const lng = special.logGamma(x)
         assert(Math.abs(Math.log(g) - lng) / lng < 0.01)
       }
+    })
+
+    describe('.gamma()', () => {
+      it('should return reference values (mpmath mp.dps=50)', () => {
+        // Positive baseline plus the reflection branch at negative half-integers.
+        assert(equal(special.gamma(0.5), 1.772453850905516, 14))
+        assert(equal(special.gamma(-0.5), -3.544907701811032, 14))
+        assert(equal(special.gamma(-1.5), 2.363271801207355, 14))
+        assert(equal(special.gamma(-2.5), -0.9453087204829419, 14))
+      })
+
+      it('should return Infinity at the non-positive integer poles', () => {
+        // ADR-0015: divergence returns Infinity specifically (not NaN, not a huge finite).
+        assert.strictEqual(special.gamma(0), Infinity)
+        assert.strictEqual(special.gamma(-1), Infinity)
+        assert.strictEqual(special.gamma(-2), Infinity)
+      })
+
+      it('should stay full-precision within 1e-6 of a negative integer pole', () => {
+        // mpmath mp.dps=60 evaluated at the exact double of (-1+1e-7) / (-2+1e-7); the
+        // (-1)^n-signed reduced sin(πz) must not lose the fractional offset.
+        assert(equal(special.gamma(-1 + 1e-7), -10000000.428048076, 13))
+        assert(equal(special.gamma(-2 + 1e-7), 5000000.458472761, 13))
+      })
+    })
+
+    describe('.logGamma()', () => {
+      it('should return reference values ln|Γ(z)| (mpmath mp.dps=50)', () => {
+        // Positive baseline plus the log-reflection branch at negative half-integers. The
+        // positive Lanczos path is itself accurate to ~1e-13, so the tolerance is 1e-13.
+        assert(equal(special.logGamma(0.5), 0.5723649429247001, 13))
+        assert(equal(special.logGamma(-0.5), 1.2655121234846454, 13))
+        assert(equal(special.logGamma(-1.5), 0.860047015376481, 13))
+        assert(equal(special.logGamma(-2.5), -0.056243716497674054, 13))
+      })
+
+      it('should return Infinity at the non-positive integer poles', () => {
+        // ADR-0015: divergence returns Infinity specifically (not NaN, not a huge finite).
+        assert.strictEqual(special.logGamma(0), Infinity)
+        assert.strictEqual(special.logGamma(-1), Infinity)
+        assert.strictEqual(special.logGamma(-2), Infinity)
+      })
+
+      it('should stay full-precision within 1e-6 of a negative integer pole', () => {
+        // mpmath mp.dps=60 at the exact double of (-1+1e-7) / (-2+1e-7); |sin(πz)| reduced mod π keeps the offset.
+        assert(equal(special.logGamma(-1 + 1e-7), 16.118095693763127, 13))
+        assert(equal(special.logGamma(-2 + 1e-7), 15.424948562092922, 13))
+      })
     })
   })
 


### PR DESCRIPTION
Closes #555

## Summary
- `gamma`, `logGamma`, and `digamma` now return `Infinity` at their non-positive integer poles. Previously the floating-point `sin(πz)` / `tan(πz)` evaluated to ~1e-16 instead of exactly 0 in the reflection branch, so the functions returned a huge *finite* number at e.g. `z = -1, -2` instead of diverging.
- All three stay full-precision within 1e-6 of a pole: the trig argument is reduced modulo its period (`z − round(z)`) before evaluation, so the tiny fractional offset that the pole term depends on is no longer rounded away when `π·z` is formed directly.
- `logGamma(z)` for `z ≤ 0` is now defined as `ln|Γ(z)|` via the log-reflection formula `ln π − ln|sin πz| − ln Γ(1−z)` instead of returning a meaningless value.

## Design decisions
- [ADR-0015: Return-value and error conventions](decisions/0015-return-value-and-error-conventions.md) — divergence returns `±Infinity` (not `NaN`, not a huge finite). The pole guards and the new `@returns` docs follow it; the code cites it inline.

## Non-trivial changes
- **`src/special/gamma.js`**: pole guard returning `Infinity` at non-positive integers; reflection branch reduces `sin(πz)` to `sign · sin(π·(z−n))` with `n = round(z)` and `sign = (−1)ⁿ` (sin is 2π-periodic with a sign flip under integer shift), restoring precision near poles.
- **`src/special/digamma.js`**: same pole guard; reflection branch reduces `tan(πz)` to `tan(π·(z−round(z)))` (tan is π-periodic, no sign correction needed).
- **`src/special/log-gamma.js`**: new `z ≤ 0` branch (`Infinity` at integer poles, log-reflection otherwise) — a behavioral domain extension; `|sin(πz)|` uses the reduced argument. The previously-anonymous default export is now a named function so the branch can recurse. All existing call sites pass positive arguments, so this is purely additive for them.

## Reference values
Near-pole and half-integer expected values were taken from mpmath at `mp.dps = 50–60`, evaluated at the *exact double* JS sees (e.g. the double nearest `-1+1e-7`), since the input itself only pins the offset to ~1e-9.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: `### Fixed` entry under `[Unreleased]`.
- **`test/special.js`**: pole (`strictEqual(..., Infinity)`), half-integer, and near-pole precision cases for all three functions.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2btWcEdi51DWbMyXQULYm)_