### PR TITLE
Fix non-reproducible seeds and vacuous assertions in dist tests (#710)

### DIFF
--- a/test/dist.js
+++ b/test/dist.js
@@ -38,7 +38,7 @@ const UnitTests = {
 
     it('should give the same sample for the same seed', () => {
       const self = new dist[tc.name](...tc.cases[0].params())
-      const s = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
+      const s = 123456789 // fixed seed so CI failures are reproducible
       self.seed(s)
       const values1 = self.sample(sampleSize)
       self.seed(s)
@@ -48,9 +48,9 @@ const UnitTests = {
 
     it('should give different samples for different seeds', () => {
       const self = new dist[tc.name](...tc.cases[0].params())
-      self.seed(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER))
+      self.seed(123456789) // fixed seed so CI failures are reproducible
       const values1 = self.sample(sampleSize)
-      self.seed(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER))
+      self.seed(987654321) // different fixed seed to guarantee distinct sequence
       const values2 = self.sample(sampleSize)
       assert(values1.reduce((acc, d, i) => acc || d !== values2[i], true))
     })
@@ -62,7 +62,7 @@ const UnitTests = {
     it('loaded state should continue where it was saved at', () => {
       // Create generator and seed
       const generator = new dist[tc.name](...tc.cases[0].params())
-      const s = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
+      const s = 123456789 // fixed seed so CI failures are reproducible
       const cut = Math.floor(sampleSize / 3)
 
       // Generate full sample
@@ -83,7 +83,7 @@ const UnitTests = {
     it('loaded state should copy full state of generator', () => {
       // Create seeded generator
       const generator1 = new dist[tc.name](...tc.cases[0].params())
-      generator1.seed(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER))
+      generator1.seed(123456789) // fixed seed so CI failures are reproducible
 
       // Generate original sample
       generator1.sample(10)
@@ -2234,8 +2234,8 @@ describe('dist', () => {
           const x0 = float()
           const degenerate = new dist.Degenerate(x0)
           assert.equal(degenerate.pdf(x0), 1)
-          assert.equal(degenerate.pdf(x0 + Math.random() * 2 - 1), 0)
-          assert.equal(degenerate.cdf(x0 - Math.random()), 0)
+          assert.equal(degenerate.pdf(x0 + 1), 0) // fixed offset guarantees argument != x0
+          assert.equal(degenerate.cdf(x0 - 1), 0) // fixed offset guarantees argument < x0
           assert.equal(degenerate.cdf(x0), 1)
           assert.equal(degenerate.cdf(x0 + Math.random()), 1)
         })

--- a/test/dist.js
+++ b/test/dist.js
@@ -52,7 +52,7 @@ const UnitTests = {
       const values1 = self.sample(sampleSize)
       self.seed(987654321) // different fixed seed to guarantee distinct sequence
       const values2 = self.sample(sampleSize)
-      assert(values1.reduce((acc, d, i) => acc || d !== values2[i], true))
+      assert(values1.reduce((acc, d, i) => acc || d !== values2[i], false))
     })
   },
 


### PR DESCRIPTION
Closes #710

## Summary
- Replaces five unseeded `Math.random()` PRNG seed selections in `test/dist.js` with fixed integer constants so CI failures are reproducible.
- Fixes two test correctness bugs found during the hotfix: a vacuous OR-fold assertion and flaky Degenerate distribution offset checks.

## Non-trivial changes
- **`test/dist.js:55`** — "should give different samples for different seeds" test had `reduce(..., true)` as its initial accumulator. Because `true || anything === true`, the fold short-circuited on the first element and the assertion was vacuous — it could never fail even if both samples were identical. Changed to `false` so the OR fold actually checks whether any pair of elements differs.
- **`test/dist.js:2237–2238`** — Degenerate pdf/cdf assertions used `Math.random()` offsets that could produce 0, turning `pdf(x0 + 0)` into `pdf(x0) = 1` (asserted 0) and `cdf(x0 - 0)` into `cdf(x0) = 1` (asserted 0). Replaced with fixed `±1` offsets that are guaranteed nonzero.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js:41,51,53,65,86`** — `Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)` replaced with `123456789` / `987654321` (distinct constants, both well within uint32 range, guaranteed to produce different xoshiro128+ sequences).

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKnbNYCsCDoeVVr54LbqC3)_