### PR TITLE
Fix pdf() NaN propagation at closed boundaries and Beta boundary formula

### DIFF
--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -527,7 +527,14 @@ class Distribution {
     }
 
     // Return value
-    return this._pdf(z)
+    const v = this._pdf(z)
+    // Formula divergences (e.g. log-barrier 0/0) at an exact closed boundary produce NaN even
+    // though the point is in the support. The limit is 0 by continuity, so return 0 instead of
+    // propagating NaN into tanhSinh and corrupting numerical moments.
+    if (Number.isNaN(v) && ((this.s[0].closed && z === this.s[0].value) || (this.s[1].closed && z === this.s[1].value))) {
+      return 0
+    }
+    return v
   }
 
   /**

--- a/src/dist/beta.js
+++ b/src/dist/beta.js
@@ -78,12 +78,17 @@ export default class Beta extends Distribution {
       return 1
     }
 
-    const a = this.c.alphaM1 * Math.log(x)
+    // When one exponent is 0, its log term would be 0*log(boundary) = 0*(-Inf) = NaN; handle it
+    // separately so the correct finite limit is returned.
+    if (this.c.alphaM1 === 0) {
+      return Math.exp(this.c.betaM1 * Math.log(1 - x) - this.c.lnBeta)
+    }
 
-    const b = this.c.betaM1 * Math.log(1 - x)
+    if (this.c.betaM1 === 0) {
+      return Math.exp(this.c.alphaM1 * Math.log(x) - this.c.lnBeta)
+    }
 
-    // Handle x = 0 and x = 1 cases
-    return Math.exp(a + b - this.c.lnBeta)
+    return Math.exp(this.c.alphaM1 * Math.log(x) + this.c.betaM1 * Math.log(1 - x) - this.c.lnBeta)
   }
 
   _cdf (x) {

--- a/test/dist.js
+++ b/test/dist.js
@@ -361,6 +361,24 @@ describe('dist', () => {
           invalid.pdf(0)
         }, 'Distribution._pdf() is not implemented')
       })
+
+      it('should return 0 when _pdf returns NaN at a closed boundary', () => {
+        // Simulates a log-barrier formula that yields 0/0 = NaN at the boundary endpoint.
+        class NaNBoundary extends Distribution {
+          constructor () {
+            super('continuous', 0)
+            this.s = [{ value: 0, closed: true }, { value: 1, closed: true }]
+            this.c = {}
+          }
+
+          _pdf (x) { return x === 0 ? NaN : 1 }
+          _cdf (x) { return x }
+        }
+        const d = new NaNBoundary()
+        assert.strictEqual(d.pdf(0), 0)
+        assert.strictEqual(d.pdf(0.5), 1)
+        assert.isFalse(isNaN(d.mean()))
+      })
     })
 
     describe('.cdf()', () => {


### PR DESCRIPTION
Closes #773

## Summary
- Added a NaN-sentinel in the base-class `pdf()`: if `_pdf(z)` returns `NaN` at a value exactly equal to a closed-support endpoint, return `0` instead of propagating NaN into `tanhSinh` and corrupting numerical moments.
- Fixed `Beta._pdf` to handle the `alpha=1` (at `x=0`) and `beta=1` (at `x=1`) cases explicitly, avoiding the `0*log(0) = 0*(-Inf) = NaN` IEEE indeterminate form and returning the correct finite limit. This transitively fixes `F`, `BetaPrime`, `BetaRectangular`, `PERT`, and `R` which all delegate to `super._pdf()`.

## Non-trivial changes
- **`src/dist/_distribution.js` (line 534)**: Base-class `pdf()` now guards against NaN at exact closed-boundary points. Without this, any distribution whose `_pdf` formula produces `0/0` at a closed endpoint (e.g. a log-barrier) silently corrupts `_numericalRawMoment`, making `mean()`, `variance()`, `skewness()`, and `kurtosis()` return `NaN`.
- **`src/dist/beta.js` (lines 83–89)**: `_pdf` now handles single-zero-exponent cases before reaching the general `exp(alphaM1*log(x) + betaM1*log(1-x))` path. Previously `alphaM1=0` caused `0*log(0) = NaN` for valid `x=0` inputs; the correct value (`Math.exp(betaM1*log(1-x) - lnBeta)`) is now returned directly.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist.js`**: Regression test for the NaN-at-closed-boundary guard using an inline `NaNBoundary` distribution stub.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_0157pYSXfC4nNCTREP89mGjd)_