### PR TITLE
Replace Math.random() inputs with deterministic grids in special.js tests (part A)

### DIFF
--- a/test/special.js
+++ b/test/special.js
@@ -44,10 +44,9 @@ describe('special', () => {
     })
 
     it('should satisfy the recurrence ψ(z+1) = ψ(z) + 1/z', () => {
-      repeat(() => {
-        const z = Math.random() * 100 + 0.1
+      for (const z of [0.1, 0.5, 1, 6, 100]) {
         assert(equal(special.digamma(z + 1), special.digamma(z) + 1 / z))
-      }, LAPS)
+      }
     })
   })
 
@@ -96,29 +95,26 @@ describe('special', () => {
   */
 
   describe('.bessel()', () => {
-    it('In(0) should be equal to 0 for n > 1', () => {
-      repeat(() => {
-        const n = Math.floor(1 + 10 * Math.random())
+    it('In(0) should be equal to 0 for n >= 1', () => {
+      for (const n of [1, 2, 3, 5, 10]) {
         assert(special.besselI(n, 0) === 0)
-      })
+      }
     })
 
     it('I1(-x) should be equal to -I1(x)', () => {
-      repeat(() => {
-        const x = 1 + 10 * Math.random()
+      for (const x of [0.1, 1, 9.9, 10, 10.1, 50]) {
         assert(equal(special.besselI(1, -x), -special.besselI(1, x)))
-      })
+      }
     })
 
     it('In(-x) should be equal to -In(x) for odd n >= 3', () => {
       // Regression for the backward-recurrence sign bug fixed in #255: abs(x) with no sign
       // correction caused I_n(-x) != -I_n(x) for odd n >= 3
-      repeat(() => {
-        const x = 1 + 10 * Math.random()
+      for (const x of [0.1, 1, 5, 9.9, 10, 10.1, 50]) {
         assert(equal(special.besselI(3, -x), -special.besselI(3, x)))
         assert(equal(special.besselI(5, -x), -special.besselI(5, x)))
         assert(equal(special.besselI(7, -x), -special.besselI(7, x)))
-      })
+      }
     })
 
     it('I1(x) should match scipy reference values', () => {
@@ -166,27 +162,28 @@ describe('special', () => {
       assert(special.besselISpherical(1, 0) === 0)
     })
 
-    it('i(n, 0) should be 1 for n > 0', () => {
-      const n = Math.floor(1 + 10 * Math.random())
-      assert(special.besselISpherical(n, 0) === 0)
+    it('i(n, 0) should be 0 for n > 0', () => {
+      for (const n of [1, 2, 5]) {
+        assert(special.besselISpherical(n, 0) === 0)
+      }
     })
 
     it('should satisfy the recurrence relation for negative order', () => {
-      repeat(() => {
-        const n = -Math.floor(1 + 10 * Math.random())
-        const x = 10 * Math.random()
-        assert(equal(special.besselISpherical(n - 1, x) - special.besselISpherical(n + 1, x),
-          (2 * n + 1) * special.besselISpherical(n, x) / x))
-      })
+      for (const n of [-1, -2, -3, -5]) {
+        for (const x of [0.5, 2, 9, 11]) {
+          assert(equal(special.besselISpherical(n - 1, x) - special.besselISpherical(n + 1, x),
+            (2 * n + 1) * special.besselISpherical(n, x) / x))
+        }
+      }
     })
 
     it('should satisfy the recurrence relation for positive order', () => {
-      repeat(() => {
-        const n = Math.floor(1 + 10 * Math.random())
-        const x = 10 * Math.random()
-        assert(equal(special.besselISpherical(n - 1, x) - special.besselISpherical(n + 1, x),
-          (2 * n + 1) * special.besselISpherical(n, x) / x))
-      })
+      for (const n of [1, 2, 3, 5]) {
+        for (const x of [0.5, 2, 9, 11]) {
+          assert(equal(special.besselISpherical(n - 1, x) - special.besselISpherical(n + 1, x),
+            (2 * n + 1) * special.besselISpherical(n, x) / x))
+        }
+      }
     })
 
     it('should return accurate small-x values for n=1', () => {
@@ -223,12 +220,12 @@ describe('special', () => {
     })
 
     it('should satisfy positive-order recurrence in the Taylor branch', () => {
-      repeat(() => {
-        const n = Math.floor(1 + 10 * Math.random())
-        const x = 0.01 + 0.98 * Math.random()
-        assert(equal(special.besselISpherical(n - 1, x) - special.besselISpherical(n + 1, x),
-          (2 * n + 1) * special.besselISpherical(n, x) / x))
-      })
+      for (const n of [1, 2, 5]) {
+        for (const x of [0.01, 0.1, 0.5, 0.99]) {
+          assert(equal(special.besselISpherical(n - 1, x) - special.besselISpherical(n + 1, x),
+            (2 * n + 1) * special.besselISpherical(n, x) / x))
+        }
+      }
     })
   })
 
@@ -306,14 +303,20 @@ describe('special', () => {
 
   describe('.betaIncomplete()', () => {
     it('B(a, b, x) should be equal to 0 if b > 0 and x <= 0', () => {
-      assert(special.betaIncomplete(Math.random(), Math.random() + 1, -Math.random()) === 0)
+      for (const a of [0.5, 1, 2]) {
+        for (const b of [1, 2]) {
+          assert(special.betaIncomplete(a, b, -1) === 0)
+        }
+      }
     })
 
     it('B(a, b, x) should be equal to B(a,b) if b > 0 and x >= 1', () => {
-      const a = Math.random()
-      const b = Math.random() + 1
-      const expected = Math.exp(special.logGamma(a) + special.logGamma(b) - special.logGamma(a + b))
-      assert(special.betaIncomplete(a, b, 1 + Math.random()) === expected)
+      for (const a of [0.5, 1, 2]) {
+        for (const b of [1, 2]) {
+          const expected = Math.exp(special.logGamma(a) + special.logGamma(b) - special.logGamma(a + b))
+          assert(special.betaIncomplete(a, b, 2) === expected)
+        }
+      }
     })
   })
 
@@ -563,7 +566,7 @@ describe('special', () => {
     })
 
     it('should converge to gamma(s) as x -> inf', () => {
-      for (let i = 0; i > LAPS; i++) {
+      for (let i = 0; i < LAPS; i++) {
         const s = Math.random() * 100
         const x = 1e5 + Math.random() * 1e5
         assert(equal(special.gammaLowerIncomplete(s, x), 1))


### PR DESCRIPTION
Closes #712

## Summary
- Replaces non-reproducible `Math.random()` inputs in 7 test blocks with fixed deterministic grids for `digamma`, `besselI`, `besselISpherical`, and `betaIncomplete`, making failures replayable and CI output stable.
- Two pre-existing bugs fixed inline during triage: a vacuous loop condition (`i > LAPS` → `i < LAPS`) in `gammaLowerIncomplete` that caused the convergence test to never execute, and a wrong test description (`i(n, 0) should be 1` → `should be 0`).

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/special.js`**: Seven `repeat(() => { Math.random()... })` blocks replaced with `for...of` loops over fixed arrays. Two pre-existing bugs corrected: vacuous loop guard and misleading test description.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf7z5nTpG4qNrVsCKwxeCR)_