### PR TITLE
Fix BetaPrime kurtosis formula typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `BetaPrime.kurtosis()` denominator factor corrected from `(beta + 1)` to `(beta - 2)`, matching the Wikipedia formula. The typo caused silently wrong excess kurtosis for all valid inputs (β > 4); e.g. `BetaPrime(2, 5).kurtosis()` returned 66 instead of 54 (#752).
 - `LogitNormal.mean()`, `.variance()`, `.skewness()`, and `.kurtosis()` now override the `Normal` base-class fallback with explicit tanh-sinh quadrature over `(0, 1)` instead of inheriting `Normal`'s hard-coded `μ`, `σ²`, `0`, `0` values. When `μ = 0` the distribution is symmetric about `x = 0.5`, giving `mean() = 0.5` and `skewness() = 0` exactly (#756).
 - `Rice.kurtosis()` returned `0` in the Bessel overflow regime (ν/σ > ~53.3, z = ν²/(4σ²) > 709). The correct leading-order asymptotic value is `−6σ²/ν²` from the noncentral-χ² 4th-cumulant expansion around the Gaussian limit; e.g. ≈ −0.00167 at ν/σ = 60 (#766).
 - `YuleSimon.skewness()` now returns `(ρ+1)²·√(ρ−2)/(ρ·(ρ−3))`. The previous formula `(ρ+1)/(ρ−3)·√((ρ−2)/ρ)` was missing a factor of `(ρ+1)/√ρ` — e.g. at ρ=5 the old code returned 2.324 instead of 6.235 (#587).

--- a/src/dist/beta-prime.js
+++ b/src/dist/beta-prime.js
@@ -92,7 +92,7 @@ export default class BetaPrime extends Beta {
   kurtosis () {
     const { alpha, beta } = this.p
     if (beta <= 4) return Infinity
-    return 6 * (alpha * (alpha + beta - 1) * (5 * beta - 11) + (beta - 1) ** 2 * (beta + 1)) /
+    return 6 * (alpha * (alpha + beta - 1) * (5 * beta - 11) + (beta - 1) ** 2 * (beta - 2)) /
       (alpha * (alpha + beta - 1) * (beta - 3) * (beta - 4))
   }
 }

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -428,7 +428,7 @@ export default [{
   fit: { params: [2, 3], seed: 42, n: 200, tolerances: { alpha: 0.7, beta: 1.0 } },
   // Moments are Infinity below threshold: mean (β≤1), variance (β≤2), skewness (β≤3), kurtosis (β≤4)
   moments: [
-    { params: [2, 5], mean: 0.5, variance: 0.25, skewness: 4, kurtosis: 66 },
+    { params: [2, 5], mean: 0.5, variance: 0.25, skewness: 4, kurtosis: 54 },
     { params: [2, 1], mean: Infinity, variance: Infinity, skewness: Infinity, kurtosis: Infinity },
     { params: [2, 2], mean: 2, variance: Infinity, skewness: Infinity, kurtosis: Infinity },
     { params: [2, 3], mean: 1, variance: 2, skewness: Infinity, kurtosis: Infinity },


### PR DESCRIPTION
Closes #752

## Summary
- Corrects a one-token typo in `BetaPrime.kurtosis()`: the factor `(beta - 1) ** 2 * (beta + 1)` is replaced with `(beta - 1) ** 2 * (beta - 2)`, matching the Wikipedia formula for beta prime excess kurtosis.
- The bug caused silently wrong results for all valid inputs (β > 4); e.g. `BetaPrime(2, 5).kurtosis()` returned 66 instead of 54.
- Updates the `moments` test reference from 66 to 54 (the old value was baked from the buggy formula).

## Non-trivial changes
- **`src/dist/beta-prime.js` line 95**: Formula fix — `(beta + 1)` → `(beta - 2)` in the numerator of the excess kurtosis expression.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Kurtosis moment reference corrected from 66 to 54.
- **`CHANGELOG.md`**: Bug fix entry added under `### Fixed`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMDsncCV1oT1yzSj71yfWc)_