### PR TITLE
Replace Math.random() inputs with deterministic values in algorithm and LA tests

### DIFF
--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -3,35 +3,31 @@ import { describe, it } from 'mocha'
 import { repeat } from './test-utils'
 import { lambertW0 } from '../src/special/lambert-w'
 import * as algorithms from '../src/algorithms'
-import { int } from '../src/core'
 
-const LAPS = 100
 const PRECISION = 1e-10
 
 describe('algorithms', () => {
   describe('.bracket()', () => {
     it('should return NaN if initial bracket is invalid', () => {
-      repeat(() => {
-        const c = Math.random() * 10
+      for (const c of [1e-8, 0.01, 0.5, 1, Math.E, 5, 10]) {
         const bracket = algorithms.bracket(
           t => t * Math.exp(t) - c,
           lambertW0(c) + 1,
           lambertW0(c) + 1
         )
         assert(Number.isNaN(bracket))
-      }, LAPS)
+      }
     })
 
     it('should find an appropriate bracket for exp(-x) = c x', () => {
-      repeat(() => {
-        const c = Math.random() * 10
+      for (const c of [1e-8, 0.01, 0.5, 1, Math.E, 5, 10]) {
         const bracket = algorithms.bracket(
           t => t * Math.exp(t) - c,
           lambertW0(c) + 1,
           lambertW0(c) + 2
         )
         assert(bracket[0] * Math.exp(bracket[0]) < c && bracket[1] * Math.exp(bracket[1]) > c)
-      }, LAPS)
+      }
     })
 
     it('should return the specified boundaries if root was not found', () => {
@@ -63,15 +59,15 @@ describe('algorithms', () => {
       ))
     })
     it('should find the solution of exp(-x) = c x', () => {
-      repeat(() => {
-        const c = Math.random() * 10
+      for (const c of [1e-8, 0.01, 0.5, 1, Math.E, 5, 10]) {
         const sol = algorithms.chandrupatla(
           t => t * Math.exp(t) - c,
           lambertW0(c) - 1,
           lambertW0(c) + 1
         )
-        assert(Math.abs((sol - lambertW0(c)) / sol) < PRECISION)
-      }, LAPS)
+        // Chandrupatla's bracket-based stopping uses absolute width, so assert absolute error.
+        assert(Math.abs(sol - lambertW0(c)) < PRECISION)
+      }
     })
     it('should find roots near zero correctly', () => {
       const sol = algorithms.chandrupatla(t => t, -1, 1)
@@ -85,15 +81,14 @@ describe('algorithms', () => {
 
   describe('.newton()', () => {
     it('should find the solution of exp(-x) = c x', () => {
-      repeat(() => {
-        const c = Math.random() * 10
+      for (const c of [1e-8, 0.01, 0.5, 1, Math.E, 5, 10]) {
         const sol = algorithms.newton(
           t => t * Math.exp(t) - c,
           t => Math.exp(t) * (1 + t),
-          Math.random() * 10
+          1.0
         )
         assert(Math.abs((sol - lambertW0(c)) / sol) < PRECISION)
-      }, LAPS)
+      }
     })
 
     it('should find the solution of exp(x) - 1 = x', () => {
@@ -116,25 +111,22 @@ describe('algorithms', () => {
 
   describe('.neumaier()', () => {
     it('should sum integers', () => {
-      repeat(() => {
-        const n = Math.floor(2 + Math.random() * 100)
+      for (const n of [2, 3, 10, 50, 100]) {
         assert.equal(
           algorithms.neumaier(Array.from({ length: n + 1 }, (d, i) => i)),
           n * (n + 1) / 2
         )
-      }, LAPS)
+      }
     })
 
     it('should sum powers of 5', () => {
-      repeat(() => {
-        const n = Math.floor(2 + Math.random() * 100)
-
+      for (const n of [2, 3, 10, 50, 100]) {
         const a = n * (n + 1) / 2
         assert.equal(
           algorithms.neumaier(Array.from({ length: n + 1 }, (d, i) => i * i * i * i * i)),
           (4 * a * a * a - a * a) / 3
         )
-      }, LAPS)
+      }
     })
 
     it('should not mutate the input array', () => {
@@ -162,12 +154,17 @@ describe('algorithms', () => {
 
   describe('.introselect()', () => {
     it('should select the k-th element across the full index range', () => {
-      repeat(() => {
-        const values = Array.from({ length: 100 }, Math.random)
-        const k = int(0, 99)
+      const testCases = [
+        { values: [5, 3, 1, 4, 2], k: 0 },
+        { values: [5, 3, 1, 4, 2], k: 2 },
+        { values: [5, 3, 1, 4, 2], k: 4 },
+        { values: [9, 4, 7, 2, 8, 1, 5, 3, 6, 0], k: 3 },
+        { values: [9, 4, 7, 2, 8, 1, 5, 3, 6, 0], k: 7 }
+      ]
+      for (const { values, k } of testCases) {
         const sorted = [...values].sort((a, b) => a - b)
         assert(algorithms.introselect([...values], k) === sorted[k])
-      }, LAPS)
+      }
     })
 
     it('should select minimum (k=0) and maximum (k=n-1)', () => {
@@ -179,10 +176,9 @@ describe('algorithms', () => {
 
     it('should select correctly in large arrays (exercises Floyd-Rivest sampling branch)', () => {
       const n = 1000
-      const values = Array.from({ length: n }, Math.random)
+      const values = Array.from({ length: n }, (_, i) => (i * 37 + 13) % n)
       const sorted = [...values].sort((a, b) => a - b)
-      const k = int(0, n - 1)
-      assert.equal(algorithms.introselect([...values], k), sorted[k])
+      assert.equal(algorithms.introselect([...values], 500), sorted[500])
     })
 
     it('should handle arrays with duplicate values', () => {

--- a/test/core.js
+++ b/test/core.js
@@ -153,10 +153,9 @@ describe('core', () => {
     })
 
     it('should return multiple items distributed uniformly', () => {
-      for (let trial = 0; trial < TRIALS; trial++) {
-        const values = ['a', 'b', 'c']
+      const values = ['a', 'b', 'c']
+      for (const k of [1, 2, 5, 10]) {
         const freqs = {}
-        const k = Math.floor(Math.random() * 200 - 100)
         for (let lap = 0; lap < LAPS; lap++) {
           let r = core.choice(values, k)
           if (k < 2) { r = [r] }
@@ -193,9 +192,8 @@ describe('core', () => {
     })
 
     it('should return multiple characters distributed uniformly', () => {
-      for (let trial = 0; trial < TRIALS; trial++) {
-        const string = 'abcdefghijkl51313#^!#?><;!-_=+.,/:{}()'
-        const k = Math.floor(Math.random() * 200 - 100)
+      const string = 'abcdefghijkl51313#^!#?><;!-_=+.,/:{}()'
+      for (const k of [1, 2, 5, 10]) {
         for (let lap = 0; lap < LAPS; lap++) {
           let r = core.char(string, k)
           if (k < 2) { r = [r] }

--- a/test/dependence.js
+++ b/test/dependence.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { repeat, equal } from './test-utils'
+import { equal } from './test-utils'
 import * as dependence from '../src/dependence'
 
 describe('dependence', () => {
@@ -179,13 +179,14 @@ describe('dependence', () => {
     })
 
     it('should return the odds ratio for contingency table of joint probabilities', () => {
-      repeat(() => {
-        const p00 = 0.01 + 0.99 * Math.random()
-        const p01 = 0.01 + 0.99 * Math.random()
-        const p10 = 0.01 + 0.99 * Math.random()
-        const p11 = 0.01 + 0.99 * Math.random()
+      // OR = 1 (independence), OR > 1, OR < 1
+      for (const [p00, p01, p10, p11] of [
+        [0.2, 0.3, 0.1, 0.15],
+        [0.4, 0.1, 0.1, 0.4],
+        [0.1, 0.4, 0.4, 0.1]
+      ]) {
         assert(equal(dependence.oddsRatio(p00, p01, p10, p11), p00 * p11 / (p01 * p10)))
-      })
+      }
     })
   })
 
@@ -336,14 +337,14 @@ describe('dependence', () => {
     })
 
     it('should return Yule\'s Q for a contingency table of joint probabilities', () => {
-      repeat(() => {
-        const p00 = 0.01 + 0.99 * Math.random()
-        const p01 = 0.01 + 0.99 * Math.random()
-        const p10 = 0.01 + 0.99 * Math.random()
-        const p11 = 0.01 + 0.99 * Math.random()
+      for (const [p00, p01, p10, p11] of [
+        [0.2, 0.3, 0.1, 0.15],
+        [0.4, 0.1, 0.1, 0.4],
+        [0.1, 0.4, 0.4, 0.1]
+      ]) {
         assert(equal(dependence.yuleQ(p00, p01, p10, p11),
           (p00 * p11 - p01 * p10) / (p00 * p11 + p01 * p10)))
-      })
+      }
     })
   })
 
@@ -354,14 +355,14 @@ describe('dependence', () => {
     })
 
     it('should return Yule\'s Y for a contingency table of joint probabilities', () => {
-      repeat(() => {
-        const p00 = 0.01 + 0.99 * Math.random()
-        const p01 = 0.01 + 0.99 * Math.random()
-        const p10 = 0.01 + 0.99 * Math.random()
-        const p11 = 0.01 + 0.99 * Math.random()
+      for (const [p00, p01, p10, p11] of [
+        [0.2, 0.3, 0.1, 0.15],
+        [0.4, 0.1, 0.1, 0.4],
+        [0.1, 0.4, 0.4, 0.1]
+      ]) {
         assert(equal(dependence.yuleY(p00, p01, p10, p11),
           (Math.sqrt(p00 * p11) - Math.sqrt(p01 * p10)) / (Math.sqrt(p00 * p11) + Math.sqrt(p01 * p10))))
-      })
+      }
     })
   })
 })

--- a/test/la.js
+++ b/test/la.js
@@ -1,6 +1,5 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
-import { repeat } from './test-utils'
 import * as la from '../src/la'
 
 const EPSILON = 1e-10
@@ -97,15 +96,14 @@ describe('la', () => {
       })
 
       it('should create an nxn identity matrix', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
+        for (const n of [1, 2, 3, 4, 5]) {
           assert.deepEqual(
             new la.Matrix(n),
             new la.Matrix(
               Array.from({ length: n }, (d, i) => Array.from({ length: n }, (dd, j) => i === j ? 1 : 0))
             )
           )
-        }, 100)
+        }
       })
 
       it('should copy another matrix', () => {
@@ -115,106 +113,90 @@ describe('la', () => {
 
     describe('.m()', () => {
       it('should return matrix as an array of arrays', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
-          assert.deepEqual(
-            new la.Matrix(arr).m(),
-            arr
-          )
-        }, 100)
+        for (const arr of [[[5]], [[1, 2], [3, 4]], [[2, 1, 0], [1, 3, 1], [0, 1, 2]], [[1, 0, 0], [0, 1, 0], [0, 0, 1]]]) {
+          assert.deepEqual(new la.Matrix(arr).m(), arr)
+        }
       })
     })
 
     describe('.ij()', () => {
       it('should return the (i, j)-th element', () => {
-        const n = 2 + Math.floor(Math.random() * 10)
-        const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
+        const arr = [[2, 1, 0], [1, 3, 1], [0, 1, 2]]
         const M = new la.Matrix(arr)
-        repeat(() => {
-          const i = Math.floor(Math.random() * n)
-          const j = Math.floor(Math.random() * n)
-          assert.deepEqual(M.ij(i, j), arr[i][j])
-        }, 100)
+        for (let i = 0; i < 3; i++) {
+          for (let j = 0; j < 3; j++) {
+            assert.deepEqual(M.ij(i, j), arr[i][j])
+          }
+        }
       })
 
       it('should set the (i, j)-th element', () => {
-        const n = 2 + Math.floor(Math.random() * 10)
-        const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
+        const arr = [[1, 2], [3, 4]]
         const M = new la.Matrix(arr)
-        repeat(() => {
-          const i = Math.floor(Math.random() * n)
-          const j = Math.floor(Math.random() * n)
-          const s = Math.random()
+        for (const [i, j, s] of [[0, 0, 9], [0, 1, 7], [1, 0, 5], [1, 1, 3]]) {
           M.ij(i, j, s)
           arr[i][j] = s
           assert.deepEqual(M, new la.Matrix(arr))
-        }, 100)
+        }
       })
     })
 
     describe('.t()', () => {
       it('should transpose the matrix', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
+        for (const arr of [[[5]], [[1, 2], [3, 4]], [[2, 1, 0], [1, 3, 1], [0, 1, 2]], [[1, 0, 0], [0, 1, 0], [0, 0, 1]]]) {
           assert.deepEqual(
             new la.Matrix(arr).t(),
             new la.Matrix(arr.map((col, i) => arr.map(row => row[i])))
           )
-        }, 100)
+        }
       })
 
       it('should return original matrix after two transposition', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
+        for (const arr of [[[5]], [[1, 2], [3, 4]], [[2, 1, 0], [1, 3, 1], [0, 1, 2]], [[1, 0, 0], [0, 1, 0], [0, 0, 1]]]) {
           const M = new la.Matrix(arr)
           assert.deepEqual(M.t().t(), M)
-        }, 100)
+        }
       })
     })
 
     describe('.f()', () => {
       it('should apply a function element-wise', () => {
-        const funcs = [Math.sqrt, Math.cos, Math.sin, Math.exp, Math.log]
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
-          const func = funcs[Math.floor(Math.random() * funcs.length)]
-          assert.deepEqual(
-            new la.Matrix(arr).f(func),
-            new la.Matrix(arr.map(d => d.map(dd => func(dd))))
-          )
-        }, 100)
+        for (const arr of [[[5]], [[1, 2], [3, 4]], [[2, 1, 1], [1, 3, 2], [1, 2, 4]]]) {
+          for (const func of [Math.sqrt, Math.cos, Math.sin, Math.exp, Math.log]) {
+            assert.deepEqual(
+              new la.Matrix(arr).f(func),
+              new la.Matrix(arr.map(d => d.map(dd => func(dd))))
+            )
+          }
+        }
       })
     })
 
     describe('.scale()', () => {
       it('should scale a matrix element-wise', () => {
-        repeat(() => {
-          const s = Math.random()
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
-          assert.deepEqual(
-            new la.Matrix(arr).scale(s),
-            new la.Matrix(arr.map(d => d.map(dd => s * dd)))
-          )
-        }, 100)
+        for (const arr of [[[5]], [[1, 2], [3, 4]], [[2, 1, 0], [1, 3, 1], [0, 1, 2]]]) {
+          for (const s of [0, 0.5, 2, -1]) {
+            assert.deepEqual(
+              new la.Matrix(arr).scale(s),
+              new la.Matrix(arr.map(d => d.map(dd => s * dd)))
+            )
+          }
+        }
       })
     })
 
     describe('.add()', () => {
       it('should add two matrices', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr1 = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
-          const arr2 = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
+        for (const [arr1, arr2] of [
+          [[[5]], [[3]]],
+          [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+          [[[2, 1, 0], [1, 3, 1], [0, 1, 2]], [[1, 0, 0], [0, 1, 0], [0, 0, 1]]]
+        ]) {
           assert.deepEqual(
             new la.Matrix(arr1).add(new la.Matrix(arr2)),
             new la.Matrix(arr1.map((d, i) => d.map((dd, j) => dd + arr2[i][j])))
           )
-        }, 100)
+        }
       })
 
       it('should throw on dimension mismatch', () => {
@@ -224,15 +206,16 @@ describe('la', () => {
 
     describe('.sub()', () => {
       it('should subtract two matrices', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr1 = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
-          const arr2 = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
+        for (const [arr1, arr2] of [
+          [[[5]], [[3]]],
+          [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+          [[[2, 1, 0], [1, 3, 1], [0, 1, 2]], [[1, 0, 0], [0, 1, 0], [0, 0, 1]]]
+        ]) {
           assert.deepEqual(
             new la.Matrix(arr1).sub(new la.Matrix(arr2)),
             new la.Matrix(arr1.map((d, i) => d.map((dd, j) => dd - arr2[i][j])))
           )
-        }, 100)
+        }
       })
 
       it('should throw on dimension mismatch', () => {
@@ -242,15 +225,16 @@ describe('la', () => {
 
     describe('.apply()', () => {
       it('should apply a matrix on a vector', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr1 = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
-          const arr2 = Array.from({ length: n }, () => Math.random())
+        for (const [arr1, arr2] of [
+          [[[5]], [3]],
+          [[[1, 2], [3, 4]], [1, -1]],
+          [[[2, 1, 0], [1, 3, 1], [0, 1, 2]], [1, 0, 1]]
+        ]) {
           assert.deepEqual(
             new la.Matrix(arr1).apply(new la.Vector(arr2)),
             new la.Vector(arr1.map(d => arr2.reduce((p, dd, i) => p + dd * d[i], 0)))
           )
-        }, 100)
+        }
       })
 
       it('should throw on dimension mismatch', () => {
@@ -264,34 +248,30 @@ describe('la', () => {
       })
 
       it('should multiply two matrices', () => {
-        // Test uses the Freivalds algorithm
-        const n = 10
-        const M = new la.Matrix(Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random())))
-        const N = new la.Matrix(Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random())))
-        const C = M.mult(N)
-        repeat(() => {
-          const r = new la.Vector(Array.from({ length: n }, () => Math.random() > 0.5 ? 1 : 0))
-          const P = M.apply(N.apply(r)).add(C.apply(r).scale(-1))
-          assert.deepEqual(P.v().reduce((s, d) => s && Math.abs(d) < EPSILON, true), true)
-        }, 100)
+        assert.deepEqual(
+          new la.Matrix([[1, 2], [3, 4]]).mult(new la.Matrix([[5, 6], [7, 8]])),
+          new la.Matrix([[19, 22], [43, 50]])
+        )
+        assert.deepEqual(
+          new la.Matrix([[2, 1, 0], [1, 3, 1], [0, 1, 2]]).mult(new la.Matrix([[1, 2, 0], [0, 1, 1], [1, 0, 2]])),
+          new la.Matrix([[2, 5, 1], [2, 5, 5], [2, 1, 5]])
+        )
       })
     })
 
     describe('.ldl()', () => {
+      const symMatrices = [
+        [[4]],
+        [[4, 1], [1, 3]],
+        [[4, 2, 1], [2, 5, 3], [1, 3, 6]]
+      ]
+
       function perform (test) {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => 0))
-          for (let i = 0; i < n; i++) {
-            arr[i][i] = Math.random()
-            for (let j = 0; j < i; j++) {
-              arr[i][j] = arr[j][i] = Math.random()
-            }
-          }
+        for (const arr of symMatrices) {
           const M = new la.Matrix(arr)
           const { D, L } = M.ldl()
           test(D, L, M)
-        }, 100)
+        }
       }
 
       it('D should be a diagonal matrix', () => {
@@ -346,28 +326,27 @@ describe('la', () => {
 
     describe('.rowSum()', () => {
       it('should return the row sum of the matrix', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
+        for (const arr of [[[5]], [[1, 2], [3, 4]], [[2, 1, 0], [1, 3, 1], [0, 1, 2]], [[1, 0, 0], [0, 1, 0], [0, 0, 1]]]) {
           assert.deepEqual(
             new la.Matrix(arr).rowSum(),
             arr.map(row => row.reduce((sum, d) => sum + d, 0))
           )
-        }, 100)
+        }
       })
     })
 
     describe('.hadamard()', () => {
       it('should return the Hadamard product of two matrices', () => {
-        repeat(() => {
-          const n = 1 + Math.floor(Math.random() * 10)
-          const arr1 = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
-          const arr2 = Array.from({ length: n }, () => Array.from({ length: n }, () => Math.random()))
+        for (const [arr1, arr2] of [
+          [[[5]], [[3]]],
+          [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+          [[[2, 1, 0], [1, 3, 1], [0, 1, 2]], [[1, 0, 0], [0, 1, 0], [0, 0, 1]]]
+        ]) {
           assert.deepEqual(
             new la.Matrix(arr1).hadamard(new la.Matrix(arr2)),
             new la.Matrix(arr1.map((row, i) => row.map((d, j) => d * arr2[i][j])))
           )
-        }, 100)
+        }
       })
 
       it('should throw on dimension mismatch', () => {


### PR DESCRIPTION
Closes #718

## Summary
- Replaces all unseeded `Math.random()` calls in `test/algorithms.js`, `test/la.js`, `test/dependence.js`, and `test/core.js` with deterministic fixed values, making test failures reproducible and ensuring boundary conditions are always exercised.
- Root-finding tests use `c ∈ {1e-8, 0.01, 0.5, 1, Math.E, 5, 10}`; summation uses `n ∈ {2, 3, 10, 50, 100}`; selection uses explicit ranked arrays; matrix tests use fixed 1×1, 2×2, 3×3 fixtures.
- The chandrupatla assertion was corrected from relative to absolute error (`|sol - W0(c)| < 1e-10`) to match the algorithm's bracket-width stopping criterion — the old relative assertion failed for `c=1e-8` where the root is near zero.

## Non-trivial changes
- **`test/algorithms.js:59-61`**: Chandrupatla test assertion changed from relative error `|sol/W0(c) - 1|` to absolute error `|sol - W0(c)|`. The algorithm converges to bracket width `~2·EPS·max(|b|,1)` (absolute), so relative error is not a sound stopping criterion for roots near zero.
- **`test/la.js:262-324`**: LDL test matrices changed from random symmetric (not guaranteed SPD) to known SPD matrices (`[[4]]`, `[[4,1],[1,3]]`, `[[4,2,1],[2,5,3],[1,3,6]]`). The old approach could generate indefinite matrices, making LDL decomposition undefined.
- **`test/la.js:248-493`**: Matrix multiply test replaced Freivalds probabilistic verification with exact expected values hand-computed and verified entry-by-entry.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/algorithms.js`**: `repeat(() => { const c = Math.random() ... }, LAPS)` → `for (const c of [...]) { ... }` for bracket, chandrupatla, newton, neumaier, introselect tests. Removed unused `int` import and `LAPS` constant.
- **`test/la.js`**: All `repeat(() => { const n = ...; const arr = Array.from(...Math.random...) })` replaced with `for (const arr of [...fixed matrices...])` across all Matrix method tests. Removed `repeat` import.
- **`test/dependence.js`**: `repeat(() => { const p00 = 0.01 + 0.99 * Math.random() ... })` replaced with `for (const [p00,p01,p10,p11] of [...])` for oddsRatio, yuleQ, yuleY. Removed `repeat` import.
- **`test/core.js`**: `k = Math.floor(Math.random() * 200 - 100)` replaced with `for (const k of [1, 2, 5, 10])` for choice() and char() tests.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6xSwRtVizTaHnSppxz94b)_