### PR TITLE
Remove \\! spacing from CDF formulas in JSDoc

### DIFF
--- a/src/dist/anglit.js
+++ b/src/dist/anglit.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \beta) = \sin^2\!\left(\frac{x - \mu}{\beta} + \frac{\pi}{4}\right)$
+ * $F(x; \mu, \beta) = \sin^2\left(\frac{x - \mu}{\beta} + \frac{\pi}{4}\right)$
  *
  * @class Anglit
  * @memberof ran.dist

--- a/src/dist/arcsine.js
+++ b/src/dist/arcsine.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; a, b) = \frac{2}{\pi}\arcsin\!\left(\sqrt{\frac{x - a}{b - a}}\right)$
+ * $F(x; a, b) = \frac{2}{\pi}\arcsin\left(\sqrt{\frac{x - a}{b - a}}\right)$
  *
  * @class Arcsine
  * @memberof ran.dist

--- a/src/dist/birnbaum-saunders.js
+++ b/src/dist/birnbaum-saunders.js
@@ -11,7 +11,7 @@ import { erfinv } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \beta, \gamma) = \Phi\!\left(\frac{1}{\gamma}\left(\sqrt{\frac{x - \mu}{\beta}} - \sqrt{\frac{\beta}{x - \mu}}\right)\right)$
+ * $F(x; \mu, \beta, \gamma) = \Phi\left(\frac{1}{\gamma}\left(\sqrt{\frac{x - \mu}{\beta}} - \sqrt{\frac{\beta}{x - \mu}}\right)\right)$
  *
  * @class BirnbaumSaunders
  * @memberof ran.dist

--- a/src/dist/exponential-logarithmic.js
+++ b/src/dist/exponential-logarithmic.js
@@ -10,7 +10,7 @@ import { polylogarithm } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; p, \beta) = 1 - \frac{\ln\!\left(1 - (1 - p)\,e^{-\beta x}\right)}{\ln p}$
+ * $F(x; p, \beta) = 1 - \frac{\ln\left(1 - (1 - p)\,e^{-\beta x}\right)}{\ln p}$
  *
  * @class ExponentialLogarithmic
  * @memberof ran.dist

--- a/src/dist/frechet.js
+++ b/src/dist/frechet.js
@@ -10,7 +10,7 @@ import { gamma } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \alpha, s, m) = \exp\!\left(-\left(\frac{x - m}{s}\right)^{-\alpha}\right)$
+ * $F(x; \alpha, s, m) = \exp\left(-\left(\frac{x - m}{s}\right)^{-\alpha}\right)$
  *
  * @class Frechet
  * @memberof ran.dist

--- a/src/dist/generalized-extreme-value.js
+++ b/src/dist/generalized-extreme-value.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; c) = \exp\!\left(-(1 - cx)^{1/c}\right)$
+ * $F(x; c) = \exp\left(-(1 - cx)^{1/c}\right)$
  *
  * @class GeneralizedExtremeValue
  * @memberof ran.dist

--- a/src/dist/generalized-gamma.js
+++ b/src/dist/generalized-gamma.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; a, d, p) = P\!\left(\frac{d}{p},\, \left(\frac{x}{a}\right)^{p}\right)$
+ * $F(x; a, d, p) = P\left(\frac{d}{p},\, \left(\frac{x}{a}\right)^{p}\right)$
  *
  * @class GeneralizedGamma
  * @memberof ran.dist

--- a/src/dist/generalized-normal.js
+++ b/src/dist/generalized-normal.js
@@ -12,7 +12,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \alpha, \beta) = \tfrac{1}{2} + \tfrac{1}{2}\operatorname{sgn}(x - \mu)\, P\!\left(\frac{1}{\beta},\, \left(\frac{|x - \mu|}{\alpha}\right)^{\beta}\right)$
+ * $F(x; \mu, \alpha, \beta) = \tfrac{1}{2} + \tfrac{1}{2}\operatorname{sgn}(x - \mu)\, P\left(\frac{1}{\beta},\, \left(\frac{|x - \mu|}{\alpha}\right)^{\beta}\right)$
  *
  * @class GeneralizedNormal
  * @memberof ran.dist

--- a/src/dist/gompertz.js
+++ b/src/dist/gompertz.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \eta, b) = 1 - \exp\!\left(-\eta\left(e^{bx} - 1\right)\right)$
+ * $F(x; \eta, b) = 1 - \exp\left(-\eta\left(e^{bx} - 1\right)\right)$
  *
  * @class Gompertz
  * @memberof ran.dist

--- a/src/dist/gumbel.js
+++ b/src/dist/gumbel.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \beta) = \exp\!\left(-e^{-(x-\mu)/\beta}\right)$
+ * $F(x; \mu, \beta) = \exp\left(-e^{-(x-\mu)/\beta}\right)$
  *
  * @class Gumbel
  * @memberof ran.dist

--- a/src/dist/half-generalized-normal.js
+++ b/src/dist/half-generalized-normal.js
@@ -10,7 +10,7 @@ import GeneralizedNormal from './generalized-normal'
  *
  * Cumulative distribution function:
  *
- * $F(x; \alpha, \beta) = P\!\left(\frac{1}{\beta},\, \left(\frac{x}{\alpha}\right)^{\beta}\right)$
+ * $F(x; \alpha, \beta) = P\left(\frac{1}{\beta},\, \left(\frac{x}{\alpha}\right)^{\beta}\right)$
  *
  * @class HalfGeneralizedNormal
  * @memberof ran.dist

--- a/src/dist/half-normal.js
+++ b/src/dist/half-normal.js
@@ -11,7 +11,7 @@ import Normal from './normal'
  *
  * Cumulative distribution function:
  *
- * $F(x; \sigma) = \operatorname{erf}\!\left(\frac{x}{\sigma\sqrt{2}}\right)$
+ * $F(x; \sigma) = \operatorname{erf}\left(\frac{x}{\sigma\sqrt{2}}\right)$
  *
  * @class HalfNormal
  * @memberof ran.dist

--- a/src/dist/hoyt.js
+++ b/src/dist/hoyt.js
@@ -10,7 +10,7 @@ import Nakagami from './nakagami'
  *
  * Cumulative distribution function:
  *
- * $F(x; m, \omega) = P\!\left(m,\, \frac{m}{\omega} x^2\right)$
+ * $F(x; m, \omega) = P\left(m,\, \frac{m}{\omega} x^2\right)$
  *
  * @class Hoyt
  * @memberof ran.dist

--- a/src/dist/hyperbolic-secant.js
+++ b/src/dist/hyperbolic-secant.js
@@ -9,7 +9,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x) = \frac{2}{\pi}\arctan\!\left(e^{\pi x/2}\right)$
+ * $F(x) = \frac{2}{\pi}\arctan\left(e^{\pi x/2}\right)$
  *
  * @class HyperbolicSecant
  * @memberof ran.dist

--- a/src/dist/inverse-chi2.js
+++ b/src/dist/inverse-chi2.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \nu) = Q\!\left(\frac{\nu}{2},\, \frac{1}{2x}\right)$
+ * $F(x; \nu) = Q\left(\frac{\nu}{2},\, \frac{1}{2x}\right)$
  *
  * where $Q(a,x)$ is the regularized upper incomplete gamma function.
  *

--- a/src/dist/inverse-gaussian.js
+++ b/src/dist/inverse-gaussian.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \lambda) = \Phi\!\left(\sqrt{\frac{\lambda}{x}}\left(\frac{x}{\mu} - 1\right)\right) + e^{2\lambda/\mu}\,\Phi\!\left(-\sqrt{\frac{\lambda}{x}}\left(\frac{x}{\mu} + 1\right)\right)$
+ * $F(x; \mu, \lambda) = \Phi\left(\sqrt{\frac{\lambda}{x}}\left(\frac{x}{\mu} - 1\right)\right) + e^{2\lambda/\mu}\,\Phi\left(-\sqrt{\frac{\lambda}{x}}\left(\frac{x}{\mu} + 1\right)\right)$
  *
  * where $\Phi$ is the standard normal CDF.
  *

--- a/src/dist/johnson-sb.js
+++ b/src/dist/johnson-sb.js
@@ -11,7 +11,7 @@ import { erfinv } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \gamma, \delta, \lambda, \xi) = \Phi\!\left(\gamma + \delta\ln\frac{z}{\lambda - z}\right)$
+ * $F(x; \gamma, \delta, \lambda, \xi) = \Phi\left(\gamma + \delta\ln\frac{z}{\lambda - z}\right)$
  *
  * where $z = x - \xi$.
  *

--- a/src/dist/johnson-su.js
+++ b/src/dist/johnson-su.js
@@ -11,7 +11,7 @@ import { erfinv } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \gamma, \delta, \lambda, \xi) = \Phi\!\left(\gamma + \delta\sinh^{-1}\!\left(\frac{x - \xi}{\lambda}\right)\right)$
+ * $F(x; \gamma, \delta, \lambda, \xi) = \Phi\left(\gamma + \delta\sinh^{-1}\left(\frac{x - \xi}{\lambda}\right)\right)$
  *
  * @class JohnsonSU
  * @memberof ran.dist

--- a/src/dist/levy.js
+++ b/src/dist/levy.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, c) = \operatorname{erfc}\!\left(\sqrt{\frac{c}{2(x - \mu)}}\right)$
+ * $F(x; \mu, c) = \operatorname{erfc}\left(\sqrt{\frac{c}{2(x - \mu)}}\right)$
  *
  * @class Levy
  * @memberof ran.dist

--- a/src/dist/lindley.js
+++ b/src/dist/lindley.js
@@ -10,7 +10,7 @@ import { lambertW1m } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \theta) = 1 - e^{-\theta x}\!\left(1 + \frac{\theta x}{1 + \theta}\right)$
+ * $F(x; \theta) = 1 - e^{-\theta x}\left(1 + \frac{\theta x}{1 + \theta}\right)$
  *
  * @class Lindley
  * @memberof ran.dist

--- a/src/dist/log-cauchy.js
+++ b/src/dist/log-cauchy.js
@@ -9,7 +9,7 @@ import Cauchy from './cauchy'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \sigma) = \frac{1}{2} + \frac{1}{\pi}\arctan\!\left(\frac{\ln x - \mu}{\sigma}\right)$
+ * $F(x; \mu, \sigma) = \frac{1}{2} + \frac{1}{\pi}\arctan\left(\frac{\ln x - \mu}{\sigma}\right)$
  *
  * @class LogCauchy
  * @memberof ran.dist

--- a/src/dist/log-gamma.js
+++ b/src/dist/log-gamma.js
@@ -12,7 +12,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \alpha, \beta, \mu) = P\!\left(\alpha,\, \beta\ln(x - \mu + 1)\right)$
+ * $F(x; \alpha, \beta, \mu) = P\left(\alpha,\, \beta\ln(x - \mu + 1)\right)$
  *
  * @class LogGamma
  * @memberof ran.dist

--- a/src/dist/log-normal.js
+++ b/src/dist/log-normal.js
@@ -10,7 +10,7 @@ import { erfinv } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \sigma) = \Phi\!\left(\frac{\ln x - \mu}{\sigma}\right)$
+ * $F(x; \mu, \sigma) = \Phi\left(\frac{\ln x - \mu}{\sigma}\right)$
  *
  * where $\Phi$ is the standard normal CDF.
  *

--- a/src/dist/logit-normal.js
+++ b/src/dist/logit-normal.js
@@ -10,7 +10,7 @@ import { erfinv } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \sigma) = \Phi\!\left(\frac{\operatorname{logit}(x) - \mu}{\sigma}\right)$
+ * $F(x; \mu, \sigma) = \Phi\left(\frac{\operatorname{logit}(x) - \mu}{\sigma}\right)$
  *
  * where $\operatorname{logit}(x) = \ln(x/(1-x))$.
  *

--- a/src/dist/makeham.js
+++ b/src/dist/makeham.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \alpha, \beta, \lambda) = 1 - \exp\!\left(-\lambda x - \frac{\alpha}{\beta}\left(e^{\beta x} - 1\right)\right)$
+ * $F(x; \alpha, \beta, \lambda) = 1 - \exp\left(-\lambda x - \frac{\alpha}{\beta}\left(e^{\beta x} - 1\right)\right)$
  *
  * @class Makeham
  * @memberof ran.dist

--- a/src/dist/maxwell-boltzmann.js
+++ b/src/dist/maxwell-boltzmann.js
@@ -12,7 +12,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; a) = P\!\left(\frac{3}{2},\, \frac{x^2}{2a^2}\right)$
+ * $F(x; a) = P\left(\frac{3}{2},\, \frac{x^2}{2a^2}\right)$
  *
  * @class MaxwellBoltzmann
  * @memberof ran.dist

--- a/src/dist/moyal.js
+++ b/src/dist/moyal.js
@@ -10,7 +10,7 @@ import { gammaUpperIncomplete, erfinv } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \sigma) = \operatorname{erfc}\!\left(\frac{1}{\sqrt{2}} e^{-(x-\mu)/(2\sigma)}\right)$
+ * $F(x; \mu, \sigma) = \operatorname{erfc}\left(\frac{1}{\sqrt{2}} e^{-(x-\mu)/(2\sigma)}\right)$
  *
  * @class Moyal
  * @memberof ran.dist

--- a/src/dist/muth.js
+++ b/src/dist/muth.js
@@ -12,7 +12,7 @@ import { lambertW1m } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \alpha) = 1 - \exp\!\left(\alpha x - \frac{e^{\alpha x} - 1}{\alpha}\right)$
+ * $F(x; \alpha) = 1 - \exp\left(\alpha x - \frac{e^{\alpha x} - 1}{\alpha}\right)$
  *
  * @class Muth
  * @memberof ran.dist

--- a/src/dist/nakagami.js
+++ b/src/dist/nakagami.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; m, \Omega) = P\!\left(m,\, \frac{m}{\Omega} x^2\right)$
+ * $F(x; m, \Omega) = P\left(m,\, \frac{m}{\Omega} x^2\right)$
  *
  * @class Nakagami
  * @memberof ran.dist

--- a/src/dist/normal.js
+++ b/src/dist/normal.js
@@ -11,7 +11,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \sigma) = \frac{1}{2}\left[1 + \operatorname{erf}\!\left(\frac{x - \mu}{\sigma\sqrt{2}}\right)\right]$
+ * $F(x; \mu, \sigma) = \frac{1}{2}\left[1 + \operatorname{erf}\left(\frac{x - \mu}{\sigma\sqrt{2}}\right)\right]$
  *
  * @class Normal
  * @memberof ran.dist

--- a/src/dist/raised-cosine.js
+++ b/src/dist/raised-cosine.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, s) = \frac{1}{2}\!\left(1 + \frac{x - \mu}{s} + \frac{\sin(\pi(x-\mu)/s)}{\pi}\right)$
+ * $F(x; \mu, s) = \frac{1}{2}\left(1 + \frac{x - \mu}{s} + \frac{\sin(\pi(x-\mu)/s)}{\pi}\right)$
  *
  * @class RaisedCosine
  * @memberof ran.dist

--- a/src/dist/skew-normal.js
+++ b/src/dist/skew-normal.js
@@ -13,7 +13,7 @@ import Normal from './normal'
  *
  * Cumulative distribution function:
  *
- * $F(x; \xi, \omega, \alpha) = \Phi\!\left(\frac{x - \xi}{\omega}\right) - 2\,T\!\left(\frac{x - \xi}{\omega},\, \alpha\right)$
+ * $F(x; \xi, \omega, \alpha) = \Phi\left(\frac{x - \xi}{\omega}\right) - 2\,T\left(\frac{x - \xi}{\omega},\, \alpha\right)$
  *
  * where $T(h, a)$ is Owen's T function
  *

--- a/src/dist/truncated-normal.js
+++ b/src/dist/truncated-normal.js
@@ -13,7 +13,7 @@ import { erfinv } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; \mu, \sigma, a, b) = \frac{\Phi\!\left(\frac{x-\mu}{\sigma}\right) - \Phi\!\left(\frac{a-\mu}{\sigma}\right)}{\Phi\!\left(\frac{b-\mu}{\sigma}\right) - \Phi\!\left(\frac{a-\mu}{\sigma}\right)}$
+ * $F(x; \mu, \sigma, a, b) = \frac{\Phi\left(\frac{x-\mu}{\sigma}\right) - \Phi\left(\frac{a-\mu}{\sigma}\right)}{\Phi\left(\frac{b-\mu}{\sigma}\right) - \Phi\left(\frac{a-\mu}{\sigma}\right)}$
  *
  * @class TruncatedNormal
  * @memberof ran.dist

--- a/src/dist/u-quadratic.js
+++ b/src/dist/u-quadratic.js
@@ -10,7 +10,7 @@ import Distribution from './_distribution'
  *
  * Cumulative distribution function:
  *
- * $F(x; a, b) = \frac{\alpha}{3}\!\left[(x - \beta)^3 + \left(\frac{b-a}{2}\right)^3\right]$
+ * $F(x; a, b) = \frac{\alpha}{3}\left[(x - \beta)^3 + \left(\frac{b-a}{2}\right)^3\right]$
  *
  * where $\alpha = 12/(b-a)^3$ and $\beta = (a+b)/2$
  *

--- a/src/dist/uniform-product.js
+++ b/src/dist/uniform-product.js
@@ -11,7 +11,7 @@ import { gamma, gammaUpperIncomplete } from '../special'
  *
  * Cumulative distribution function:
  *
- * $F(x; n) = Q\!\left(n,\, -\ln x\right)$
+ * $F(x; n) = Q\left(n,\, -\ln x\right)$
  *
  * where $Q(a,x)$ is the regularized upper incomplete gamma function
  *


### PR DESCRIPTION
## Summary
- Removes `\!` (LaTeX negative thin space) from CDF formula lines across 35 distribution files — these were inserted by the previous PR but shouldn't be there

## Non-trivial changes
_No logic changes — purely JSDoc text edits._

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_018CSdyuzpXMqmnifEBnZAHx)_