### PR TITLE
Tighten erfcx test tolerance to 1e-14

### DIFF
--- a/test/special.js
+++ b/test/special.js
@@ -1273,7 +1273,7 @@ describe('special', () => {
 
   describe('.erfcx()', () => {
     it('should return 1 at zero', () => {
-      assert(equal(special.erfcx(0), 1))
+      assert(equal(special.erfcx(0), 1, 14))
     })
 
     it('should return reference values', () => {
@@ -1283,13 +1283,13 @@ describe('special', () => {
         { x: 2.0, y: 0.25539567631050569 },
         { x: 5.0, y: 0.11070463773306866 }
       ].forEach(d => {
-        assert(equal(special.erfcx(d.x), d.y), `erfcx(${d.x})`)
+        assert(equal(special.erfcx(d.x), d.y, 14), `erfcx(${d.x})`)
       })
     })
 
     it('should remain finite for large x where erfc(x) underflows to 0', () => {
       assert(special.erfc(30) === 0, 'erfc(30) underflows in float64')
-      assert(equal(special.erfcx(30), 0.018795888861416754), 'erfcx(30) reference value')
+      assert(equal(special.erfcx(30), 0.018795888861416754, 14), 'erfcx(30) reference value')
     })
 
     it('should return reference values for negative arguments', () => {
@@ -1297,7 +1297,7 @@ describe('special', () => {
         { x: -1, y: 5.0089800807622833 },
         { x: -3, y: 16205.988853999588 }
       ].forEach(d => {
-        assert(equal(special.erfcx(d.x), d.y), `erfcx(${d.x})`)
+        assert(equal(special.erfcx(d.x), d.y, 14), `erfcx(${d.x})`)
       })
     })
   })


### PR DESCRIPTION
Closes #702

## Summary
- Tightens all `erfcx` test assertions in `test/special.js` from the default relative error ≤ 1e-10 to ≤ 1e-14, matching the precision requirement of `InverseGaussian._cdf` which depends on `erfcx` since PR #690
- A regression degrading `erfcx` accuracy from 1e-14 to anywhere in the 1e-10–1e-13 range would now be caught by the test suite

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/special.js`**: Added explicit `14` precision argument to four `equal()` calls in the `.erfcx()` test block, tightening relative error tolerance from 1e-10 (default) to 1e-14

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPSYNhm7iTEdpk2E7jCGRc)_