### PR TITLE
Fix dead loop in gammaLowerIncomplete convergence test (#709)

### DIFF
--- a/test/special.js
+++ b/test/special.js
@@ -563,7 +563,7 @@ describe('special', () => {
     })
 
     it('should converge to gamma(s) as x -> inf', () => {
-      for (let i = 0; i > LAPS; i++) {
+      for (let i = 0; i < LAPS; i++) {
         const s = Math.random() * 100
         const x = 1e5 + Math.random() * 1e5
         assert(equal(special.gammaLowerIncomplete(s, x), 1))


### PR DESCRIPTION
Closes #709

## Summary
- Fixes an inverted loop condition `i > LAPS` (always false) to `i < LAPS` in `test/special.js:566`, restoring the "should converge to gamma(s) as x → ∞" convergence test that was previously vacuous

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/special.js:566`**: Loop condition corrected from `i > LAPS` (always false, loop never ran) to `i < LAPS` (correct, runs 100 iterations)

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WERE5oNPZTC5NnqkRxAm42)_