### PR TITLE
Decouple Rademacher from Categorical with direct Distribution subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Rademacher` now subclasses `Distribution` directly instead of `Categorical`, implementing analytical `_pdf`, `_cdf`, and `_generator` methods. Eliminates unnecessary alias-table infrastructure for a two-point symmetric distribution (#668).
 - `Levy`, `Lindley`, `Moyal`, and `Reciprocal` now implement exact closed-form quantile functions (`_q`) instead of falling back to the root-finder: `Levy` and `Moyal` via `erfinv`, `Lindley` via the `W₋₁` branch of Lambert W, and `Reciprocal` (log-uniform) directly as `a·(b/a)^p`. Quantile values are unchanged but computation is now O(1) instead of O(iterations); the `Lindley`, `Moyal`, and `Reciprocal` `_generator()` samplers now reuse `_q` (#619).
 - Owen T iterative methods (T1–T5 in `src/special/owen-t.js`) now use convergence-checked loops (`|term| < |sum| · ε`) instead of fixed iteration counts. The `ORDERS` table remains as a safety cap (maximum iterations), but series terminate early once machine precision is reached, improving accuracy near sector boundaries from ~10 to ~15 significant digits (#554).
 - `generalizedHarmonic` direct-sum path now uses Neumaier compensated summation instead of raw accumulation, and the zeta-function switch threshold is lowered from n ≥ 20 to n ≥ 10. For large m the terms drop off rapidly, causing raw accumulation to lose ~2 decimal digits; compensated summation eliminates this rounding error (#553).

--- a/src/dist/rademacher.js
+++ b/src/dist/rademacher.js
@@ -1,4 +1,4 @@
-import Categorical from './categorical'
+import Distribution from './_distribution'
 
 /**
  * Probability mass function for the [Rademacher distribution]{@link https://en.wikipedia.org/wiki/Rademacher_distribution}:
@@ -11,12 +11,31 @@ import Categorical from './categorical'
  * @memberof ran.dist
  * @constructor
  */
-export default class Rademacher extends Categorical {
-  // Special case of categorical
+export default class Rademacher extends Distribution {
   /** */
   constructor () {
-    super([0.5, 0, 0.5], -1)
-    this.p = {}
+    super('discrete', 0)
+    this.s = [{
+      value: -1,
+      closed: true
+    }, {
+      value: 1,
+      closed: true
+    }]
+  }
+
+  _generator () {
+    return this.r.next() < 0.5 ? -1 : 1
+  }
+
+  _pdf (x) {
+    return x === -1 || x === 1 ? 0.5 : 0
+  }
+
+  _cdf (x) {
+    if (x < -1) return 0
+    if (x < 1) return 0.5
+    return 1
   }
 
   _q (p) {


### PR DESCRIPTION
Closes #668

## Summary
- `Rademacher` previously subclassed `Categorical([0.5, 0, 0.5], -1)`, incurring a 3-slot alias-table lookup for a two-point symmetric distribution with no parameters
- Now subclasses `Distribution` directly with analytical `_pdf`, `_cdf`, and `_generator` — eliminating unnecessary infrastructure while keeping the existing `_q` intact
- `_generator()` uses `this.r.next() < 0.5 ? -1 : 1`, strictly faster than alias-table sampling; all 5291 existing tests pass unchanged

## Design decisions
- [ADR-0014: Categorical this.c natural params split](decisions/0014-categorical-this-c-natural-params-split.md) — covers the broader Categorical decoupling rationale that motivates this change

## Non-trivial changes
- **`src/dist/rademacher.js`**: Replaces `extends Categorical` with `extends Distribution`. Adds `_pdf(x)` (0.5 for x=±1, 0 otherwise), `_cdf(x)` (0/0.5/1 at the correct boundaries), and `_generator()` (single PRNG comparison). Support set to `[{value: -1, closed: true}, {value: 1, closed: true}]`. The pre-existing `_q(p)` is retained unchanged.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added entry under `### Changed` for the refactor

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfeUfKktwPkwNNtXzjjt89)_