### PR TITLE
Release v1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-06-06
+
 ### Added
 
 - `BetaGeometric` distribution: PMF `f(k;α,β)=B(α+1,β+k−1)/B(α,β)`, support `k∈{1,2,3,…}`. Implements a closed-form O(1) CDF derived via a telescoping Beta-function identity (`F(k)=1−B(α,β+k)/B(α,β)`), replacing the previous `PreComputed` accumulation stub. Accessible as `ran.dist.BetaGeometric(alpha, beta)` (#703).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ranjs",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ranjs",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranjs",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Library for generating various random variables.",
   "keywords": [
     "random",


### PR DESCRIPTION
## Release v1.28.0

### Changes since v1.27.0

a32ca981 Release v1.28.0
13547df1 README precision section updated with test reference value provenance (#569)
7bef004a Replace fixed ±5 integer grid window with adaptive Fisher-info window in fit() (#663)
d6862d2a Solution compounded for #663 — adaptive-fit-window-fisher-info
cd988d32 Complete BetaGeometric: _fitInit, fit test, precision gate, CHANGELOG, README
e5c28313 Expand new-distribution checklist in CLAUDE.md
3f492083 Add precision gate to new-distribution test checklist in CLAUDE.md
f771c6a0 Add BetaNegativeBinomial to precision-discrete.js gate
8d042130 Add _fitInit and fit test for BetaNegativeBinomial
afcf0d68 Add explicit new-distribution checklist to CLAUDE.md
927291b6 Add beta-negative-binomial subpath export to package.json
e7d77c3a BetaNegativeBinomial distribution finalized and exported (#704)
467355ad BetaGeometric subpath export added to package.json
0869f06f BetaGeometric distribution added with closed-form CDF and tests (#703)
e019ec89 Solution compounded for #703 — beta-geometric-telescoping-cdf
cf374b32 Math.random() inputs replaced with deterministic values in algorithm and LA tests
978f65a6 Math.random() calls in dispersion and shape tests replaced with deterministic assertions (#717)
e075e1c0 Tautological Math.random comparisons in location tests replaced with known-value assertions (#715)
e845a60d Math.random() inputs replaced with deterministic grids in hurwitzZeta, lambertW, and marcumQ/P tests
1ed55c1c Math.random() calls in f11 and incomplete-gamma tests replaced with deterministic grids
87739f36 Midpoint CDF regression tests added for BetaBinomial and NegativeHypergeometric (#707)
662435c2 Math.random() inputs replaced with deterministic grids in special.js tests
124e60c9 Vacuous initial accumulator in different-seeds test corrected
6846b71b Unseeded Math.random() in PRNG reproducibility tests replaced with fixed constants (#710)
783ef86d Dead loop in gammaLowerIncomplete convergence test fixed (#709)
0d294fb0 Math.min(1, …) CDF clamp restored for BetaBinomial and NegativeHypergeometric (#701)
480790bf erfcx test tolerance tightened to 1e-14 (#702)
d8f6b9b9 Remove completed items from todo.md
10e5ee5e Widen FisherZ([1,1]) quantile tolerance to 4e-14 (#562)
0297eef4 Distribution test tolerances tightened to 1e-14 (#562)
db9f3c22 Obsolete partial reference generators removed
2f24e0bb mpmath reference value generation script added for all distributions
e7e30960 Secondary cases refVals replaced with mpmath references for HalfGeneralizedNormal–Normal (#559)
9b3a9172 mpmath generation and embed scripts added for Alpha–Gumbel cases refVals
29a483b5 Secondary cases refVals replaced with mpmath references for Alpha–Gumbel
cc80dc43 Reference values updated with mpmath/scipy sources for all discrete distributions (#561)
07d880ef Secondary cases refVals replaced with mpmath references for Pareto–Wigner (#560)
96799063 docs: update README precision section for BetaBinomial/NegativeHypergeometric (#684)
e9719bcb fix(#684): improve logGamma/logBeta precision on small positive-integer arguments

---
*Automated release PR — do not add commits to this branch.*