### PR TITLE
Fix generalizedHarmonic(n, 1) returning NaN for n ≥ 10

### DIFF
--- a/src/special/generalized-harmonic.js
+++ b/src/special/generalized-harmonic.js
@@ -1,6 +1,10 @@
 import riemannZeta from './riemann-zeta'
 import hurwitzZeta from './hurwitz-zeta'
+import digamma from './digamma'
 import neumaier from '../algorithms/neumaier'
+
+// Euler-Mascheroni constant γ; used for the m=1 identity H_n = γ + ψ(n+1).
+const EULER_MASCHERONI = 0.5772156649015329
 
 /**
  * Computes the generalized harmonic number H(n, m).
@@ -22,6 +26,7 @@ export default function (n, m) {
     return neumaier(terms)
   }
 
-  // Otherwise use the zeta functions.
+  // m=1 avoids ζ(1)−ζ(1,n+1) = ∞−∞ (NaN); use the exact identity H_n = γ + ψ(n+1) instead.
+  if (m === 1) return EULER_MASCHERONI + digamma(n + 1)
   return riemannZeta(m) - hurwitzZeta(m, n + 1)
 }

--- a/test/precision.js
+++ b/test/precision.js
@@ -569,6 +569,14 @@ describe('special-function precision gate', () => {
     it('returns H(5,1) = 137/60 via direct sum to 1e-14 relative error', () => {
       assert.approximately(special.generalizedHarmonic(5, 1) / 2.283333333333333, 1, 1e-14)
     })
+    // m=1 harmonic number for n>=10: previously returned NaN (∞−∞ via zeta path); now uses γ+ψ(n+1)
+    // n=10 is the smallest n that hits the digamma path (boundary of n>=10 branch).
+    it('returns H(10,1) = 7381/2520 at path boundary to 1e-14 relative error', () => {
+      assert.approximately(special.generalizedHarmonic(10, 1) / 2.9289682539682538, 1, 1e-14)
+    })
+    it('returns H(15,1) via digamma path to 1e-14 relative error', () => {
+      assert.approximately(special.generalizedHarmonic(15, 1) / 3.3182289932289932, 1, 1e-14)
+    })
   })
 
   describe('marcumP', () => {


### PR DESCRIPTION
Closes #679

## Summary
- `generalizedHarmonic(n, 1)` silently returned `NaN` for all `n ≥ 10` because the zeta path computed `ζ(1) − ζ(1, n+1) = ∞ − ∞`.
- Fixed by intercepting `m === 1` before the zeta dispatch and using the exact identity `H_n = γ + ψ(n+1)`, which avoids the pole entirely and achieves full double-precision accuracy.
- Added precision tests for the path boundary (`n=10`) and a representative interior point (`n=15`).

## Non-trivial changes
- **`src/special/generalized-harmonic.js`**: Added `m === 1` guard for `n ≥ 10` using `EULER_MASCHERONI + digamma(n + 1)`. This is a behavioral fix — callers that previously received `NaN` will now receive a correct finite value.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/precision.js`**: Two precision tests added for `H(10,1)` and `H(15,1)` with reference values verified against the exact rationals 7381/2520 and 1195757/360360.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKWTqAn7NPgDKYTvL8AwmF)_