### PR TITLE
Add analytical moments for log-transformed distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Distribution` base class now exposes `mean()`, `variance()`, `skewness()`, and `kurtosis()` methods. Each returns the theoretical value via a numerical fallback (tanh-sinh quadrature for continuous distributions, compensated summation for discrete) and can be overridden per-distribution with a closed-form formula. `Cauchy` overrides all four to return `NaN` (moments undefined) (#403).
+- Analytical `mean()`, `variance()`, `skewness()`, and `kurtosis()` (excess) for the log-transformed distributions `LogNormal`, `Gilbrat`, `LogGamma`, and `LogLaplace`, overriding the numerical fallback from #403 and verified against mpmath (`mp.dps = 50`). `LogNormal`/`Gilbrat` use the standard log-normal formulas. `LogGamma` (Wolfram exp-gamma parameterization, `X = e^Y + μ − 1` with `Y ~ Gamma(α, β)`) and `LogLaplace` (`X = e^Y` with `Y ~ Laplace(μ, b)`) derive their raw moments from the underlying gamma/Laplace MGF and return `Infinity` for the parameter regimes where a moment diverges (`β ≤ k` and `kb ≥ 1` respectively for the `k`-th moment) (#572).
 
 ## [1.28.0] - 2026-06-06
 

--- a/src/dist/log-gamma.js
+++ b/src/dist/log-gamma.js
@@ -59,6 +59,55 @@ export default class LogGamma extends Gamma {
     return super._cdf(Math.log(x - this.p.mu + 1))
   }
 
+  // Moments of X = e^Y + μ − 1 with Y ~ Gamma(α, rate β) come from the gamma MGF
+  // E[e^{kY}] = (β/(β−k))^α, NOT from digamma/polygamma (those describe ln of a gamma
+  // variate, the opposite transform). The k-th raw moment diverges once β ≤ k.
+  _expMoment (k) {
+    return this.p.beta > k ? Math.pow(this.p.beta / (this.p.beta - k), this.p.alpha) : Infinity
+  }
+
+  /**
+   * @returns {number} The mean, $(\beta/(\beta-1))^\alpha + \mu - 1$; `Infinity` for $\beta \le 1$.
+   */
+  mean () {
+    return this._expMoment(1) + this.p.mu - 1
+  }
+
+  /**
+   * @returns {number} The variance; `Infinity` for $\beta \le 2$.
+   */
+  variance () {
+    const r2 = this._expMoment(2)
+    if (!Number.isFinite(r2)) return Infinity
+    const r1 = this._expMoment(1)
+    return r2 - r1 * r1
+  }
+
+  /**
+   * @returns {number} The skewness; `Infinity` for $\beta \le 3$.
+   */
+  skewness () {
+    const r3 = this._expMoment(3)
+    if (!Number.isFinite(r3)) return Infinity
+    const r1 = this._expMoment(1)
+    const r2 = this._expMoment(2)
+    const v = r2 - r1 * r1
+    return (r3 - 3 * r1 * r2 + 2 * r1 ** 3) / Math.pow(v, 1.5)
+  }
+
+  /**
+   * @returns {number} The excess kurtosis; `Infinity` for $\beta \le 4$.
+   */
+  kurtosis () {
+    const r4 = this._expMoment(4)
+    if (!Number.isFinite(r4)) return Infinity
+    const r1 = this._expMoment(1)
+    const r2 = this._expMoment(2)
+    const r3 = this._expMoment(3)
+    const v = r2 - r1 * r1
+    return (r4 - 4 * r1 * r3 + 6 * r1 * r1 * r2 - 3 * r1 ** 4) / (v * v) - 3
+  }
+
   static _fitInit (data) {
     // log(x−μ+1) ~ Gamma(α,β) with μ=0: gamma MOM on log(x+1) seeds the Gamma parameters
     const n = data.length

--- a/src/dist/log-laplace.js
+++ b/src/dist/log-laplace.js
@@ -49,6 +49,54 @@ export default class LogLaplace extends Laplace {
       : Math.exp(this.p.mu - this.p.b * Math.log(2 - 2 * p))
   }
 
+  // Moments of X = e^Y with Y ~ Laplace(μ, b) come from the Laplace MGF
+  // E[e^{kY}] = e^{μk}/(1 − b²k²), which diverges once kb ≥ 1.
+  _expMoment (k) {
+    return k * this.p.b < 1 ? Math.exp(this.p.mu * k) / (1 - this.p.b * this.p.b * k * k) : Infinity
+  }
+
+  /**
+   * @returns {number} The mean, $e^\mu/(1 - b^2)$; `Infinity` for $b \ge 1$.
+   */
+  mean () {
+    return this._expMoment(1)
+  }
+
+  /**
+   * @returns {number} The variance; `Infinity` for $b \ge 1/2$.
+   */
+  variance () {
+    const m2 = this._expMoment(2)
+    if (!Number.isFinite(m2)) return Infinity
+    const m1 = this._expMoment(1)
+    return m2 - m1 * m1
+  }
+
+  /**
+   * @returns {number} The skewness; `Infinity` for $b \ge 1/3$.
+   */
+  skewness () {
+    const m3 = this._expMoment(3)
+    if (!Number.isFinite(m3)) return Infinity
+    const m1 = this._expMoment(1)
+    const m2 = this._expMoment(2)
+    const v = m2 - m1 * m1
+    return (m3 - 3 * m1 * m2 + 2 * m1 ** 3) / Math.pow(v, 1.5)
+  }
+
+  /**
+   * @returns {number} The excess kurtosis; `Infinity` for $b \ge 1/4$.
+   */
+  kurtosis () {
+    const m4 = this._expMoment(4)
+    if (!Number.isFinite(m4)) return Infinity
+    const m1 = this._expMoment(1)
+    const m2 = this._expMoment(2)
+    const m3 = this._expMoment(3)
+    const v = m2 - m1 * m1
+    return (m4 - 4 * m1 * m3 + 6 * m1 * m1 * m2 - 3 * m1 ** 4) / (v * v) - 3
+  }
+
   static _fitInit (data) {
     // log(Y) ~ Laplace(mu, b): median is MOM for location; median absolute deviation / ln(2) for scale
     // because median(|X-mu|) = b*ln(2) for Laplace, so b = MAD / ln(2)

--- a/src/dist/log-normal.js
+++ b/src/dist/log-normal.js
@@ -49,6 +49,42 @@ export default class LogNormal extends Normal {
     return Math.exp(this.p.mu + this.c.sigmaRoot2 * erfinv(2 * p - 1))
   }
 
+  // Closed-form moments override the inherited Normal moments (which describe the underlying
+  // log scale, not the exponentiated variate). All four are finite for every (μ, σ).
+  /**
+   * @returns {number} The mean, $e^{\mu + \sigma^2/2}$.
+   */
+  mean () {
+    return Math.exp(this.p.mu + this.p.sigma * this.p.sigma / 2)
+  }
+
+  /**
+   * @returns {number} The variance, $(e^{\sigma^2} - 1)\,e^{2\mu + \sigma^2}$.
+   */
+  variance () {
+    const s2 = this.p.sigma * this.p.sigma
+    // expm1 keeps full precision of e^{σ²} − 1 for small σ, where e^{σ²} rounds to exactly 1.
+    return Math.expm1(s2) * Math.exp(2 * this.p.mu + s2)
+  }
+
+  /**
+   * @returns {number} The skewness, $(e^{\sigma^2} + 2)\sqrt{e^{\sigma^2} - 1}$.
+   */
+  skewness () {
+    const em1 = Math.expm1(this.p.sigma * this.p.sigma)
+    return (em1 + 3) * Math.sqrt(em1)
+  }
+
+  /**
+   * @returns {number} The excess kurtosis, $e^{4\sigma^2} + 2e^{3\sigma^2} + 3e^{2\sigma^2} - 6$.
+   */
+  kurtosis () {
+    const s2 = this.p.sigma * this.p.sigma
+    // The constants sum to 1+2+3−6=0, so an expm1 form cancels the −6 exactly and stays
+    // accurate as σ→0 (where the excess kurtosis vanishes) instead of differencing near 6.
+    return Math.expm1(4 * s2) + 2 * Math.expm1(3 * s2) + 3 * Math.expm1(2 * s2)
+  }
+
   static get _fitInitIsExact () {
     // _fitInit returns the exact closed-form MLE, so fit() skips the optimizer (ADR-0016).
     return true

--- a/test/dist.js
+++ b/test/dist.js
@@ -617,6 +617,131 @@ describe('dist', () => {
         // Truncating to ±1σ removes tails, giving negative excess kurtosis
         assert(new dist.TruncatedNormal(0, 1, -1, 1).kurtosis() < 0)
       })
+
+      // LogNormal analytical moments (mpmath dps=50 reference values)
+      it('LogNormal(0,0.5) moments should match closed form', () => {
+        const d = new dist.LogNormal(0, 0.5)
+        assert(Math.abs(d.mean() - 1.1331484530668263) < 1e-14)
+        assert(Math.abs(d.variance() - 0.3646958540123867) < 1e-14)
+        assert(Math.abs(d.skewness() - 1.7501896550697182) < 1e-13)
+        assert(Math.abs(d.kurtosis() - 5.898445673784779) < 1e-12)
+      })
+
+      it('LogNormal(1,0.25) moments should match closed form', () => {
+        const d = new dist.LogNormal(1, 0.25)
+        assert(Math.abs(d.mean() - 2.8045693562372267) < 1e-13)
+        assert(Math.abs(d.variance() - 0.5072882141823729) < 1e-13)
+        assert(Math.abs(d.skewness() - 0.778251635797484) < 1e-13)
+        assert(Math.abs(d.kurtosis() - 1.095931274730182) < 1e-12)
+      })
+
+      it('LogNormal(0,1e-8) variance should stay ≈ σ² (expm1 avoids cancellation)', () => {
+        // Math.exp(1e-16) rounds to exactly 1, so a naive e^{σ²}−1 would return 0
+        const v = new dist.LogNormal(0, 1e-8).variance()
+        assert(Math.abs(v - 1.0000000000000001e-16) < 1e-30)
+      })
+
+      // Gilbrat = LogNormal(0,1); inherits the log-normal formulas
+      it('Gilbrat moments should match LogNormal(0,1) closed form', () => {
+        const d = new dist.Gilbrat()
+        assert(Math.abs(d.mean() - 1.6487212707001282) < 1e-13)
+        assert(Math.abs(d.variance() - 4.670774270471605) < 1e-13)
+        assert(Math.abs(d.skewness() - 6.1848771386325545) < 1e-12)
+        assert(Math.abs(d.kurtosis() - 110.93639217631153) < 1e-10)
+      })
+
+      // LogGamma (Wolfram exp-gamma param: X = exp(Y)+μ−1, Y~Gamma(α, rate β))
+      it('LogGamma(2,5,0) moments should match the gamma-MGF closed form', () => {
+        const d = new dist.LogGamma(2, 5, 0)
+        assert(Math.abs(d.mean() - 0.5625) < 1e-14)
+        assert(Math.abs(d.variance() - 0.3363715277777778) < 1e-14)
+        assert(Math.abs(d.skewness() - 4.400909271598007) < 1e-12)
+        assert(Math.abs(d.kurtosis() - 74.30035379812695) < 1e-11)
+      })
+
+      it('LogGamma(1.5,6,2) moments should match the gamma-MGF closed form', () => {
+        const d = new dist.LogGamma(1.5, 6, 2)
+        assert(Math.abs(d.mean() - 2.3145341380123985) < 1e-14)
+        assert(Math.abs(d.variance() - 0.10911730708738357) < 1e-14)
+        assert(Math.abs(d.skewness() - 3.512226133248932) < 1e-12)
+        assert(Math.abs(d.kurtosis() - 31.701516341694518) < 1e-11)
+      })
+
+      it('LogGamma mean should diverge for β ≤ 1', () => {
+        assert(new dist.LogGamma(2, 1, 0).mean() === Infinity)
+        assert(new dist.LogGamma(2, 0.5, 0).mean() === Infinity)
+      })
+
+      it('LogGamma(2,2,2) should diverge: finite mean, infinite higher moments', () => {
+        const d = new dist.LogGamma(2, 2, 2)
+        assert(Math.abs(d.mean() - 5) < 1e-14)
+        assert(d.variance() === Infinity)
+        assert(d.skewness() === Infinity)
+        assert(d.kurtosis() === Infinity)
+      })
+
+      it('LogGamma(2,2.5,0): finite variance but skewness/kurtosis diverge (2 < β ≤ 3)', () => {
+        const d = new dist.LogGamma(2, 2.5, 0)
+        assert(Math.abs(d.mean() - 1.7777777777777777) < 1e-14)
+        assert(Math.abs(d.variance() - 17.28395061728395) < 1e-12)
+        assert(d.skewness() === Infinity)
+        assert(d.kurtosis() === Infinity)
+      })
+
+      it('LogGamma(2,3.5,0) should have finite skewness but infinite kurtosis', () => {
+        const d = new dist.LogGamma(2, 3.5, 0)
+        assert(Math.abs(d.mean() - 0.96) < 1e-14)
+        assert(Math.abs(d.variance() - 1.6028444444444445) < 1e-13)
+        assert(Math.abs(d.skewness() - 15.791857713882274) < 1e-11)
+        assert(d.kurtosis() === Infinity)
+      })
+
+      // LogLaplace (X = exp(Y), Y~Laplace(μ, b); moments via the Laplace MGF)
+      it('LogLaplace(0,0.2) moments should match the Laplace-MGF closed form', () => {
+        const d = new dist.LogLaplace(0, 0.2)
+        assert(Math.abs(d.mean() - 1.0416666666666667) < 1e-14)
+        assert(Math.abs(d.variance() - 0.10540674603174603) < 1e-14)
+        assert(Math.abs(d.skewness() - 3.0046141326124665) < 1e-13)
+        assert(Math.abs(d.kurtosis() - 40.717785467128024) < 1e-12)
+      })
+
+      it('LogLaplace(0.5,0.2) moments should match the Laplace-MGF closed form', () => {
+        const d = new dist.LogLaplace(0.5, 0.2)
+        assert(Math.abs(d.mean() - 1.7174179903126334) < 1e-13)
+        assert(Math.abs(d.variance() - 0.2865252423350928) < 1e-13)
+        // skewness/kurtosis depend only on b, so they match the μ=0 case
+        assert(Math.abs(d.skewness() - 3.0046141326124665) < 1e-13)
+        assert(Math.abs(d.kurtosis() - 40.717785467128024) < 1e-12)
+      })
+
+      it('LogLaplace mean should diverge for b ≥ 1', () => {
+        assert(new dist.LogLaplace(0, 1).mean() === Infinity)
+        assert(new dist.LogLaplace(0, 2).mean() === Infinity)
+      })
+
+      it('LogLaplace(0,0.4): finite mean/variance but skewness/kurtosis diverge (1/3 ≤ b < 1/2)', () => {
+        const d = new dist.LogLaplace(0, 0.4)
+        assert(Math.abs(d.mean() - 1.1904761904761905) < 1e-14)
+        assert(Math.abs(d.variance() - 1.3605442176870748) < 1e-13)
+        assert(d.skewness() === Infinity)
+        assert(d.kurtosis() === Infinity)
+      })
+
+      it('LogLaplace(0,0.5) variance should diverge (b ≥ 1/2)', () => {
+        const d = new dist.LogLaplace(0, 0.5)
+        assert(Math.abs(d.mean() - 1.3333333333333333) < 1e-14)
+        assert(d.variance() === Infinity)
+        assert(d.skewness() === Infinity)
+        assert(d.kurtosis() === Infinity)
+      })
+
+      it('LogLaplace(0,0.3) kurtosis should diverge (b ≥ 1/4) but skewness finite', () => {
+        const d = new dist.LogLaplace(0, 0.3)
+        assert(Math.abs(d.mean() - 1.098901098901099) < 1e-14)
+        assert(Math.abs(d.variance() - 0.35491637483395727) < 1e-13)
+        assert(Math.abs(d.skewness() - 13.08208855547686) < 1e-11)
+        assert(d.kurtosis() === Infinity)
+      })
     })
 
     describe('.fit()', () => {


### PR DESCRIPTION
Closes #572

## Summary
- Adds closed-form `mean()`, `variance()`, `skewness()`, and `kurtosis()` (excess) overrides to `LogNormal`, `Gilbrat`, `LogGamma`, and `LogLaplace`, replacing the slow numerical fallback from #403. Before this change `LogNormal`/`Gilbrat` silently inherited `Normal`'s moments (returning the *underlying* normal's mean/variance), which were wrong for the exponentiated variate.
- `LogGamma` and `LogLaplace` derive their raw moments from the underlying gamma/Laplace **moment-generating function** and return `Infinity` in the parameter regimes where a moment diverges.
- All values verified against mpmath at `mp.dps = 50`.

## Non-trivial changes

- **`src/dist/log-normal.js`**: Standard log-normal moments — `mean = e^{μ+σ²/2}`, `var = (e^{σ²}−1)e^{2μ+σ²}`, `skew = (e^{σ²}+2)√(e^{σ²}−1)`, excess `kurt = e^{4σ²}+2e^{3σ²}+3e^{2σ²}−6`. Uses `Math.expm1` throughout to avoid catastrophic cancellation as σ→0 (a naïve `e^{σ²}−1` returns 0 once `σ ≲ 1e-8`; the `−6` in kurtosis is cancelled exactly since the constants sum to 0). `Gilbrat` inherits these unchanged as `LogNormal(0,1)`.
- **`src/dist/log-gamma.js`**: Wolfram exp-gamma parameterization `X = e^Y + μ − 1`, `Y ~ Gamma(α, rate β)`. Raw moments from the gamma MGF `E[e^{kY}] = (β/(β−k))^α` via a private `_expMoment(k)` helper; central moments reconstructed from raw moments (shift-invariant, so the `μ−1` offset only enters the mean). Returns `Infinity` for `β ≤ k`. **Note:** the issue text suggested digamma/polygamma formulas — those describe `ln(Gamma)`, the opposite transform; the MGF form is correct for this file's `exp(Gamma)` parameterization (the issue said to adjust for it).
- **`src/dist/log-laplace.js`**: `X = e^Y`, `Y ~ Laplace(μ, b)`. Raw moments from the Laplace MGF `E[e^{kY}] = e^{μk}/(1−b²k²)`; returns `Infinity` for `kb ≥ 1`. Skewness/kurtosis depend only on `b`.
- **`test/dist.js`**: mpmath-referenced moment assertions for all four distributions, including the full divergence staircase (mean at `β≤1` / `b≥1`; variance, skewness, kurtosis boundaries) and a small-σ regression test locking in the `expm1` precision fix.

No ADR added: per `CLAUDE.md`, overriding base-class methods with closed-form formulas is an implementation-technique choice (no public-API, export-structure, or convention change), which is explicitly out of ADR scope.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu8rd6WM5xv5ZjQZmBKsSw)_