### PR TITLE
Clarify Slash moment JSDoc: all moments undefined (E[|X|] diverges like Cauchy)

### DIFF
--- a/src/dist/slash.js
+++ b/src/dist/slash.js
@@ -58,14 +58,14 @@ export default class Slash extends Normal {
   }
 
   /**
-   * @returns {number} Mean of the distribution (undefined for Slash).
+   * @returns {number} NaN (mean does not exist for the Slash distribution — E[|X|] diverges, same as Cauchy).
    */
   mean () {
     return NaN
   }
 
   /**
-   * @returns {number} Variance of the distribution (undefined for Slash).
+   * @returns {number} NaN (variance does not exist for the Slash distribution — Slash tails decay as 1/x², same as Cauchy, so E[|X|] diverges and all moments are undefined).
    */
   variance () {
     return NaN

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -4910,7 +4910,7 @@ export default [{
 }, {
   name: 'Slash',
   moments: [
-    // All moments of the Slash distribution are undefined.
+    // Slash tails decay as 1/x² (same as Cauchy), so E[|X|] diverges and all moments are undefined.
     { params: [], mean: NaN, variance: NaN, skewness: NaN, kurtosis: NaN }
   ],
   invalidParams: [],


### PR DESCRIPTION
Closes #753

## Summary
- The `mean()` and `variance()` JSDoc `@returns` descriptions in `src/dist/slash.js` were vague ("undefined for Slash"). Replaced with explicit mathematical rationale: the Slash PDF decays as 1/x² (same as Cauchy), so E[|X|] diverges and all moments are undefined — consistent with the Lebesgue convention used for Cauchy and Student's t with ν ≤ 1.
- Test comment updated to explain the tail-decay reason rather than just stating the conclusion.
- Return values (`NaN` for all four moments) are unchanged — they were already correct from #736.

## Design decisions
- Issue #753 originally proposed `mean() = 0` (Cauchy principal value) and `variance() = Infinity`. After reviewing the project's Lebesgue convention (see `cauchy.js` returning `NaN`, `student-t.js` returning `NaN` for ν ≤ 1), the consistent choice is `NaN` for all Slash moments. The principal-value `0` would be an inconsistency since Cauchy — which has identical 1/x² tail decay — also returns `NaN`.

## Non-trivial changes
_No non-trivial changes — this PR is purely a documentation clarification (JSDoc and test comment). Return values are unchanged._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_018U34zr8zBRvaW6f17rvXP4)_