### PR TITLE
Add CDF formulas to JSDoc for all 141 distributions

### DIFF
--- a/src/dist/alpha.js
+++ b/src/dist/alpha.js
@@ -10,6 +10,10 @@ import { erf, erfinv } from '../special'
  * functions of the [normal distribution]{@link #dist.Normal}.
  * Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta) = \frac{\Phi(\alpha - \beta/x)}{\Phi(\alpha)}$
+ *
  * @class Alpha
  * @memberof ran.dist
  * @see Johnson, Kotz, and Balakrishnan, Continuous Univariate Distributions Vol. 1, 2nd ed., John Wiley and Sons, 1994, p. 173.

--- a/src/dist/anglit.js
+++ b/src/dist/anglit.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  * where $\mu \in \mathbb{R}$ and $\beta > 0$.
  * Support: $x \in \Big\[\mu-\frac{\beta \pi}{4}, \mu + \frac{\beta \pi}{4}\Big\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \beta) = \sin^2\!\left(\frac{x - \mu}{\beta} + \frac{\pi}{4}\right)$
+ *
  * @class Anglit
  * @memberof ran.dist
  * @see M. King, Statistics for Process Control Engineers, John Wiley and Sons, 2017, p. 472.

--- a/src/dist/arcsine.js
+++ b/src/dist/arcsine.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  * where $a, b \in \mathbb{R}$ and $a < b$.
  * Support: $x \in \[a, b\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b) = \frac{2}{\pi}\arcsin\!\left(\sqrt{\frac{x - a}{b - a}}\right)$
+ *
  * @class Arcsine
  * @memberof ran.dist
  * @see W. Feller, An Introduction to Probability Theory and Its Applications Vol. 2, 2nd ed., John Wiley and Sons, 1991, p. 79.

--- a/src/dist/balding-nichols.js
+++ b/src/dist/balding-nichols.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  * where $\alpha = \frac{1 - F}{F} p$, $\beta = \frac{1 - F}{F} (1 - p)$ and $F, p \in (0, 1)$.
  * Support: $x \in (0, 1)$. It is simply a re-parametrization of the [beta distribution]{@link #dist.Beta}.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; F, p) = I_x\!\left(\frac{(1-F)p}{F},\, \frac{(1-F)(1-p)}{F}\right)$
+ *
  * @class BaldingNichols
  * @memberof ran.dist
  * @see D.J. Balding and R.A. Nichols, "A method for quantifying differentiation between populations at multi-allelic loci and its implications for investigating identity and paternity", Genetica 96, 3–12, 1995.

--- a/src/dist/bates.js
+++ b/src/dist/bates.js
@@ -10,6 +10,10 @@ import Distribution from './_distribution'
  * with $z = \frac{x - a}{b - a}$, $n \in \mathbb{N}^+$ and $a, b \in \mathbb{R}, a < b$.
  * Support: $x \in \[a, b\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; n, a, b) = F_{\mathrm{IH}}\!\left(n\cdot\frac{x - a}{b - a};\, n\right)$
+ *
  * @class Bates
  * @memberof ran.dist
  * @constructor

--- a/src/dist/benini.js
+++ b/src/dist/benini.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $\alpha, \beta, \sigma > 0$. Support: $x \in (\sigma, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta, \sigma) = 1 - e^{-\alpha y - \beta y^2}$
+ *
  * @class Benini
  * @memberof ran.dist
  * @constructor

--- a/src/dist/benktander-ii.js
+++ b/src/dist/benktander-ii.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $a > 0$ and $b \in (0, 1]$. Support: $x \in [1, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b) = 1 - x^{b-1} e^{a(1 - x^b)/b}$
+ *
  * @class BenktanderII
  * @memberof ran.dist
  * @constructor

--- a/src/dist/bernoulli.js
+++ b/src/dist/bernoulli.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * where $p \in \[0, 1\]$. Support: $k \in \\{0, 1\\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; p) = \begin{cases} 0 & k < 0 \\ 1 - p & 0 \le k < 1 \\ 1 & k \ge 1 \end{cases}$
+ *
  * @class Bernoulli
  * @memberof ran.dist
  * @constructor

--- a/src/dist/beta-binomial.js
+++ b/src/dist/beta-binomial.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $n \in \mathbb{N}_0$ and $\alpha, \beta > 0$. Support: $k \in \{0, ..., n\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; n, \alpha, \beta) = \sum_{i=0}^{k} \binom{n}{i} \frac{B(i + \alpha,\, n - i + \beta)}{B(\alpha, \beta)}$
+ *
  * @class BetaBinomial
  * @memberof ran.dist
  * @constructor

--- a/src/dist/beta-geometric.js
+++ b/src/dist/beta-geometric.js
@@ -9,6 +9,10 @@ import rBeta from './_beta'
  *
  * with $\alpha, \beta > 0$. Support: $k \in \{1, 2, 3, \ldots\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \alpha, \beta) = 1 - \frac{B(\alpha, \beta + k)}{B(\alpha, \beta)}$
+ *
  * @class BetaGeometric
  * @memberof ran.dist
  * @param {number} alpha First shape parameter.

--- a/src/dist/beta-negative-binomial.js
+++ b/src/dist/beta-negative-binomial.js
@@ -11,6 +11,10 @@ import poisson from './_poisson'
  *
  * with $r \in \mathbb{N}^+$ and $\alpha, \beta > 0$. Support: $k \in \mathbb{N}_0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; r, \alpha, \beta) = \sum_{i=0}^{k} \binom{r + i - 1}{i} \frac{B(\alpha + r,\, \beta + i)}{B(\alpha, \beta)}$
+ *
  * @class BetaNegativeBinomial
  * @memberof ran.dist
  * @constructor

--- a/src/dist/beta-prime.js
+++ b/src/dist/beta-prime.js
@@ -10,6 +10,10 @@ import Beta from './beta'
  * with $\alpha, \beta > 0$ and $\mathrm{B}(x, y)$ is the beta function.
  * Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta) = I_{x/(1+x)}(\alpha, \beta)$
+ *
  * @class BetaPrime
  * @memberof ran.dist
  * @constructor

--- a/src/dist/beta-rectangular.js
+++ b/src/dist/beta-rectangular.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $\alpha, \beta > 0$, $\theta \in \[0, 1\]$, $a, b \in \mathbb{R}$, $a < b$ and $\mathrm{B}(x, y)$ is the beta function. Support: $x \in \[a, b\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta, \theta, a, b) = \theta\, I_z(\alpha, \beta) + (1 - \theta)\, z$
+ *
  * @class BetaRectangular
  * @memberof ran.dist
  * @constructor

--- a/src/dist/beta.js
+++ b/src/dist/beta.js
@@ -10,6 +10,10 @@ import Distribution from './_distribution'
  * with $\alpha, \beta > 0$ and $\mathrm{B}(\alpha, \beta)$ is the beta function.
  * Support: $x \in (0, 1)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta) = I_x(\alpha, \beta)$
+ *
  * @class Beta
  * @memberof ran.dist
  * @constructor

--- a/src/dist/binomial.js
+++ b/src/dist/binomial.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $n \in \mathbb{N}_0$ and $p \in \[0, 1\]$. Support: $k \in \{0, ..., n\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; n, p) = I_{1-p}(n - k,\, k + 1)$
+ *
  * @class Binomial
  * @memberof ran.dist
  * @constructor

--- a/src/dist/birnbaum-saunders.js
+++ b/src/dist/birnbaum-saunders.js
@@ -9,6 +9,10 @@ import { erfinv } from '../special'
  *
  * with $\mu \in \mathbb{R}$, $\beta, \gamma > 0$, $z = \sqrt{\frac{x - \mu}{\beta}}$ and $\phi(x)$ is the probability density function of the standard [normal distribution]{@link #dist.Normal}. Support: $x \in (\mu, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \beta, \gamma) = \Phi\!\left(\frac{1}{\gamma}\left(\sqrt{\frac{x - \mu}{\beta}} - \sqrt{\frac{\beta}{x - \mu}}\right)\right)$
+ *
  * @class BirnbaumSaunders
  * @memberof ran.dist
  * @constructor

--- a/src/dist/borel-tanner.js
+++ b/src/dist/borel-tanner.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * where $\mu \in \[0, 1\]$ and $n \in \mathbb{N}^+$. Support: $k \ge n$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \mu, n) = \sum_{i=n}^{k} \frac{n}{i} \frac{(\mu i)^{i-n} e^{-\mu i}}{(i - n)!}$
+ *
  * @class BorelTanner
  * @memberof ran.dist
  * @constructor

--- a/src/dist/borel.js
+++ b/src/dist/borel.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * where $\mu \in \[0, 1\]$. Support: $k \in \mathbb{N}^+$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \mu) = \sum_{i=1}^{k} \frac{(\mu i)^{i-1} e^{-\mu i}}{i!}$
+ *
  * @class Borel
  * @memberof ran.dist
  * @constructor

--- a/src/dist/bounded-pareto.js
+++ b/src/dist/bounded-pareto.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $L, H > 0$, $H > L$ and $\alpha > 0$. Support: $x \in \[L, H\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; L, H, \alpha) = \frac{1 - (L/x)^{\alpha}}{1 - (L/H)^{\alpha}}$
+ *
  * @class BoundedPareto
  * @memberof ran.dist
  * @constructor

--- a/src/dist/bradford.js
+++ b/src/dist/bradford.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $c > 0$. Support: $x \in \[0, 1\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; c) = \frac{\ln(1 + cx)}{\ln(1 + c)}$
+ *
  * @class Bradford
  * @memberof ran.dist
  * @constructor

--- a/src/dist/burr.js
+++ b/src/dist/burr.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $c, k > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; c, k) = 1 - (1 + x^c)^{-k}$
+ *
  * @class Burr
  * @memberof ran.dist
  * @constructor

--- a/src/dist/categorical.js
+++ b/src/dist/categorical.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * where $w_k > 0$. Support: $k \in \mathbb{N}_0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \mathbf{w}) = \frac{\sum_{i=0}^{k} w_i}{\sum_{j} w_j}$
+ *
  * @class Categorical
  * @memberof ran.dist
  * @constructor

--- a/src/dist/cauchy.js
+++ b/src/dist/cauchy.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * where $x_0 \in \mathbb{R}$ and $\gamma > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; x_0, \gamma) = \frac{1}{2} + \frac{1}{\pi}\arctan\!\left(\frac{x - x_0}{\gamma}\right)$
+ *
  * @class Cauchy
  * @memberof ran.dist
  * @constructor

--- a/src/dist/champernowne.js
+++ b/src/dist/champernowne.js
@@ -8,6 +8,12 @@ import Distribution from './_distribution'
  * with normalization constant $C = \frac{\alpha\sqrt{1 - \lambda^2}}{2\arccos(\lambda)}$,
  * where $\alpha > 0$, $0 \le \lambda < 1$, and $x_0 \in \mathbb{R}$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \lambda, x_0) = \frac{\arctan(k \tanh(\alpha(x - x_0)/2)) + \arctan(k)}{2\arctan(k)}$
+ *
+ * where $k = \sqrt{(1 - \lambda)/(1 + \lambda)}$
+ *
  * @class Champernowne
  * @memberof ran.dist
  * @constructor

--- a/src/dist/chi.js
+++ b/src/dist/chi.js
@@ -9,6 +9,12 @@ import Chi2 from './chi2'
  *
  * where $k \in \mathbb{N}^+$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; k) = P(k/2,\, x^2/2)$
+ *
+ * where $P(a,x)$ is the regularized lower incomplete gamma function
+ *
  * @class Chi
  * @memberof ran.dist
  * @constructor

--- a/src/dist/chi2.js
+++ b/src/dist/chi2.js
@@ -10,6 +10,10 @@ import Distribution from './_distribution'
  *
  * where $k \in \mathbb{N}^+$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; k) = P(k/2,\, x/2)$
+ *
  * @class Chi2
  * @memberof ran.dist
  * @constructor

--- a/src/dist/conway-maxwell-poisson.js
+++ b/src/dist/conway-maxwell-poisson.js
@@ -9,6 +9,12 @@ import PreComputed from './_pre-computed'
  * where $\lambda > 0$, $\nu > 0$, and $Z(\lambda, \nu) = \sum_{j=0}^\infty \frac{\lambda^j}{(j!)^\nu}$.
  * Support: $k \in \mathbb{N}_0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \lambda, \nu) = \sum_{i=0}^{k} \frac{\lambda^i}{(i!)^{\nu} Z(\lambda, \nu)}$
+ *
+ * where $Z(\lambda, \nu) = \sum_{j=0}^{\infty} \frac{\lambda^j}{(j!)^{\nu}}$ is the normalizing constant
+ *
  * @class ConwayMaxwellPoisson
  * @memberof ran.dist
  * @constructor

--- a/src/dist/dagum.js
+++ b/src/dist/dagum.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $p, a, b > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; p, a, b) = \left(1 + \left(\frac{x}{b}\right)^{-a}\right)^{-p}$
+ *
  * @class Dagum
  * @memberof ran.dist
  * @constructor

--- a/src/dist/davis.js
+++ b/src/dist/davis.js
@@ -23,6 +23,10 @@ const B2K_OVER_FACT = (() => {
  *
  * with $\mu > 0$, $b > 0$, and $n > 1$. Support: $x \in (\mu, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, b, n) = \int_{\mu}^{x} f(t;\, \mu, b, n)\, \mathrm{d}t$
+ *
  * @class Davis
  * @memberof ran.dist
  * @constructor

--- a/src/dist/degenerate.js
+++ b/src/dist/degenerate.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * where $x_0 \in \mathbb{R}$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; x_0) = \begin{cases} 0 & x < x_0 \\ 1 & x \ge x_0 \end{cases}$
+ *
  * @class Degenerate
  * @memberof ran.dist
  * @constructor

--- a/src/dist/delaporte.js
+++ b/src/dist/delaporte.js
@@ -11,6 +11,10 @@ import PreComputed from './_pre-computed'
  *
  * with $\alpha, \beta, \lambda > 0$. Support: $k \in \mathbb{N}_0$. For $\lambda = 0$, it is the [negative binomial]{@link #dist.NegativeBinomial}, and for $\alpha = \beta = 0$ it is the [Poisson distribution]{@link #dist.Poisson}. Note that these special cases are not covered by this class. For these distributions, please refer to the corresponding generators.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \alpha, \beta, \lambda) = \sum_{i=0}^{k} f(i;\, \alpha, \beta, \lambda)$
+ *
  * @class Delaporte
  * @memberof ran.dist
  * @constructor

--- a/src/dist/discrete-uniform.js
+++ b/src/dist/discrete-uniform.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $x_\mathrm{min}, x_\mathrm{max} \in \mathbb{Z}$ and $x_\mathrm{min} < x_\mathrm{max}$. Support: $k \in \{x_\mathrm{min}, ..., x_\mathrm{max}\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; x_{\min}, x_{\max}) = \frac{\lfloor k \rfloor - x_{\min} + 1}{x_{\max} - x_{\min} + 1}$
+ *
  * @class DiscreteUniform
  * @memberof ran.dist
  * @constructor

--- a/src/dist/discrete-weibull.js
+++ b/src/dist/discrete-weibull.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $q \in (0, 1)$ and $\beta > 0$. Support: $k \in \mathbb{N}_0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; q, \beta) = 1 - q^{(k+1)^{\beta}}$
+ *
  * @class DiscreteWeibull
  * @memberof ran.dist
  * @constructor

--- a/src/dist/double-gamma.js
+++ b/src/dist/double-gamma.js
@@ -9,6 +9,10 @@ import Gamma from './gamma'
  *
  * where $\alpha, \beta > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta) = \begin{cases} \tfrac{1}{2}\bigl(1 - P(\alpha,\, \beta|x|)\bigr) & x \le 0 \\ \tfrac{1}{2}\bigl(1 + P(\alpha,\, \beta|x|)\bigr) & x > 0 \end{cases}$
+ *
  * @class DoubleGamma
  * @memberof ran.dist
  * @constructor

--- a/src/dist/double-weibull.js
+++ b/src/dist/double-weibull.js
@@ -7,6 +7,10 @@ import Weibull from './weibull'
  *
  * with $\lambda, k > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \lambda, k) = \begin{cases} \tfrac{1}{2} e^{-(|x|/\lambda)^k} & x \le 0 \\ 1 - \tfrac{1}{2} e^{-(|x|/\lambda)^k} & x > 0 \end{cases}$
+ *
  * @class DoubleWeibull
  * @memberof ran.dist
  * @constructor

--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -14,6 +14,10 @@ import Distribution from './_distribution'
  * where $\alpha, \beta > 0$ and $\lambda_1, \lambda_2 \ge 0$. Support: $x \in (0, 1)$.
  * Formula from C. Orsi. New insights into non-central beta distributions. arXiv:1706.08557, 2017, Eq. (21).
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta, \lambda_1, \lambda_2) = e^{-(\lambda_1 + \lambda_2)/2} \sum_{k=0}^{\infty} \sum_{l=0}^{\infty} \frac{(\lambda_1/2)^k}{k!} \frac{(\lambda_2/2)^l}{l!} I_x(\alpha + k,\, \beta + l)$
+ *
  * @class DoublyNoncentralBeta
  * @memberof ran.dist
  * @constructor

--- a/src/dist/doubly-noncentral-chi2.js
+++ b/src/dist/doubly-noncentral-chi2.js
@@ -16,6 +16,10 @@ import powell from '../algorithms/powell'
  * identifiable from data. After calling `fit()`, the individual parameters are
  * an arbitrary symmetric split of the fitted sums; do not interpret them individually.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; k, \lambda_1, \lambda_2) = F_{\chi^2_{\mathrm{nc}}}(x;\, k,\, \lambda_1 + \lambda_2)$
+ *
  * @class DoublyNoncentralChi2
  * @memberof ran.dist
  * @constructor

--- a/src/dist/doubly-noncentral-f.js
+++ b/src/dist/doubly-noncentral-f.js
@@ -8,6 +8,10 @@ import DoublyNoncentralBeta from './doubly-noncentral-beta'
  * where $d_1, d_2 \in \mathbb{N}^+$ and $\lambda_1, \lambda_2 \ge 0$. Support: $x > 0$.
  * Formula from M. L. Tiku. Series expansions for the doubly non-central F-distribution. *Australian Journal of Statistics*, 7(2):78–89, 1965.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; d_1, d_2, \lambda_1, \lambda_2) = F_{\mathrm{DNB}}\!\left(\frac{d_1 x}{d_2 + d_1 x};\, \tfrac{d_1}{2}, \tfrac{d_2}{2}, \lambda_1, \lambda_2\right)$
+ *
  * @class DoublyNoncentralF
  * @memberof ran.dist
  * @constructor

--- a/src/dist/doubly-noncentral-t.js
+++ b/src/dist/doubly-noncentral-t.js
@@ -14,6 +14,10 @@ import NoncentralT from './noncentral-t'
  * where $\nu \in \mathbb{N}^+$, $\mu \in \mathbb{R}$ and $\theta > 0$. Support: $x \in \mathbb{R}$.
  * Implementation is based on Section 10.4.1.2 in Marc S. Paolella. Intermediate Probability: A Computational Approach. (2007)
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \nu, \mu, \theta) = e^{-\theta/2} \sum_{j=0}^{\infty} \frac{(\theta/2)^j}{j!}\, F_{t_{\mathrm{nc}}}(x;\, \nu + 2j,\, \mu)$
+ *
  * @class DoublyNoncentralT
  * @memberof ran.dist
  * @constructor

--- a/src/dist/erlang.js
+++ b/src/dist/erlang.js
@@ -11,6 +11,10 @@ import Distribution from './_distribution'
  *
  * where $k \in \mathbb{N}^+$ and $\lambda > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; k, \lambda) = P(k,\, \lambda x)$
+ *
  * @class Erlang
  * @memberof ran.dist
  * @constructor

--- a/src/dist/exponential-logarithmic.js
+++ b/src/dist/exponential-logarithmic.js
@@ -8,6 +8,10 @@ import { polylogarithm } from '../special'
  *
  * with $p \in (0, 1)$ and $\beta > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; p, \beta) = 1 - \frac{\ln\!\left(1 - (1 - p)\,e^{-\beta x}\right)}{\ln p}$
+ *
  * @class ExponentialLogarithmic
  * @memberof ran.dist
  * @constructor

--- a/src/dist/exponential.js
+++ b/src/dist/exponential.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $\lambda > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \lambda) = 1 - e^{-\lambda x}$
+ *
  * @class Exponential
  * @memberof ran.dist
  * @constructor

--- a/src/dist/exponentiated-weibull.js
+++ b/src/dist/exponentiated-weibull.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $\lambda, k, \alpha > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \lambda, k, \alpha) = \left(1 - e^{-(x/\lambda)^k}\right)^{\alpha}$
+ *
  * @class ExponentiatedWeibull
  * @memberof ran.dist
  * @constructor

--- a/src/dist/f.js
+++ b/src/dist/f.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $d_1, d_2 > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; d_1, d_2) = I_{d_1 x / (d_2 + d_1 x)}(d_1/2,\, d_2/2)$
+ *
  * @class F
  * @memberof ran.dist
  * @constructor

--- a/src/dist/fisher-z.js
+++ b/src/dist/fisher-z.js
@@ -7,6 +7,10 @@ import F from './f'
  *
  * with $d_1, d_2 > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; d_1, d_2) = I_{d_1 e^{2x}/(d_2 + d_1 e^{2x})}(d_1/2,\, d_2/2)$
+ *
  * @class FisherZ
  * @memberof ran.dist
  * @constructor

--- a/src/dist/flory-schulz.js
+++ b/src/dist/flory-schulz.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $a \in (0, 1)$. Support: $k \in \mathbb{N}^+$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; a) = 1 - (1 - a)^k (1 + ka)$
+ *
  * @class FlorySchulz
  * @memberof ran.dist
  * @constructor

--- a/src/dist/frechet.js
+++ b/src/dist/frechet.js
@@ -8,6 +8,10 @@ import { gamma } from '../special'
  *
  * with $z = \frac{x - m}{s}$. and $\alpha, s > 0$, $m \in \mathbb{R}$. Support: $x \in \mathbb{R}, x > m$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, s, m) = \exp\!\left(-\left(\frac{x - m}{s}\right)^{-\alpha}\right)$
+ *
  * @class Frechet
  * @memberof ran.dist
  * @constructor

--- a/src/dist/gamma-gompertz.js
+++ b/src/dist/gamma-gompertz.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $b, s, \beta > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; b, s, \beta) = 1 - \left(\frac{\beta}{\beta + e^{bx} - 1}\right)^{s}$
+ *
  * @class GammaGompertz
  * @memberof ran.dist
  * @constructor

--- a/src/dist/gamma.js
+++ b/src/dist/gamma.js
@@ -10,6 +10,10 @@ import Distribution from './_distribution'
  *
  * where $\alpha, \beta > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta) = P(\alpha,\, \beta x)$
+ *
  * @class Gamma
  * @memberof ran.dist
  * @see G. Marsaglia and W. W. Tsang, "A Simple Method for Generating Gamma Variables", ACM Trans. Math. Softw. 26(3), 363–372, 2000.

--- a/src/dist/generalized-exponential.js
+++ b/src/dist/generalized-exponential.js
@@ -8,6 +8,10 @@ import { lambertW0 } from '../special'
  *
  * where $a, b, c > 0$. Support> $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b, c) = 1 - e^{-(a + b)x + \frac{b}{c}(e^{-cx} - 1)}$
+ *
  * @class GeneralizedExponential
  * @memberof ran.dist
  * @constructor

--- a/src/dist/generalized-extreme-value.js
+++ b/src/dist/generalized-extreme-value.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $c \ne 0$. Support: $x \in (-\infty, 1 / c]$ if $c > 0$, $x \in [1 / c, \infty)$ otherwise.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; c) = \exp\!\left(-(1 - cx)^{1/c}\right)$
+ *
  * @class GeneralizedExtremeValue
  * @memberof ran.dist
  * @constructor

--- a/src/dist/generalized-gamma.js
+++ b/src/dist/generalized-gamma.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * where $a, d, p > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, d, p) = P\!\left(\frac{d}{p},\, \left(\frac{x}{a}\right)^{p}\right)$
+ *
  * @class GeneralizedGamma
  * @memberof ran.dist
  * @constructor

--- a/src/dist/generalized-hermite.js
+++ b/src/dist/generalized-hermite.js
@@ -13,6 +13,10 @@ import PreComputed from './_pre-computed'
  * Support: $k \in \mathbb{N}$. It is the distribution of $X_1 + m X_m$ where $X_1, X_2$ are Poisson variates with
  * parameters $a_1, a_m$ respectively.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; a_1, a_m, m) = \sum_{i=0}^{k} f(i;\, a_1, a_m, m)$
+ *
  * @class GeneralizedHermite
  * @memberof ran.dist
  * @constructor

--- a/src/dist/generalized-logistic.js
+++ b/src/dist/generalized-logistic.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $z = \frac{x - \mu}{s}$, $\mu \in \mathbb{R}$ and $s, c > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, s, c) = \frac{1}{\left(1 + e^{-(x-\mu)/s}\right)^{c}}$
+ *
  * @class GeneralizedLogistic
  * @memberof ran.dist
  * @constructor

--- a/src/dist/generalized-normal.js
+++ b/src/dist/generalized-normal.js
@@ -10,6 +10,10 @@ import Distribution from './_distribution'
  * where $\mu \in \mathbb{R}$ and $\alpha, \beta > 0$. Support: $x \in \mathbb{R}$. It is also a special case of the
  * [generalized gamma distribution]{@link #dist.GeneralizedGamma}.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \alpha, \beta) = \tfrac{1}{2} + \tfrac{1}{2}\operatorname{sgn}(x - \mu)\, P\!\left(\frac{1}{\beta},\, \left(\frac{|x - \mu|}{\alpha}\right)^{\beta}\right)$
+ *
  * @class GeneralizedNormal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/generalized-pareto.js
+++ b/src/dist/generalized-pareto.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $\mu, \xi \in \mathbb{R}$, $\sigma > 0$ and $z = \frac{x - \mu}{\sigma}$. Support: $x \in [\mu, \infty)$ if $\xi \ge 0$, $x \in \[\mu, \mu - \sigma / \xi\]$ otherwise.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \sigma, \xi) = 1 - \left(1 + \xi\,\frac{x - \mu}{\sigma}\right)^{-1/\xi}$
+ *
  * @class GeneralizedPareto
  * @memberof ran.dist
  * @constructor

--- a/src/dist/geometric.js
+++ b/src/dist/geometric.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $p \in (0, 1]$. Support: $k \in \{0, 1, 2, ...\}$. Note that the [discrete exponential distribution]{@link https://docs.scipy.org/doc/scipy/reference/tutorial/stats/discrete_planck.html} is also a geometric distribution with rate parameter equal to $-\ln(1 - p)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; p) = 1 - (1 - p)^{k+1}$
+ *
  * @class Geometric
  * @memberof ran.dist
  * @constructor

--- a/src/dist/gilbrat.js
+++ b/src/dist/gilbrat.js
@@ -7,6 +7,10 @@ import LogNormal from './log-normal'
  *
  * Support: $x > 0$. Note that this distribution is simply a special case of the [log-normal]{@link #dist.LogNormal}.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x) = \Phi(\ln x)$
+ *
  * @class Gilbrat
  * @memberof ran.dist
  * @constructor

--- a/src/dist/gompertz.js
+++ b/src/dist/gompertz.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $\eta, b > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \eta, b) = 1 - \exp\!\left(-\eta\left(e^{bx} - 1\right)\right)$
+ *
  * @class Gompertz
  * @memberof ran.dist
  * @constructor

--- a/src/dist/gumbel.js
+++ b/src/dist/gumbel.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $z = \frac{x - \mu}{\beta}$ and $\mu \in \mathbb{R}$, $\beta > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \beta) = \exp\!\left(-e^{-(x-\mu)/\beta}\right)$
+ *
  * @class Gumbel
  * @memberof ran.dist
  * @constructor

--- a/src/dist/half-generalized-normal.js
+++ b/src/dist/half-generalized-normal.js
@@ -8,6 +8,10 @@ import GeneralizedNormal from './generalized-normal'
  *
  * with $\alpha, \beta > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta) = P\!\left(\frac{1}{\beta},\, \left(\frac{x}{\alpha}\right)^{\beta}\right)$
+ *
  * @class HalfGeneralizedNormal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/half-logistic.js
+++ b/src/dist/half-logistic.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * Support: $x \in [0, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x) = \tanh(x/2)$
+ *
  * @class HalfLogistic
  * @memberof ran.dist
  * @constructor

--- a/src/dist/half-normal.js
+++ b/src/dist/half-normal.js
@@ -9,6 +9,10 @@ import Normal from './normal'
  *
  * with $\sigma > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \sigma) = \operatorname{erf}\!\left(\frac{x}{\sigma\sqrt{2}}\right)$
+ *
  * @class HalfNormal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/heads-minus-tails.js
+++ b/src/dist/heads-minus-tails.js
@@ -12,6 +12,10 @@ import { logBinomial } from '../special'
  *
  * where $n \in \mathbb{N}^+$. Support: $k \in \[0, 2n\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; n) = \sum_{i=0}^{k} f(i;\, n)$
+ *
  * @class HeadsMinusTails
  * @memberof ran.dist
  * @see http://mathworld.wolfram.com/Heads-Minus-TailsDistribution.html

--- a/src/dist/hoyt.js
+++ b/src/dist/hoyt.js
@@ -8,6 +8,10 @@ import Nakagami from './nakagami'
  *
  * where $m \ge 0.5$ and $\omega > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; m, \omega) = P\!\left(m,\, \frac{m}{\omega} x^2\right)$
+ *
  * @class Hoyt
  * @memberof ran.dist
  * @deprecated Use [ran.dist.Nakagami]{@link ran.dist.Nakagami} instead. This class will be removed in a future major release.

--- a/src/dist/hyperbolic-secant.js
+++ b/src/dist/hyperbolic-secant.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x) = \frac{2}{\pi}\arctan\!\left(e^{\pi x/2}\right)$
+ *
  * @class HyperbolicSecant
  * @memberof ran.dist
  * @constructor

--- a/src/dist/hyperexponential.js
+++ b/src/dist/hyperexponential.js
@@ -11,6 +11,10 @@ import powell from '../algorithms/powell'
  *
  * where $w_i, \lambda_i > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mathbf{w}, \boldsymbol{\lambda}) = \sum_{i=1}^{n} w_i \left(1 - e^{-\lambda_i x}\right)$
+ *
  * @class Hyperexponential
  * @memberof ran.dist
  * object with two properties: weight and rate.

--- a/src/dist/hypergeometric.js
+++ b/src/dist/hypergeometric.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $N \in \mathbb{N}^+$, $K \in \{0, 1, ..., N\}$ and $n \in \{0, 1, ..., N\}$. Support: $k \in \{\mathrm{max}(0, n+K-N), ..., \mathrm{min}(n, K)\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; N, K, n) = \sum_{i=\max(0,\, n+K-N)}^{k} \frac{\binom{K}{i}\binom{N-K}{n-i}}{\binom{N}{n}}$
+ *
  * @class Hypergeometric
  * @memberof ran.dist
  * @constructor

--- a/src/dist/inverse-chi2.js
+++ b/src/dist/inverse-chi2.js
@@ -9,6 +9,12 @@ import Distribution from './_distribution'
  *
  * with $\nu \in \mathbb{N}^+$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \nu) = Q\!\left(\frac{\nu}{2},\, \frac{1}{2x}\right)$
+ *
+ * where $Q(a,x)$ is the regularized upper incomplete gamma function.
+ *
  * @class InverseChi2
  * @memberof ran.dist
  * @constructor

--- a/src/dist/inverse-gamma.js
+++ b/src/dist/inverse-gamma.js
@@ -8,6 +8,10 @@ import Gamma from './gamma'
  *
  * where $\alpha, \beta > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta) = Q(\alpha,\, \beta/x)$
+ *
  * @class InverseGamma
  * @memberof ran.dist
  * @constructor

--- a/src/dist/inverse-gaussian.js
+++ b/src/dist/inverse-gaussian.js
@@ -9,6 +9,12 @@ import Distribution from './_distribution'
  *
  * with $\mu, \lambda > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \lambda) = \Phi\!\left(\sqrt{\frac{\lambda}{x}}\left(\frac{x}{\mu} - 1\right)\right) + e^{2\lambda/\mu}\,\Phi\!\left(-\sqrt{\frac{\lambda}{x}}\left(\frac{x}{\mu} + 1\right)\right)$
+ *
+ * where $\Phi$ is the standard normal CDF.
+ *
  * @class InverseGaussian
  * @memberof ran.dist
  * @see J. R. Michael, W. R. Schucany and R. W. Haas, "Generating Random Variates Using Transformations with Multiple Roots", Am. Stat. 30(2), 88–90, 1976.

--- a/src/dist/inverted-weibull.js
+++ b/src/dist/inverted-weibull.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $c > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; c) = \exp(-x^{-c})$
+ *
  * @class InvertedWeibull
  * @memberof ran.dist
  * @constructor

--- a/src/dist/irwin-hall.js
+++ b/src/dist/irwin-hall.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $n \in \mathbb{N}^+$. Support: $x \in \[0, n\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; n) = \frac{1}{n!}\sum_{k=0}^{\lfloor x \rfloor} (-1)^k \binom{n}{k} (x - k)^n$
+ *
  * @class IrwinHall
  * @memberof ran.dist
  * value is 1.

--- a/src/dist/johnson-sb.js
+++ b/src/dist/johnson-sb.js
@@ -9,6 +9,12 @@ import { erfinv } from '../special'
  *
  * with $\gamma, \xi \in \mathbb{R}$, $\delta, \lambda > 0$ and $z = x - \xi$. Support: $x \in (\xi, \xi + \lambda)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \gamma, \delta, \lambda, \xi) = \Phi\!\left(\gamma + \delta\ln\frac{z}{\lambda - z}\right)$
+ *
+ * where $z = x - \xi$.
+ *
  * @class JohnsonSB
  * @memberof ran.dist
  * @constructor

--- a/src/dist/johnson-su.js
+++ b/src/dist/johnson-su.js
@@ -9,6 +9,10 @@ import { erfinv } from '../special'
  *
  * with $\gamma, \xi \in \mathbb{R}$, $\delta, \lambda > 0$ and $z = \frac{x - \xi}{\lambda}$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \gamma, \delta, \lambda, \xi) = \Phi\!\left(\gamma + \delta\sinh^{-1}\!\left(\frac{x - \xi}{\lambda}\right)\right)$
+ *
  * @class JohnsonSU
  * @memberof ran.dist
  * @constructor

--- a/src/dist/kolmogorov.js
+++ b/src/dist/kolmogorov.js
@@ -8,6 +8,10 @@ import { EPS, MAX_ITER } from '../core/constants'
  *
  * Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x) = 1 + 2\sum_{k=1}^{\infty} (-1)^k e^{-2k^2 x^2}$
+ *
  * @class Kolmogorov
  * @memberof ran.dist
  * @constructor

--- a/src/dist/kumaraswamy.js
+++ b/src/dist/kumaraswamy.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $a, b > 0$. Support: $x \in (0, 1)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b) = 1 - (1 - x^a)^b$
+ *
  * @class Kumaraswamy
  * @memberof ran.dist
  * @constructor

--- a/src/dist/laplace.js
+++ b/src/dist/laplace.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * where $\mu \in \mathbb{R}$ and $b > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, b) = \begin{cases} \tfrac{1}{2} e^{(x-\mu)/b} & x < \mu \\ 1 - \tfrac{1}{2} e^{-(x-\mu)/b} & x \ge \mu \end{cases}$
+ *
  * @class Laplace
  * @memberof ran.dist
  * @constructor

--- a/src/dist/levy.js
+++ b/src/dist/levy.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $\mu \in \mathbb{R}$ and $c > 0$. Support: $x \in [\mu, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, c) = \operatorname{erfc}\!\left(\sqrt{\frac{c}{2(x - \mu)}}\right)$
+ *
  * @class Levy
  * @memberof ran.dist
  * @constructor

--- a/src/dist/lindley.js
+++ b/src/dist/lindley.js
@@ -8,6 +8,10 @@ import { lambertW1m } from '../special'
  *
  * with $\theta > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \theta) = 1 - e^{-\theta x}\!\left(1 + \frac{\theta x}{1 + \theta}\right)$
+ *
  * @class Lindley
  * @memberof ran.dist
  * @constructor

--- a/src/dist/log-cauchy.js
+++ b/src/dist/log-cauchy.js
@@ -7,6 +7,10 @@ import Cauchy from './cauchy'
  *
  * with $\mu \in \mathbb{R}$ and $\sigma > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \sigma) = \frac{1}{2} + \frac{1}{\pi}\arctan\!\left(\frac{\ln x - \mu}{\sigma}\right)$
+ *
  * @class LogCauchy
  * @memberof ran.dist
  * @constructor

--- a/src/dist/log-gamma.js
+++ b/src/dist/log-gamma.js
@@ -10,6 +10,10 @@ import Distribution from './_distribution'
  *
  * where $\alpha, \beta > 0$ and $\mu \ge 0$. Support: $x \in [\mu, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta, \mu) = P\!\left(\alpha,\, \beta\ln(x - \mu + 1)\right)$
+ *
  * @class LogGamma
  * @memberof ran.dist
  * @constructor

--- a/src/dist/log-laplace.js
+++ b/src/dist/log-laplace.js
@@ -7,6 +7,10 @@ import Laplace from './laplace'
  *
  * where $\mu \in \mathbb{R}$ and $b > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, b) = \begin{cases} \tfrac{1}{2} e^{(\ln x - \mu)/b} & x < e^{\mu} \\ 1 - \tfrac{1}{2} e^{-(\ln x - \mu)/b} & x \ge e^{\mu} \end{cases}$
+ *
  * @class LogLaplace
  * @memberof ran.dist
  * @constructor

--- a/src/dist/log-logistic.js
+++ b/src/dist/log-logistic.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $\alpha, \beta > 0$. Support: $x \in [0, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta) = \frac{1}{1 + (x/\alpha)^{-\beta}}$
+ *
  * @class LogLogistic
  * @memberof ran.dist
  * @constructor

--- a/src/dist/log-normal.js
+++ b/src/dist/log-normal.js
@@ -8,6 +8,12 @@ import { erfinv } from '../special'
  *
  * where $\mu \in \mathbb{R}$ and $\sigma > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \sigma) = \Phi\!\left(\frac{\ln x - \mu}{\sigma}\right)$
+ *
+ * where $\Phi$ is the standard normal CDF.
+ *
  * @class LogNormal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/log-series.js
+++ b/src/dist/log-series.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $p \in (0, 1)$. Support: $k \in \mathbb{N}^+$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; p) = 1 + \frac{I_p(k+1, 0)}{\ln(1-p)}$
+ *
  * @class LogSeries
  * @memberof ran.dist
  * @see A. Kemp, "Efficient generation of logarithmically distributed pseudo-random variables", Appl. Stat. 30(3), 249–253, 1981.

--- a/src/dist/logarithmic.js
+++ b/src/dist/logarithmic.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $a, b \in [1, \infty)$ and $a < b$. Support: $x \in \[a, b\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b) = \frac{a(1-\ln a) - x(1-\ln x)}{a(1-\ln a) - b(1-\ln b)}$
+ *
  * @class Logarithmic
  * @memberof ran.dist
  * @constructor

--- a/src/dist/logistic-exponential.js
+++ b/src/dist/logistic-exponential.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * where $\lambda, \kappa > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \lambda, \kappa) = \frac{(e^{\lambda x} - 1)^{\kappa}}{1 + (e^{\lambda x} - 1)^{\kappa}}$
+ *
  * @class LogisticExponential
  * @memberof ran.dist
  * @constructor

--- a/src/dist/logistic.js
+++ b/src/dist/logistic.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $z = \frac{x - \mu}{s}$, $\mu \in \mathbb{R}$ and $s > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, s) = \frac{1}{1 + e^{-(x-\mu)/s}}$
+ *
  * @class Logistic
  * @memberof ran.dist
  * @constructor

--- a/src/dist/logit-normal.js
+++ b/src/dist/logit-normal.js
@@ -8,6 +8,12 @@ import { erfinv } from '../special'
  *
  * with $\mu \in \mathbb{R}$, $\sigma > 0$ and $\mathrm{logit}(x) = \ln \frac{x}{1 - x}$. Support: $x \in (0, 1)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \sigma) = \Phi\!\left(\frac{\operatorname{logit}(x) - \mu}{\sigma}\right)$
+ *
+ * where $\operatorname{logit}(x) = \ln(x/(1-x))$.
+ *
  * @class LogitNormal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/lomax.js
+++ b/src/dist/lomax.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $\lambda, \alpha > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \lambda, \alpha) = 1 - \left(1 + \frac{x}{\lambda}\right)^{-\alpha}$
+ *
  * @class Lomax
  * @memberof ran.dist
  * @constructor

--- a/src/dist/makeham.js
+++ b/src/dist/makeham.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $\alpha, \beta, \lambda > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta, \lambda) = 1 - \exp\!\left(-\lambda x - \frac{\alpha}{\beta}\left(e^{\beta x} - 1\right)\right)$
+ *
  * @class Makeham
  * @memberof ran.dist
  * @constructor

--- a/src/dist/maxwell-boltzmann.js
+++ b/src/dist/maxwell-boltzmann.js
@@ -10,6 +10,10 @@ import Distribution from './_distribution'
  *
  * with $a > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a) = P\!\left(\frac{3}{2},\, \frac{x^2}{2a^2}\right)$
+ *
  * @class MaxwellBoltzmann
  * @memberof ran.dist
  * @constructor

--- a/src/dist/mielke.js
+++ b/src/dist/mielke.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $k, s > 0$. Support: $x > 0$. It can be viewed as a re-parametrization of the [Dagum distribution]{@link #dist.Dagum}.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; k, s) = \left(1 + x^{-s}\right)^{-k/s}$
+ *
  * @class Mielke
  * @memberof ran.dist
  * @constructor

--- a/src/dist/moyal.js
+++ b/src/dist/moyal.js
@@ -8,6 +8,10 @@ import { gammaUpperIncomplete, erfinv } from '../special'
  *
  * where $z = \frac{x - \mu}{\sigma}$, $\mu \in \mathbb{R}$ and $\sigma > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \sigma) = \operatorname{erfc}\!\left(\frac{1}{\sqrt{2}} e^{-(x-\mu)/(2\sigma)}\right)$
+ *
  * @class Moyal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/muth.js
+++ b/src/dist/muth.js
@@ -10,6 +10,10 @@ import { lambertW1m } from '../special'
  *
  * with $\alpha \in (0, 1]$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha) = 1 - \exp\!\left(\alpha x - \frac{e^{\alpha x} - 1}{\alpha}\right)$
+ *
  * @class Muth
  * @memberof ran.dist
  * @constructor

--- a/src/dist/nakagami.js
+++ b/src/dist/nakagami.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * where $m \in \mathbb{R}$, $m \ge 0.5$ and $\Omega > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; m, \Omega) = P\!\left(m,\, \frac{m}{\Omega} x^2\right)$
+ *
  * @class Nakagami
  * @memberof ran.dist
  * @constructor

--- a/src/dist/negative-binomial.js
+++ b/src/dist/negative-binomial.js
@@ -11,6 +11,10 @@ import Distribution from './_distribution'
  *
  * with $r \in \mathbb{N}^+$ and $p \in \[0, 1)$. Support: $k \in \mathbb{N}_0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; r, p) = 1 - I_p(k + 1,\, r)$
+ *
  * @class NegativeBinomial
  * @memberof ran.dist
  * integer.

--- a/src/dist/negative-hypergeometric.js
+++ b/src/dist/negative-hypergeometric.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $N \in \mathbb{N}_0$, $K \in \{0, 1, ..., N\}$ and $r \in \{0, 1, ..., N - K\}$. Support: $k \in \{0, ..., K\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; N, K, r) = \sum_{i=0}^{k} \frac{\binom{i+r-1}{i}\binom{N-r-i}{K-i}}{\binom{N}{K}}$
+ *
  * @class NegativeHypergeometric
  * @memberof ran.dist
  * @constructor

--- a/src/dist/neyman-a.js
+++ b/src/dist/neyman-a.js
@@ -9,6 +9,10 @@ import PreComputed from './_pre-computed'
  *
  * where $\lambda, \theta > 0$ and $S(n, m)$ denotes the [Stirling number of the second kind]{@link https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind}. Support: $k \in \mathbb{N}_0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \lambda, \phi) = \sum_{i=0}^{k} f(i;\, \lambda, \phi)$
+ *
  * @class NeymanA
  * @memberof ran.dist
  * @constructor

--- a/src/dist/noncentral-beta.js
+++ b/src/dist/noncentral-beta.js
@@ -11,6 +11,10 @@ import Distribution from './_distribution'
  *
  * where $\alpha, \beta > 0$ and $\lambda \ge 0$. Support: $x \in \[0, 1\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \alpha, \beta, \lambda) = e^{-\lambda/2}\sum_{k=0}^{\infty} \frac{(\lambda/2)^k}{k!}\, I_x(\alpha + k,\, \beta)$
+ *
  * @class NoncentralBeta
  * @memberof ran.dist
  * @constructor

--- a/src/dist/noncentral-chi.js
+++ b/src/dist/noncentral-chi.js
@@ -10,6 +10,12 @@ import NoncentralChi2 from './noncentral-chi2'
  *
  * with $k \in \mathbb{N}^+$, $\lambda > 0$ and $I_n(x)$ is the modified Bessel function of the first kind with order $n$. Support: $x \in [0, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; k, \lambda) = 1 - Q_{k/2}\!\left(\lambda,\, x\right)$
+ *
+ * where $Q_M(a, b)$ is the Marcum Q-function.
+ *
  * @class NoncentralChi
  * @memberof ran.dist
  * @constructor

--- a/src/dist/noncentral-chi2.js
+++ b/src/dist/noncentral-chi2.js
@@ -9,6 +9,12 @@ import Distribution from './_distribution'
  *
  * with $k \in \mathbb{N}^+$, $\lambda \ge 0$ and $I_n(x)$ is the modified Bessel function of the first kind with order $n$. Support: $x \in [0, \infty)$. When $\lambda = 0$ the distribution degenerates to a central $\chi^2(k)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; k, \lambda) = 1 - Q_{k/2}\!\left(\sqrt{\lambda},\, \sqrt{x}\right)$
+ *
+ * where $Q_M(a, b)$ is the Marcum Q-function.
+ *
  * @class NoncentralChi2
  * @memberof ran.dist
  * @constructor

--- a/src/dist/noncentral-f.js
+++ b/src/dist/noncentral-f.js
@@ -8,6 +8,10 @@ import NoncentralBeta from './noncentral-beta'
  *
  * where $d_1, d_2 \in \mathbb{N}^+$ and $\lambda > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; d_1, d_2, \lambda) = e^{-\lambda/2}\sum_{k=0}^{\infty} \frac{(\lambda/2)^k}{k!}\, I_{d_1 x / (d_2 + d_1 x)}\!\left(\tfrac{d_1}{2} + k,\, \tfrac{d_2}{2}\right)$
+ *
  * @class NoncentralF
  * @memberof ran.dist
  * @constructor

--- a/src/dist/noncentral-t.js
+++ b/src/dist/noncentral-t.js
@@ -11,6 +11,10 @@ import Distribution from './_distribution'
  *
  * with $\nu \in \mathbb{N}^+$ and $\mu \in \mathbb{R}$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \nu, \mu) = \int_{-\infty}^{x} f(t;\, \nu, \mu)\, \mathrm{d}t$
+ *
  * @class NoncentralT
  * @memberof ran.dist
  * @param {number} nu Degrees of freedom. If not an integer, it is rounded to the nearest one.

--- a/src/dist/normal.js
+++ b/src/dist/normal.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $\mu \in \mathbb{R}$ and $\sigma > 0$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \sigma) = \frac{1}{2}\left[1 + \operatorname{erf}\!\left(\frac{x - \mu}{\sigma\sqrt{2}}\right)\right]$
+ *
  * @class Normal
  * @memberof ran.dist
  * @see https://en.wikipedia.org/wiki/Ziggurat_algorithm Improved Ziggurat algorithm (sampling algorithm)

--- a/src/dist/pareto.js
+++ b/src/dist/pareto.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $x_\mathrm{min}, \alpha > 0$. Support: $x \in [x_\mathrm{min}, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; x_{\min}, \alpha) = 1 - \left(\frac{x_{\min}}{x}\right)^{\alpha}$
+ *
  * @class Pareto
  * @memberof ran.dist
  * @constructor

--- a/src/dist/pert.js
+++ b/src/dist/pert.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * where $a, b, c \in \mathbb{R}$, $a < b < c$, $\alpha = \frac{4b + c - 5a}{c - a}$, $\beta = \frac{5c - a -4b}{c - a}$ and $\mathrm{B}(x, y)$ is the beta function. Support: $x \in [a, c]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b, c) = I_{(x-a)/(c-a)}(\alpha, \beta)$
+ *
  * @class PERT
  * @memberof ran.dist
  * @constructor

--- a/src/dist/poisson.js
+++ b/src/dist/poisson.js
@@ -9,6 +9,12 @@ import Distribution from './_distribution'
  *
  * with $\lambda > 0$. Support: $k \in \mathbb{N}_0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \lambda) = 1 - P(k + 1,\, \lambda)$
+ *
+ * where $P(a,x)$ is the regularized lower incomplete gamma function
+ *
  * @class Poisson
  * @memberof ran.dist
  * @see D. E. Knuth, "Seminumerical Algorithms", The Art of Computer Programming vol. 2, 1969 (small λ). A. C. Atkinson, "The Computer Generation of Poisson Random Variables", Appl. Stat. 28(1), 29–35, 1979 (large λ).

--- a/src/dist/polya-aeppli.js
+++ b/src/dist/polya-aeppli.js
@@ -9,6 +9,10 @@ import poisson from './_poisson'
  *
  * where $\lambda > 0$ and $\theta \in (0, 1)$. Support: $k \in \mathbb{N}_0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \lambda, \theta) = \sum_{i=0}^{k} f(i;\, \lambda, \theta)$
+ *
  * @class PolyaAeppli
  * @memberof ran.dist
  * @constructor

--- a/src/dist/power-law.js
+++ b/src/dist/power-law.js
@@ -7,6 +7,10 @@ import Kumaraswamy from './kumaraswamy'
  *
  * with $a > 0$. Support: $x \in (0, 1)$. It is a special case of the [Kumaraswamy distribution]{@link #dist.Kumaraswamy}.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a) = x^a$
+ *
  * @class PowerLaw
  * @memberof ran.dist
  * @constructor

--- a/src/dist/q-exponential.js
+++ b/src/dist/q-exponential.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * where $q < 2$, $\lambda > 0$ and $e^x_q$ denotes the [q-exponential function]{@link https://en.wikipedia.org/wiki/Tsallis_statistics#q-exponential}. Support: $x > 0$ if $q \ge 1$, otherwise $x \in \big[0, \frac{1}{\lambda (1 - q)}\big)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; q, \lambda) = 1 - \left(1 - (1-q)\lambda x\right)^{1/(1-q)}$
+ *
  * @class QExponential
  * @memberof ran.dist
  * @constructor

--- a/src/dist/r.js
+++ b/src/dist/r.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * where $c > 0$. Support: $x \in \[-1, 1\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; c) = I_{(x+1)/2}(c/2,\, c/2)$
+ *
  * @class R
  * @memberof ran.dist
  * @constructor

--- a/src/dist/rademacher.js
+++ b/src/dist/rademacher.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * Support: $k \in \{-1, 1\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k) = \begin{cases} 0 & k < -1 \\ \tfrac{1}{2} & -1 \le k < 1 \\ 1 & k \ge 1 \end{cases}$
+ *
  * @class Rademacher
  * @memberof ran.dist
  * @constructor

--- a/src/dist/raised-cosine.js
+++ b/src/dist/raised-cosine.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * where $\mu \in \mathbb{R}$ and $s > 0$. Support: $x \in \[\mu - s, \mu + s\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, s) = \frac{1}{2}\!\left(1 + \frac{x - \mu}{s} + \frac{\sin(\pi(x-\mu)/s)}{\pi}\right)$
+ *
  * @class RaisedCosine
  * @memberof ran.dist
  * @constructor

--- a/src/dist/rayleigh.js
+++ b/src/dist/rayleigh.js
@@ -7,6 +7,10 @@ import Weibull from './weibull'
  *
  * with $\sigma > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \sigma) = 1 - e^{-x^2/(2\sigma^2)}$
+ *
  * @class Rayleigh
  * @memberof ran.dist
  * @constructor

--- a/src/dist/reciprocal-inverse-gaussian.js
+++ b/src/dist/reciprocal-inverse-gaussian.js
@@ -7,6 +7,12 @@ import InverseGaussian from './inverse-gaussian'
  *
  * with $\mu, \lambda > 0$. Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \lambda) = 1 - F_{\mathrm{IG}}(1/x;\, \mu,\, \lambda)$
+ *
+ * where $F_{\mathrm{IG}}$ is the inverse Gaussian CDF
+ *
  * @class ReciprocalInverseGaussian
  * @memberof ran.dist
  * @constructor

--- a/src/dist/reciprocal.js
+++ b/src/dist/reciprocal.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $a, b > 0$ and $a < b$. Support: $x \in \[a, b\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b) = \frac{\ln x - \ln a}{\ln b - \ln a}$
+ *
  * @class Reciprocal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/rice.js
+++ b/src/dist/rice.js
@@ -10,6 +10,12 @@ import Distribution from './_distribution'
  *
  * with $\nu, \sigma > 0$ and $I_0(x)$ is the modified Bessel function of the first kind with order zero. Support: $x \in [0, \infty)$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \nu, \sigma) = 1 - Q_1\!\left(\frac{\nu}{\sigma},\, \frac{x}{\sigma}\right)$
+ *
+ * where $Q_1$ is the Marcum Q-function of order 1
+ *
  * @class Rice
  * @memberof ran.dist
  * @constructor

--- a/src/dist/shifted-log-logistic.js
+++ b/src/dist/shifted-log-logistic.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $z = \frac{x - \mu}{\sigma}$, $\mu, \xi \in \mathbb{R}$ and $\sigma > 0$. Support: $x \ge \mu - \sigma/\xi$ if $\xi > 0$, $x \le \mu - \sigma/\xi$ if $\xi < 0$, $x \in \mathbb{R}$ otherwise.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \sigma, \xi) = \frac{1}{1 + \left(1 + \xi\,\frac{x - \mu}{\sigma}\right)^{-1/\xi}}$
+ *
  * @class ShiftedLogLogistic
  * @memberof ran.dist
  * @constructor

--- a/src/dist/skellam.js
+++ b/src/dist/skellam.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $\mu_1, \mu_2 \ge 0$ and $I_n(x)$ is the modified Bessel function of the first kind with order $n$. Support: $k \in \mathbb{N}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \mu_1, \mu_2) = \sum_{i=-\infty}^{k} f(i;\, \mu_1, \mu_2)$
+ *
  * @class Skellam
  * @memberof ran.dist
  * @constructor

--- a/src/dist/skew-normal.js
+++ b/src/dist/skew-normal.js
@@ -11,6 +11,12 @@ import Normal from './normal'
  * cumulative distribution functions of the standard [normal distribution]{@link #dist.Normal}.
  * Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \xi, \omega, \alpha) = \Phi\!\left(\frac{x - \xi}{\omega}\right) - 2\,T\!\left(\frac{x - \xi}{\omega},\, \alpha\right)$
+ *
+ * where $T(h, a)$ is Owen's T function
+ *
  * @class SkewNormal
  * @memberof ran.dist
  * @see A. Azzalini, "SN package FAQ", https://azzalini.stat.unipd.it/SN/faq-r.html (sampling algorithm)

--- a/src/dist/slash.js
+++ b/src/dist/slash.js
@@ -10,6 +10,10 @@ import Normal from './normal'
  * where $\phi(x)$ is the probability density function of the standard [normal distribution]{@link #dist.Normal}.
  * Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x) = \Phi(x) - \frac{\phi(x) - \phi(0)}{x}$
+ *
  * @class Slash
  * @memberof ran.dist
  * @constructor

--- a/src/dist/soliton.js
+++ b/src/dist/soliton.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $N \in \mathbb{N}^+$. Support: $k \in \{1, 2, ..., N\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; K) = \sum_{i=1}^{k} f(i;\, K)$
+ *
  * @class Soliton
  * @memberof ran.dist
  * @constructor

--- a/src/dist/student-t.js
+++ b/src/dist/student-t.js
@@ -11,6 +11,10 @@ import Distribution from './_distribution'
  *
  * with $\nu > 0$ and $\mathrm{B}(x, y)$ is the beta function. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \nu) = \begin{cases} \tfrac{1}{2} I_{\nu/(\nu+x^2)}(\nu/2,\, 1/2) & x \le 0 \\ 1 - \tfrac{1}{2} I_{\nu/(\nu+x^2)}(\nu/2,\, 1/2) & x > 0 \end{cases}$
+ *
  * @class StudentT
  * @memberof ran.dist
  * @constructor

--- a/src/dist/student-z.js
+++ b/src/dist/student-z.js
@@ -8,6 +8,12 @@ import Distribution from './_distribution'
  *
  * with $n > 1$. Support: $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; n) = F_t\!\left(x\sqrt{n-1};\, n-1\right)$
+ *
+ * where $F_t$ is the Student's t CDF
+ *
  * @class StudentZ
  * @memberof ran.dist
  * @constructor

--- a/src/dist/trapezoidal.js
+++ b/src/dist/trapezoidal.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * where $a, b, c, d \in \mathbb{R}$, $a < d$, $a \le b < c$ and $c \le d$. Support: $x \in \[a, d\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b, c, d) = \begin{cases} \dfrac{(x-a)^2}{(b-a)(d+c-a-b)} & a \le x < b \\[4pt] \dfrac{2x-a-b}{d+c-a-b} & b \le x < c \\[4pt] 1 - \dfrac{(d-x)^2}{(d-c)(d+c-a-b)} & c \le x \le d \end{cases}$
+ *
  * @class Trapezoidal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/triangular.js
+++ b/src/dist/triangular.js
@@ -7,6 +7,10 @@ import Distribution from './_distribution'
  *
  * with $a, b, c \in \mathbb{R}$, $a < b$ and $a \le c \le b$. Support: $x \in \[a, b\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b, c) = \begin{cases} \dfrac{(x-a)^2}{(b-a)(c-a)} & a \le x < c \\[4pt] 1 - \dfrac{(b-x)^2}{(b-a)(b-c)} & c \le x \le b \end{cases}$
+ *
  * @class Triangular
  * @memberof ran.dist
  * @constructor

--- a/src/dist/truncated-normal.js
+++ b/src/dist/truncated-normal.js
@@ -11,6 +11,10 @@ import { erfinv } from '../special'
  * The functions $\phi$ and $\Phi$ denote the probability density and cumulative distribution functions of the normal
  * distribution. Finally, $\mu \in \mathbb{R}$, $\sigma > 0$ and $b > a$. Support: $x \in [a, b]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \mu, \sigma, a, b) = \frac{\Phi\!\left(\frac{x-\mu}{\sigma}\right) - \Phi\!\left(\frac{a-\mu}{\sigma}\right)}{\Phi\!\left(\frac{b-\mu}{\sigma}\right) - \Phi\!\left(\frac{a-\mu}{\sigma}\right)}$
+ *
  * @class TruncatedNormal
  * @memberof ran.dist
  * @constructor

--- a/src/dist/tukey-lambda.js
+++ b/src/dist/tukey-lambda.js
@@ -8,6 +8,10 @@ import chandrupatla from '../algorithms/chandrupatla'
  *
  * where $Q(p) = \frac{p^\lambda - (1 - p)^\lambda}{\lambda}$ and $F(x) = Q^{-1}(x)$. Support: $x \in \[-1/\lambda, 1/\lambda\]$ if $\lambda > 0$, otherwise $x \in \mathbb{R}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \lambda) = \int_{-\infty}^{x} f(t;\, \lambda)\, \mathrm{d}t$
+ *
  * @class TukeyLambda
  * @memberof ran.dist
  * @constructor

--- a/src/dist/u-quadratic.js
+++ b/src/dist/u-quadratic.js
@@ -8,6 +8,12 @@ import Distribution from './_distribution'
  * where $\alpha = \frac{12}{(b - a)^3}$, $\beta = \frac{a + b}{2}$, $a, b \in \mathbb{R}$ and $a < b$.
  * Support: $x \in \[a, b\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b) = \frac{\alpha}{3}\!\left[(x - \beta)^3 + \left(\frac{b-a}{2}\right)^3\right]$
+ *
+ * where $\alpha = 12/(b-a)^3$ and $\beta = (a+b)/2$
+ *
  * @class UQuadratic
  * @memberof ran.dist
  * @constructor

--- a/src/dist/uniform-product.js
+++ b/src/dist/uniform-product.js
@@ -9,6 +9,12 @@ import { gamma, gammaUpperIncomplete } from '../special'
  *
  * with $n \in \mathbb{N}, n > 1$. Support: $x \in (0, 1\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; n) = Q\!\left(n,\, -\ln x\right)$
+ *
+ * where $Q(a,x)$ is the regularized upper incomplete gamma function
+ *
  * @class UniformProduct
  * @memberof ran.dist
  * @constructor

--- a/src/dist/uniform-ratio.js
+++ b/src/dist/uniform-ratio.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * Support: $x > 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x) = \begin{cases} \tfrac{1}{2} x & 0 < x \le 1 \\ 1 - \tfrac{1}{2x} & x > 1 \end{cases}$
+ *
  * @class UniformRatio
  * @memberof ran.dist
  * @constructor

--- a/src/dist/uniform.js
+++ b/src/dist/uniform.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  * with $x_\mathrm{min}, x_\mathrm{max} \in \mathbb{R}$ and $x_\mathrm{min} < x_\mathrm{max}$.
  * Support: $x \in \[x_\mathrm{min}, x_\mathrm{max}\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; a, b) = \frac{x - a}{b - a}$
+ *
  * @class Uniform
  * @memberof ran.dist
  * @constructor

--- a/src/dist/von-mises.js
+++ b/src/dist/von-mises.js
@@ -10,6 +10,12 @@ import { MAX_ITER } from '../core/constants'
  *
  * with $\kappa > 0$. Support: $x \in \[-\pi, \pi\]$. Note that originally this distribution is periodic and therefore it is defined over $\mathbb{R}$, but (without the loss of general usage) this implementation still does limit the support on the bounded interval $\[-\pi, \pi\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \kappa) = \frac{1}{2} + \frac{x}{2\pi} + \frac{1}{\pi} \sum_{k=1}^{\infty} \frac{I_k(\kappa)}{k\, I_0(\kappa)} \sin(kx)$
+ *
+ * where $I_k$ is the modified Bessel function of the first kind
+ *
  * @class VonMises
  * @memberof ran.dist
  * @see L. Barabesi, "Generating von Mises variates by the ratio-of-uniforms method", Statistica Applicata 7(4), 417–426, 1995.

--- a/src/dist/weibull.js
+++ b/src/dist/weibull.js
@@ -9,6 +9,10 @@ import { gamma } from '../special'
  *
  * with $\lambda, k > 0$. Support: $x \ge 0$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; \lambda, k) = 1 - e^{-(x/\lambda)^k}$
+ *
  * @class Weibull
  * @memberof ran.dist
  * @constructor

--- a/src/dist/wigner.js
+++ b/src/dist/wigner.js
@@ -9,6 +9,10 @@ import Distribution from './_distribution'
  *
  * with $R > 0$. Support: $x \in \[-R, R\]$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(x; R) = \frac{1}{2} + \frac{x\sqrt{R^2 - x^2}}{\pi R^2} + \frac{\arcsin(x/R)}{\pi}$
+ *
  * @class Wigner
  * @memberof ran.dist
  * @constructor

--- a/src/dist/yule-simon.js
+++ b/src/dist/yule-simon.js
@@ -8,6 +8,12 @@ import Distribution from './_distribution'
  *
  * with $\rho > 0$ and $\mathrm{B}(x, y)$ is the beta function. Support: $k \in \mathbb{N}^+$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; \rho) = 1 - k\, B(k,\, \rho + 1)$
+ *
+ * where $B$ is the beta function
+ *
  * @class YuleSimon
  * @memberof ran.dist
  * @constructor

--- a/src/dist/zeta.js
+++ b/src/dist/zeta.js
@@ -9,6 +9,12 @@ import Distribution from './_distribution'
  *
  * with $s \in (1, \infty)$ and $\zeta(x)$ is the Riemann zeta function. Support: $k \in \mathbb{N}^+$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; s) = \frac{H(k, s)}{\zeta(s)}$
+ *
+ * where $H(k, s) = \sum_{i=1}^{k} i^{-s}$ is the generalized harmonic number.
+ *
  * @class Zeta
  * @memberof ran.dist
  * @see L. Devroye, "Non-Uniform Random Variate Generation", Springer-Verlag, 1986, ch. 10.

--- a/src/dist/zipf-mandelbrot.js
+++ b/src/dist/zipf-mandelbrot.js
@@ -8,6 +8,10 @@ import Distribution from './_distribution'
  *
  * with $s > 1$, $q \ge 0$, $N \in \mathbb{N}^+$ and $H_{N,s,q} = \sum_{j=1}^{N}(j+q)^{-s}$. Support: $k \in \{1, 2, \ldots, N\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; N, s, q) = \frac{1}{H_{N,s,q}} \sum_{i=1}^{k} (i + q)^{-s}$
+ *
  * @class ZipfMandelbrot
  * @memberof ran.dist
  * @constructor

--- a/src/dist/zipf.js
+++ b/src/dist/zipf.js
@@ -8,6 +8,12 @@ import Distribution from './_distribution'
  *
  * with $s \ge 0$, $N \in \mathbb{N}^+$ and $H_{N, s}$ denotes the generalized harmonic number. Support: $k \in \{1, 2, ..., N\}$.
  *
+ * Cumulative distribution function:
+ *
+ * $F(k; s, N) = \frac{H_{k, s}}{H_{N, s}}$
+ *
+ * where $H_{k, s} = \sum_{i=1}^{k} i^{-s}$.
+ *
  * @class Zipf
  * @memberof ran.dist
  * @constructor


### PR DESCRIPTION
## Summary
- Adds a "Cumulative distribution function:" section to the class-level JSDoc of every distribution (141 files), immediately after the existing PDF/PMF formula and before the first `@` tag
- Follows the same LaTeX inline-math style as the existing PDF/PMF formulas; no pipeline or template changes required — formulas render through the existing MathJax path
- For distributions with closed-form CDFs the explicit formula is shown; those requiring special functions use standard notation ($P(a,x)$, $I_x(a,b)$, $\Phi(x)$, $\operatorname{erf}$, Marcum Q, Owen T, etc.); distributions with no simple closed form show the integral or sum definition

## Non-trivial changes

_No logic changes — this PR is purely JSDoc documentation additions._

The mathematical content of the formulas is the only thing worth reviewing. Spot-check a few formulas against a reference (Wikipedia or DLMF) if you want confidence in correctness:

- **Distributions using special functions** (gamma, beta, normal families): formulas expressed in terms of $P(a,x)$, $I_x(a,b)$, $\Phi(x)$ — these are the same functions the `_cdf` implementations call, so the notation is consistent
- **Piecewise CDFs** (laplace, double-gamma, student-t, triangular, trapezoidal, bernoulli, rademacher): multi-case `\begin{cases}` blocks
- **Series/mixture CDFs** (noncentral-beta, noncentral-f, doubly-noncentral-*): Poisson-weighted sums shown explicitly
- **No closed form** (tukey-lambda, davis): integral definition $\int f(t)\,\mathrm{d}t$

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes (all 141 files)</summary>

JSDoc-only edits — one new block inserted per distribution file between the support line and the first `@` tag. No production logic changed.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_018CSdyuzpXMqmnifEBnZAHx)_