### PR TITLE
Fix LogitNormal inherited Normal moments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `LogitNormal.mean()`, `.variance()`, `.skewness()`, and `.kurtosis()` now override the `Normal` base-class fallback with explicit tanh-sinh quadrature over `(0, 1)` instead of inheriting `Normal`'s hard-coded `μ`, `σ²`, `0`, `0` values. When `μ = 0` the distribution is symmetric about `x = 0.5`, giving `mean() = 0.5` and `skewness() = 0` exactly (#756).
 - `Rice.kurtosis()` returned `0` in the Bessel overflow regime (ν/σ > ~53.3, z = ν²/(4σ²) > 709). The correct leading-order asymptotic value is `−6σ²/ν²` from the noncentral-χ² 4th-cumulant expansion around the Gaussian limit; e.g. ≈ −0.00167 at ν/σ = 60 (#766).
 - `YuleSimon.skewness()` now returns `(ρ+1)²·√(ρ−2)/(ρ·(ρ−3))`. The previous formula `(ρ+1)/(ρ−3)·√((ρ−2)/ρ)` was missing a factor of `(ρ+1)/√ρ` — e.g. at ρ=5 the old code returned 2.324 instead of 6.235 (#587).
 - `YuleSimon.kurtosis()` falling-factorial coefficients corrected: `E[K^(n)] = n!·(n-1)!·ρ/∏(ρ−i)`, so f3 = 12ρ and f4 = 144ρ (previously 6ρ and 24ρ, missing the `(n-1)!` factor for n≥3). At ρ=5 the old code returned excess kurtosis ≈19 instead of 118.8 (#587).

--- a/src/dist/logit-normal.js
+++ b/src/dist/logit-normal.js
@@ -48,6 +48,48 @@ export default class LogitNormal extends Normal {
     return 1 / (1 + Math.exp(-(this.p.mu + this.c.sigmaRoot2 * erfinv(2 * p - 1))))
   }
 
+  /**
+   * @returns {number} Mean of the distribution.
+   */
+  mean () {
+    return this._numericalRawMoment(1)
+  }
+
+  /**
+   * @returns {number} Variance of the distribution.
+   */
+  variance () {
+    const m1 = this._numericalRawMoment(1)
+    const m2 = this._numericalRawMoment(2)
+    const v = m2 - m1 * m1
+    return v < 0 ? 0 : v
+  }
+
+  /**
+   * @returns {number} Skewness of the distribution.
+   */
+  skewness () {
+    const m1 = this._numericalRawMoment(1)
+    const m2 = this._numericalRawMoment(2)
+    const m3 = this._numericalRawMoment(3)
+    const v = m2 - m1 * m1
+    if (!(v > 0)) return NaN
+    return (m3 - 3 * m1 * m2 + 2 * Math.pow(m1, 3)) / Math.pow(v, 1.5)
+  }
+
+  /**
+   * @returns {number} Excess kurtosis of the distribution.
+   */
+  kurtosis () {
+    const m1 = this._numericalRawMoment(1)
+    const m2 = this._numericalRawMoment(2)
+    const m3 = this._numericalRawMoment(3)
+    const m4 = this._numericalRawMoment(4)
+    const v = m2 - m1 * m1
+    if (!(v > 0)) return NaN
+    return (m4 - 4 * m1 * m3 + 6 * m1 * m1 * m2 - 3 * Math.pow(m1, 4)) / (v * v) - 3
+  }
+
   static get _fitInitIsExact () {
     // _fitInit returns the exact closed-form MLE, so fit() skips the optimizer (ADR-0016).
     return true

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -3456,6 +3456,12 @@ export default [{
 }, {
   name: 'LogitNormal',
   fit: { params: [0, 1], seed: 42, n: 200, tolerances: { mu: 0.2, sigma: 0.2 } },
+  // Moments via tanhSinh quadrature over (0, 1). mu=0 cases: mean=0.5 and skewness=0 are exact
+  // by symmetry of N(0,1) through the logistic transform. Variance/kurtosis from tanhSinh integration.
+  moments: [
+    { params: [0, 1], mean: 0.5, variance: 0.043379035858092996, skewness: 0, kurtosis: -0.8606196018182741, tol: { mean: 1e-12, variance: 1e-10, skewness: 1e-8, kurtosis: 1e-6 } },
+    { params: [1, 0.5], mean: 0.7205808152432993, variance: 0.009402931736068987, skewness: -0.5671643683436923, kurtosis: 0.1930958554263773, tol: 1e-6 }
+  ],
   invalidParams: [
     [], // all params required
     [0, -1], [0, 0] // sigma > 0


### PR DESCRIPTION
Closes #756

## Summary
- `LogitNormal` extended `Normal` and inherited `mean()=μ`, `variance()=σ²`, `skewness()=0`, `kurtosis()=0` — all wrong. The logit-normal distribution has no closed-form moments; they must be computed by numerical integration over `(0, 1)`.
- Adds `mean()`, `variance()`, `skewness()`, and `kurtosis()` overrides that delegate to `this._numericalRawMoment(n)`, following the identical pattern already established in `JohnsonSB`.
- `BirnbaumSaunders` was already fixed in a prior session (#582) and required no changes here.

## Non-trivial changes
- **`src/dist/logit-normal.js`**: Four moment methods added. The `μ=0` case is symmetric about `x=0.5` through the logistic transform, so `mean()=0.5` and `skewness()=0` are exact; variance and kurtosis come from tanh-sinh quadrature over the open support `(0, 1)`.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Two `moments:` entries added for `LogitNormal` — symmetric case `(0, 1)` with tight tolerances on mean/skewness (exact by symmetry) and loose on variance/kurtosis (quadrature), plus asymmetric case `(1, 0.5)` at `tol: 1e-6`.
- **`CHANGELOG.md`**: Bug fix entry added under `### Fixed`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_015wAw5tBxiFyYBCeS8P2tZG)_