### PR TITLE
Add neumaier infinity guard regression test

### DIFF
--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -154,6 +154,10 @@ describe('algorithms', () => {
     it('should return NaN for indeterminate -Infinity + Infinity', () => {
       assert(Number.isNaN(algorithms.neumaier([-Infinity, Infinity])))
     })
+
+    it('should return Infinity for mixed finite/infinite inputs', () => {
+      assert.equal(algorithms.neumaier([1, Infinity, -1]), Infinity)
+    })
   })
 
   describe('.introselect()', () => {


### PR DESCRIPTION
Closes #565

## Summary
- Adds a regression test for `neumaier([1, Infinity, -1])` returning `Infinity` (not `NaN`)
- The guard condition at `src/algorithms/neumaier.js:22` (`isFinite(s) && isFinite(t)`) was already correct — compensation is skipped whenever either operand is non-finite, preventing `∞ − ∞ = NaN` corruption
- No production code changed; this PR only adds the missing test case required by the issue

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/algorithms.js`**: Added one `it()` block verifying `neumaier([1, Infinity, -1]) === Infinity`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9j5obj2nLndv5t1S9oui)_