### PR TITLE
Remove deprecated q(p) undefined return; throw for p outside [0,1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `Distribution.q(p)` no longer returns `undefined` for `p` outside `[0, 1]`; it now throws `Error('Invalid probability. p must be in [0, 1].')`. The deprecation warning introduced in #592 (v1.26.0) is also removed (#594).
 - `scripts/bench.js` and the 11 `jstat` / `@stdlib` devDependencies that backed it. The one-time comparative benchmark (issue #114) has served its purpose; keeping the packages inflated `npm install` and triggered false-positive alerts on snyk scans of the repo. ADR-0011 documents the original decision and rationale.
 
 ## [1.26.0] - 2026-05-31

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,6 @@ Every public function and method signals "no ordinary result" through exactly on
 
 **Applies everywhere, not just distributions.** `ran.core`, `ran.special`, `ran.algorithms`, and `ran.la` follow the same split: `throw` for contract violations (wrong arity, dimension mismatch, impossible input); `NaN`/`±Infinity` for out-of-domain or divergent math. **Never wrap hot numeric loops in `throw`/`try` for ordinary out-of-domain inputs** — let the math produce `NaN`/`Infinity`.
 
-**Known deviation:** `Distribution.q(p)` returns `undefined` for `p ∉ [0, 1]`. This predates the convention and is a caller error that *should* throw; correcting it is a breaking change that ships through the standard deprecation cycle in an ordinary minor release (see "Versioning and Changelog"). Do not copy this pattern into new code.
-
 ## Testing Conventions
 
 - Tests live in `test/` and mirror `src/` module structure.

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -15,9 +15,6 @@ import { MAX_ITER } from '../core/constants'
  * @class Distribution
  * @memberof ran.dist
  */
-// Warn once when q(p) is called with p outside [0,1]; removal tracked in #594
-let _qOutOfRangeWarned = false
-
 class Distribution {
   constructor (type, k) {
     // decisions/0009-rename-single-letter-instance-fields.md — descriptive names replace single-letter abbreviations
@@ -547,16 +544,12 @@ class Distribution {
    * @method q
    * @memberof ran.dist.Distribution
    * @param {number} p The probability at which the quantile should be evaluated.
-   * @returns {number|undefined} The value of the quantile function at the specified probability if $p \in [0, 1]$ and the quantile could be found,
-   * undefined otherwise.
+   * @returns {number} The value of the quantile function at the specified probability.
+   * @throws {Error} If p is outside [0, 1].
    */
   q (p) {
     if (p < 0 || p > 1) {
-      if (!_qOutOfRangeWarned) {
-        _qOutOfRangeWarned = true
-        console.warn('[ranjs] Distribution.q(p) with p outside [0,1] is deprecated and will throw in v1.27.0; currently returns undefined.')
-      }
-      return undefined
+      throw Error('Invalid probability. p must be in [0, 1].')
     } else if (p === 0) {
       // If zero, return lower support boundary
       return this.s[0].value

--- a/test/dist.js
+++ b/test/dist.js
@@ -302,9 +302,9 @@ describe('dist', () => {
     })
 
     describe('.q()', () => {
-      it('should return undefined if p < 0 or p > 1', () => {
-        assert(typeof invalid.q(-1) === 'undefined')
-        assert(typeof invalid.q(2) === 'undefined')
+      it('should throw for p < 0 or p > 1', () => {
+        assert.throws(() => invalid.q(-1), Error)
+        assert.throws(() => invalid.q(2), Error)
       })
     })
 


### PR DESCRIPTION
Closes #594

## Summary
- Completes the deprecation cycle started in #592 (v1.26.0): `Distribution.q(p)` now throws `Error('Invalid probability. p must be in [0, 1].')` for `p < 0` or `p > 1` instead of emitting a `console.warn` and returning `undefined`.
- Removes the `_qOutOfRangeWarned` module-level flag and the warn-once guard — no longer needed.
- Updates JSDoc `@returns` from `{number|undefined}` to `{number}` and adds `@throws`, so the generated `.d.ts` no longer types `q` as `number | undefined`.

## Design decisions
- [ADR-0015: Return value and error conventions](decisions/0015-return-value-and-error-conventions.md) — out-of-range `p` is a caller/programming error; `throw` is the correct channel per the convention table.

## Non-trivial changes
- **`src/dist/_distribution.js`**: Behavioral change — `q(p)` now throws instead of returning `undefined` for `p ∉ [0, 1]`. This completes the breaking removal step of the deprecation cycle. The `number | undefined` return type is eliminated from the generated `.d.ts`.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Test updated from asserting `undefined` return to asserting `throws`.
- **`CHANGELOG.md`**: `### Removed` bullet added referencing #592 deprecation.
- **`CLAUDE.md`**: "Known deviation" note removed — the deviation is now resolved.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoDDSLqZaA2BXTF5YiFnQ8)_