### PR TITLE
Add midpoint CDF regression tests for BetaBinomial and NegativeHypergeometric

### DIFF
--- a/test/dist-cases-discrete.js
+++ b/test/dist-cases-discrete.js
@@ -101,6 +101,17 @@ export default [{
     quantileVals: [
       { p: 0.5, x: 2 }
     ]
+  }, {
+    name: 'symmetric n=25 alpha=beta=3 midpoint boundary',
+    params: () => [25, 3, 3],
+    // exact: CDF(12)=0.5 by symmetry (alpha=beta, n odd); exercises the fwd>=0.25
+    // midpoint path where Math.min(1,…) clamp guards against floating-point over-accumulation (#701)
+    refVals: [
+      { x: 12, pmf: 35 / 522, cdf: 0.5 }
+    ],
+    quantileVals: [
+      { p: 0.5, x: 12 }
+    ]
   }],
   // scipy.stats.betabinom(n=25, a=2, b=2)
   refVals: [
@@ -857,6 +868,19 @@ export default [{
     ],
     quantileVals: [
       { p: 0.5, x: 2 }
+    ]
+  }, {
+    name: 'balanced midpoint boundary N=20 K=10 r=5',
+    params: () => [20, 10, 5],
+    // exact: CDF(4) = sum_{k=0}^{4} C(k+4,k)·C(15-k,5) / C(20,10) = 92378/184756 = 0.5;
+    // PMF(4) = C(8,4)·C(11,6)/C(20,10) = 70·462/184756 = 735/4199;
+    // exercises the fwd>=0.25 midpoint path where Math.min(1,…) clamp guards against
+    // floating-point over-accumulation (#701 regression)
+    refVals: [
+      { x: 4, pmf: 735 / 4199, cdf: 0.5 }
+    ],
+    quantileVals: [
+      { p: 0.5, x: 4 }
     ]
   }],
   // scipy.stats.nhypergeom(M=35, n=15, r=7)


### PR DESCRIPTION
Closes #707

## Summary
- Adds a `BetaBinomial(25, 3, 3)` sub-case with exact refVals at `x=12` (CDF = 0.5 by symmetry, PMF = 35/522): exercises the `fwd >= 0.25` lower-half midpoint CDF path guarded by the `Math.min(1, …)` clamp restored in #701.
- Adds a `NegativeHypergeometric(20, 10, 5)` sub-case with exact refVals at `x=4` (CDF = 92378/184756 = 0.5 by combinatorial identity, PMF = 735/4199): exercises the same midpoint path for the second affected distribution.
- Both cases extend the `cdfRange` invariant (`cdf <= 1`) to the midpoint branch — without this coverage the clamp could be silently removed and all tests would still pass.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-discrete.js`**: Two new sub-cases added to `BetaBinomial` and `NegativeHypergeometric` `cases` arrays, each with `refVals` (exact PMF and CDF) and `quantileVals` at the support midpoint.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_013ikdZNHAt5AisdZTBvvChK)_