### PR TITLE
Replace tautological Math.random() tests with deterministic assertions in dispersion and shape

### DIFF
--- a/src/dispersion/variance.js
+++ b/src/dispersion/variance.js
@@ -13,7 +13,7 @@
  * ran.dispersion.variance([1])
  * // => NaN
  *
- * ran.dispersion.variance([1, 2, 3])
+ * ran.dispersion.variance([1, 2, 3, 4, 5])
  * // => 2.5
  */
 export default function (values) {

--- a/test/dispersion.js
+++ b/test/dispersion.js
@@ -1,9 +1,7 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { repeat, equal } from './test-utils'
+import { equal } from './test-utils'
 import * as dispersion from '../src/dispersion'
-
-const SAMPLE_SIZE = 100
 
 describe('dispersion', () => {
   describe('.cv()', () => {
@@ -17,12 +15,14 @@ describe('dispersion', () => {
     })
 
     it('should return the coefficient of variation', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const mean = values.reduce((m, d) => d + m, 0) / values.length
-        const stdev = Math.sqrt(values.reduce((v, d) => (d - mean) * (d - mean) + v, 0) / (values.length - 1))
-        assert(equal(dispersion.cv(values), stdev / mean))
-      })
+      // [1, 2, 3]: mean=2, sample_var=1, stdev=1, cv=0.5
+      assert(equal(dispersion.cv([1, 2, 3]), 0.5))
+      // [2, 4, 6]: mean=4, sample_var=4, stdev=2, cv=0.5
+      assert(equal(dispersion.cv([2, 4, 6]), 0.5))
+      // [1, 3, 5]: mean=3, sample_var=4, stdev=2, cv=2/3
+      assert(equal(dispersion.cv([1, 3, 5]), 2 / 3))
+      // all-identical: stdev=0, cv=0
+      assert(equal(dispersion.cv([5, 5, 5]), 0))
     })
   })
 
@@ -96,11 +96,12 @@ describe('dispersion', () => {
         ],
         entropy: 3.40119738166
       }]
-      const base = Math.random()
 
-      testCases.forEach(tc => {
-        assert(equal(dispersion.entropy(tc.probabilities, base), tc.entropy / Math.log(base), 8))
-      })
+      for (const base of [2, 10]) {
+        testCases.forEach(tc => {
+          assert(equal(dispersion.entropy(tc.probabilities, base), tc.entropy / Math.log(base), 8))
+        })
+      }
     })
   })
 
@@ -115,20 +116,12 @@ describe('dispersion', () => {
     })
 
     it('should return the relative mean absolute difference', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        let mean = 0
-        let g = 0
-        for (let i = 0; i < values.length; i++) {
-          mean += values[i]
-          for (let j = 0; j < values.length; j++) {
-            g += Math.abs(values[i] - values[j])
-          }
-        }
-        mean /= values.length
-        g /= 2 * mean * values.length * values.length
-        assert(equal(dispersion.gini(values), g))
-      })
+      // [1, 2, 3]: rmd=4/9, gini=rmd/2=2/9
+      assert(equal(dispersion.gini([1, 2, 3]), 2 / 9))
+      // [1, 2, 3, 4]: rmd=0.5, gini=0.25
+      assert(equal(dispersion.gini([1, 2, 3, 4]), 0.25))
+      // all-identical: gini=0
+      assert(equal(dispersion.gini([3, 3, 3]), 0))
     })
   })
 
@@ -142,24 +135,12 @@ describe('dispersion', () => {
     })
 
     it('should return the interquartile range for a finite sample', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const iqr = dispersion.iqr(values)
-
-        // Lower quartile.
-        let h = (values.length - 1) * 0.25
-        let q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        let q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const lo = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-
-        // Upper quartile.
-        h = (values.length - 1) * 0.75
-        q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const hi = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-
-        assert(equal(hi - lo, iqr))
-      })
+      // [1, 2, 3, 4, 5]: Q1=2 (h=1, exact), Q3=4 (h=3, exact), IQR=2
+      assert(equal(dispersion.iqr([1, 2, 3, 4, 5]), 2))
+      // [0, 1, 2, 3]: Q1=0.75 (h=0.75, interp), Q3=2.25 (h=2.25, interp), IQR=1.5
+      assert(equal(dispersion.iqr([0, 1, 2, 3]), 1.5))
+      // all-identical: IQR=0
+      assert(equal(dispersion.iqr([3, 3, 3, 3]), 0))
     })
   })
 
@@ -170,17 +151,12 @@ describe('dispersion', () => {
     })
 
     it('should return the mean absolute difference', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        let md = 0
-        for (let i = 0; i < values.length; i++) {
-          for (let j = 0; j < values.length; j++) {
-            md += Math.abs(values[i] - values[j])
-          }
-        }
-        md /= values.length * values.length
-        assert(equal(dispersion.md(values), md))
-      })
+      // [0, 2]: n=2, 2*|0-2|/4=1
+      assert(equal(dispersion.md([0, 2]), 1))
+      // [1, 2, 3]: n=3, 2*(1+2+1)/9=8/9
+      assert(equal(dispersion.md([1, 2, 3]), 8 / 9))
+      // all-identical: md=0
+      assert(equal(dispersion.md([4, 4, 4]), 0))
     })
   })
 
@@ -190,24 +166,10 @@ describe('dispersion', () => {
     })
 
     it('should return the midhinge for a finite sample', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const mh = dispersion.midhinge(values)
-
-        // Lower quartile.
-        let h = (values.length - 1) * 0.25
-        let q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        let q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const lo = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-
-        // Upper quartile.
-        h = (values.length - 1) * 0.75
-        q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const hi = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-
-        assert(equal(0.5 * (hi + lo), mh))
-      })
+      // [1, 2, 3, 4, 5]: Q1=2, Q3=4, midhinge=(2+4)/2=3
+      assert(equal(dispersion.midhinge([1, 2, 3, 4, 5]), 3))
+      // [0, 1, 2, 3]: Q1=0.75, Q3=2.25, midhinge=1.5
+      assert(equal(dispersion.midhinge([0, 1, 2, 3]), 1.5))
     })
   })
 
@@ -217,13 +179,12 @@ describe('dispersion', () => {
     })
 
     it('should return the range for a finite sample', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const range = dispersion.range(values)
-        const min = values.sort((a, b) => a - b)[0]
-        const max = values.sort((a, b) => b - a)[0]
-        assert(equal(max - min, range))
-      })
+      // [3, 1, 4, 1, 5, 9, 2, 6]: min=1, max=9, range=8
+      assert(equal(dispersion.range([3, 1, 4, 1, 5, 9, 2, 6]), 8))
+      // [7, 2, 5]: min=2, max=7, range=5
+      assert(equal(dispersion.range([7, 2, 5]), 5))
+      // all-identical: range=0
+      assert(equal(dispersion.range([4, 4, 4]), 0))
     })
   })
 
@@ -238,20 +199,10 @@ describe('dispersion', () => {
     })
 
     it('should return the relative mean absolute difference', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        let mean = 0
-        let rd = 0
-        for (let i = 0; i < values.length; i++) {
-          mean += values[i]
-          for (let j = 0; j < values.length; j++) {
-            rd += Math.abs(values[i] - values[j])
-          }
-        }
-        mean /= values.length
-        rd /= mean * values.length * values.length
-        assert(equal(dispersion.rmd(values), rd))
-      })
+      // [1, 2, 3]: md=8/9, mean=2, rmd=4/9
+      assert(equal(dispersion.rmd([1, 2, 3]), 4 / 9))
+      // [1, 2, 3, 4]: rmd=0.5
+      assert(equal(dispersion.rmd([1, 2, 3, 4]), 0.5))
     })
   })
 
@@ -265,24 +216,10 @@ describe('dispersion', () => {
     })
 
     it('should return the quartile coefficient of dispersion for a finite sample', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const qcd = dispersion.qcd(values)
-
-        // Lower quartile.
-        let h = (values.length - 1) * 0.25
-        let q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        let q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const lo = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-
-        // Upper quartile.
-        h = (values.length - 1) * 0.75
-        q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const hi = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-
-        assert(equal((hi - lo) / (lo + hi), qcd))
-      })
+      // [1, 2, 3, 4, 5]: Q1=2, Q3=4, qcd=(4-2)/(4+2)=1/3
+      assert(equal(dispersion.qcd([1, 2, 3, 4, 5]), 1 / 3))
+      // [0, 1, 2, 3]: Q1=0.75, Q3=2.25, qcd=1.5/3=0.5
+      assert(equal(dispersion.qcd([0, 1, 2, 3]), 0.5))
     })
   })
 
@@ -293,12 +230,12 @@ describe('dispersion', () => {
     })
 
     it('should return the unbiased standard deviation', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const mean = values.reduce((m, d) => d + m, 0) / values.length
-        const stdev = Math.sqrt(values.reduce((v, d) => (d - mean) * (d - mean) + v, 0) / (values.length - 1))
-        assert(equal(dispersion.stdev(values), stdev))
-      })
+      // [1, 2, 3]: sample_var=1, stdev=1
+      assert(equal(dispersion.stdev([1, 2, 3]), 1))
+      // [2, 4, 6]: mean=4, sample_var=4, stdev=2
+      assert(equal(dispersion.stdev([2, 4, 6]), 2))
+      // all-identical: stdev=0
+      assert(equal(dispersion.stdev([7, 7, 7]), 0))
     })
   })
 
@@ -309,12 +246,12 @@ describe('dispersion', () => {
     })
 
     it('should return the unbiased variance', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const mean = values.reduce((m, d) => d + m, 0) / values.length
-        const variance = values.reduce((v, d) => (d - mean) * (d - mean) + v, 0) / (values.length - 1)
-        assert(equal(dispersion.variance(values), variance))
-      })
+      // [1, 2, 3]: mean=2, sample_var=((1+0+1)/2)=1
+      assert(equal(dispersion.variance([1, 2, 3]), 1))
+      // [2, 4, 6]: mean=4, sample_var=((4+0+4)/2)=4
+      assert(equal(dispersion.variance([2, 4, 6]), 4))
+      // all-identical: var=0
+      assert(equal(dispersion.variance([5, 5, 5]), 0))
     })
   })
 
@@ -329,12 +266,12 @@ describe('dispersion', () => {
     })
 
     it('should return the coefficient of variation', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const mean = values.reduce((m, d) => d + m, 0) / values.length
-        const variance = values.reduce((v, d) => (d - mean) * (d - mean) + v, 0) / (values.length - 1)
-        assert(equal(dispersion.vmr(values), variance / mean))
-      })
+      // [1, 2, 3]: mean=2, var=1, vmr=0.5
+      assert(equal(dispersion.vmr([1, 2, 3]), 0.5))
+      // [2, 4, 6]: mean=4, var=4, vmr=1
+      assert(equal(dispersion.vmr([2, 4, 6]), 1))
+      // [1, 3, 5]: mean=3, var=4, vmr=4/3
+      assert(equal(dispersion.vmr([1, 3, 5]), 4 / 3))
     })
   })
 })

--- a/test/shape.js
+++ b/test/shape.js
@@ -1,12 +1,9 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { repeat, equal } from './test-utils'
-import { int } from '../src/core'
+import { equal } from './test-utils'
 import * as shape from '../src/shape'
 
-const SAMPLE_SIZE = 100
-
-describe('dispersion', () => {
+describe('shape', () => {
   describe('.kurtosis()', () => {
     it('should return NaN if sample size is less than 3', () => {
       assert(Number.isNaN(shape.kurtosis([])))
@@ -19,24 +16,10 @@ describe('dispersion', () => {
     })
 
     it('should return the kurtosis', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const kurtosis = shape.kurtosis(values)
-        const n = values.length
-        let x1 = 0
-        for (let i = 0; i < values.length; i++) {
-          x1 += values[i]
-        }
-        x1 /= n
-
-        let x2 = 0
-        let x4 = 0
-        for (let i = 0; i < values.length; i++) {
-          x2 += Math.pow(values[i] - x1, 2)
-          x4 += Math.pow(values[i] - x1, 4)
-        }
-        assert(equal((n + 1) * n * (n - 1) * x4 / (x2 * x2 * (n - 2) * (n - 3)) - 3 * (n - 1) * (n - 1) / ((n - 2) * (n - 3)), kurtosis))
-      })
+      // [1, 2, 3, 4, 5]: symmetric, m2=2, m4=6.8, kurtosis=-1.2
+      assert(equal(shape.kurtosis([1, 2, 3, 4, 5]), -1.2))
+      // [2, 4, 4, 4, 5, 5, 7, 9]: mean=5, m2=4, m4=44.5, kurtosis=0.940625
+      assert(equal(shape.kurtosis([2, 4, 4, 4, 5, 5, 7, 9]), 0.940625))
     })
   })
 
@@ -46,34 +29,23 @@ describe('dispersion', () => {
     })
 
     it('should return the moment for finite sample for c = 0', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const k = int(0, 10)
-        const moment = shape.moment(values, k)
-        const n = values.length
-        let xk = 0
-        for (let i = 0; i < values.length; i++) {
-          xk += Math.pow(values[i], k)
-        }
-        xk /= n
-        assert(equal(xk, moment))
-      })
+      // k=0: x^0=1 for all x, so moment=1
+      assert(equal(shape.moment([1, 2, 3], 0), 1))
+      // k=1: moment([1,2,3], 1) = mean = 2
+      assert(equal(shape.moment([1, 2, 3], 1), 2))
+      // k=2: moment([1,2,3], 2) = (1+4+9)/3 = 14/3
+      assert(equal(shape.moment([1, 2, 3], 2), 14 / 3))
+      // k=2: moment([1,2,3,4,5], 2) = (1+4+9+16+25)/5 = 11
+      assert(equal(shape.moment([1, 2, 3, 4, 5], 2), 11))
     })
 
     it('should return the moment for finite sample for c != 0', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const k = int(0, 10)
-        const c = Math.random()
-        const moment = shape.moment(values, k, c)
-        const n = values.length
-        let xk = 0
-        for (let i = 0; i < values.length; i++) {
-          xk += Math.pow(values[i] - c, k)
-        }
-        xk /= n
-        assert(equal(xk, moment))
-      })
+      // moment([1,2,3], 1, 2) = mean([-1,0,1]) = 0
+      assert(equal(shape.moment([1, 2, 3], 1, 2), 0))
+      // moment([1,2,3,4,5], 2, 3) = mean([4,1,0,1,4]) = 2
+      assert(equal(shape.moment([1, 2, 3, 4, 5], 2, 3), 2))
+      // moment([2,4,6], 3, 4) = mean([-8,0,8]) = 0
+      assert(equal(shape.moment([2, 4, 6], 3, 4), 0))
     })
   })
 
@@ -83,16 +55,14 @@ describe('dispersion', () => {
     })
 
     it('should return quantile for finite sample', () => {
-      repeat(() => {
-        const p = Math.random()
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const q = shape.quantile(values, p)
-        const h = (values.length - 1) * p
-        const q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        const q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const qTest = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-        assert(equal(qTest, q))
-      })
+      // Evenly-spaced [1..5]: quartile points land on exact integers
+      assert(equal(shape.quantile([1, 2, 3, 4, 5], 0), 1))
+      assert(equal(shape.quantile([1, 2, 3, 4, 5], 0.25), 2))
+      assert(equal(shape.quantile([1, 2, 3, 4, 5], 0.5), 3))
+      assert(equal(shape.quantile([1, 2, 3, 4, 5], 0.75), 4))
+      assert(equal(shape.quantile([1, 2, 3, 4, 5], 1), 5))
+      // Interpolation: h=2.25, Q=30+0.25*(40-30)=32.5
+      assert(equal(shape.quantile([10, 20, 30, 40], 0.75), 32.5))
     })
   })
 
@@ -130,26 +100,12 @@ describe('dispersion', () => {
     })
 
     it('should return the skewness', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const skewness = shape.skewness(values)
-        const n = values.length
-        let x1 = 0
-        let x2 = 0
-        let x3 = 0
-        for (let i = 0; i < values.length; i++) {
-          x1 += values[i]
-          x2 += values[i] * values[i]
-          x3 += Math.pow(values[i], 3)
-        }
-        x1 /= n
-        x2 /= n
-        x3 /= n
-        const s = Math.sqrt(Math.abs(x2 - x1 * x1))
-        const c = Math.sqrt(n * (n - 1)) / (n - 2)
-        const ref = c * (x3 - 3 * x1 * s * s - x1 * x1 * x1) / (s * s * s)
-        assert(Math.abs(ref - skewness) <= 1e-10 * (1 + Math.abs(skewness)))
-      })
+      // [1, 2, 3, 4, 5]: symmetric, m3=0, skewness=0
+      assert(equal(shape.skewness([1, 2, 3, 4, 5]), 0))
+      // [1, 1, 1, 2]: positive skew = 2 (from docstring)
+      assert(equal(shape.skewness([1, 1, 1, 2]), 2))
+      // [1, 2, 2, 2]: negative skew = -2 (from docstring)
+      assert(equal(shape.skewness([1, 2, 2, 2]), -2))
     })
   })
 
@@ -163,29 +119,10 @@ describe('dispersion', () => {
     })
 
     it('should return Yule\'s coefficient for a finite sample', () => {
-      repeat(() => {
-        const values = Array.from({ length: SAMPLE_SIZE }, Math.random)
-        const yule = shape.yule(values)
-
-        // Lower quartile.
-        let h = (values.length - 1) * 0.25
-        let q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        let q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const lo = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-
-        // Upper quartile.
-        h = (values.length - 1) * 0.75
-        q0 = values.sort((a, b) => a - b)[Math.floor(h)]
-        q1 = values.sort((a, b) => a - b)[Math.floor(h) + 1]
-        const hi = q0 + (typeof q1 === 'undefined' ? 0 : (h - Math.floor(h)) * (q1 - q0))
-
-        // Median.
-        const median = values.length % 2 === 0
-          ? 0.5 * (values[values.length / 2 - 1] + values[values.length / 2])
-          : values[(values.length - 1) / 2]
-
-        assert(equal((lo + hi - 2 * median) / (hi - lo), yule))
-      })
+      // [1, 2, 3, 4, 5]: Q1=2, Q3=4, median=3, yule=(2+4-6)/(4-2)=0
+      assert(equal(shape.yule([1, 2, 3, 4, 5]), 0))
+      // [1, 1, 2, 4, 8]: Q1=1, Q3=4, median=2, yule=(1+4-4)/(4-1)=1/3
+      assert(equal(shape.yule([1, 1, 2, 4, 8]), 1 / 3))
     })
   })
 })


### PR DESCRIPTION
Closes #717

## Summary
- Replaced all 12 `Math.random()` call sites in `test/dispersion.js` and 5 in `test/shape.js` with deterministic assertions against analytically-known expected values (e.g. `cv([1,2,3]) = 0.5`, `kurtosis([1,2,3,4,5]) = -1.2`)
- Added edge-case assertions for all-identical inputs (zero variance, zero IQR, zero range) and two-element arrays
- Fixed two inline bugs found during triage: wrong docstring example in `variance.js` (`[1,2,3]→2.5` corrected to `[1,2,3,4,5]→2.5`) and mislabelled `describe('dispersion',...)` in `test/shape.js` corrected to `describe('shape',...)`

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dispersion.js`**: Removed `repeat`/`SAMPLE_SIZE`, replaced 12 `Math.random()` patterns with hardcoded `assert(equal(..., expected))` calls for `cv`, `entropy`, `gini`, `iqr`, `md`, `midhinge`, `range`, `rmd`, `qcd`, `stdev`, `variance`, `vmr`
- **`test/shape.js`**: Removed `repeat`/`int`/`SAMPLE_SIZE`, replaced 5 `Math.random()` patterns with hardcoded assertions for `kurtosis`, `moment`, `quantile`, `skewness`, `yule`; fixed top-level `describe` label from `'dispersion'` to `'shape'`
- **`src/dispersion/variance.js`**: Corrected JSDoc example input from `[1, 2, 3]` to `[1, 2, 3, 4, 5]` so the example matches the documented output of `2.5`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXByCaqMT23PvD5k5bLrQ9)_