### PR TITLE
Make Distribution.load() a static factory, add type and k to save()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `YuleSimon.kurtosis()` falling-factorial coefficients corrected: `E[K^(n)] = n!·(n-1)!·ρ/∏(ρ−i)`, so f3 = 12ρ and f4 = 144ρ (previously 6ρ and 24ρ, missing the `(n-1)!` factor for n≥3). At ρ=5 the old code returned excess kurtosis ≈19 instead of 118.8 (#587).
 - `FlorySchulz._fitInit` seed corrected from `2/mean` to `2/(mean+1)`, matching the distribution's mean formula `E[X]=(2−a)/a` (previously the comment and implementation used the wrong formula `E[X]=2/a`) (#587).
 
+### Changed
 
+- `Distribution.save()` now includes `type` and `k` fields in the snapshot. `Distribution.load()` is now a static factory method — call `ran.dist.Pareto.load(state)` instead of `new ran.dist.Pareto().load(state)`. The static form reconstructs an instance without a throw-away constructor call (#537).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ d.bic(data)       // Bayesian information criterion
 d.test(data)      // KS test (continuous) or chi-squared test (discrete)
 d.seed(value)     // set PRNG seed; returns the instance
 d.save()          // serialise PRNG state + parameters to a plain object
-d.load(state)     // restore from a saved state; returns the instance
 
-ran.dist.Gamma.fit(data)  // static — MLE fit; returns a new instance
+ran.dist.Gamma.load(state)  // static — restore from a saved state; returns a new instance
+ran.dist.Gamma.fit(data)    // static — MLE fit; returns a new instance
 ```
 
 ## Return values and errors

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -402,14 +402,14 @@ class Distribution {
    *
    * @method save
    * @memberof ran.dist.Distribution
-   * @returns {{prngState: *, params: Object, constants: Object, support: {value: number, closed: boolean}[]}} Object representing the inner state of the current generator.
+   * @returns {{type: string, k: number, prngState: *, params: Object, constants: Object, support: {value: number, closed: boolean}[]}} Object representing the inner state of the current generator.
    * @example
    *
    * let pareto1 = new ran.dist.Pareto(1, 2).seed('test')
    * let sample1 = pareto1.sample(2)
    * let state = pareto1.save()
    *
-   * let pareto2 = new ran.dist.Pareto().load(state)
+   * let pareto2 = ran.dist.Pareto.load(state)
    * let sample2 = pareto2.sample(3)
    * // => [ 1.1315154468682591,
    * //      5.44269493220745,
@@ -418,6 +418,8 @@ class Distribution {
    */
   save () {
     return {
+      type: this._type,
+      k: this.k,
       prngState: this.r.save(),
       params: this.p,
       constants: this.c,
@@ -426,40 +428,41 @@ class Distribution {
   }
 
   /**
-   * Loads a new state for the generator.
+   * Reconstructs a distribution instance from a snapshot created by save(). No constructor call is needed.
    *
    * @method load
    * @memberof ran.dist.Distribution
-   * @param {Object} state The state to load.
-   * @returns {this} Reference to the current distribution.
+   * @param {Object} state The state to load, as returned by save().
+   * @returns {Distribution} New distribution instance with the restored state.
    * @example
    *
    * let pareto1 = new ran.dist.Pareto(1, 2).seed('test')
    * let sample1 = pareto1.sample(2)
    * let state = pareto1.save()
    *
-   * let pareto2 = new ran.dist.Pareto().load(state)
+   * let pareto2 = ran.dist.Pareto.load(state)
    * let sample2 = pareto2.sample(3)
    * // => [ 1.1315154468682591,
    * //      5.44269493220745,
    * //      1.2587482868229616 ]
    *
    */
-  load (state) {
-    // Set parameters
-    this.p = state.params
-
-    // Set helper constants
-    this.c = state.constants
-
-    // Set support
-    this.s = state.support
-
-    // Set PRNG state
-    this.r.load(state.prngState)
-
-    return this
+  static load (state) {
+    const instance = Object.create(this.prototype)
+    instance._type = state.type
+    instance.k = state.k
+    instance.p = state.params
+    instance.s = state.support
+    instance.c = state.constants
+    instance.r = new Xoshiro128p()
+    instance.r.load(state.prngState)
+    instance._afterLoad()
+    return instance
   }
+
+  // Hook for subclasses that store non-serializable state (AliasTable, lazy look-up tables, etc.)
+  // beyond the four standard fields. Override to rebuild those structures from this.p/this.c.
+  _afterLoad () {}
 
   /**
    * @overload

--- a/src/dist/_pre-computed.js
+++ b/src/dist/_pre-computed.js
@@ -19,10 +19,20 @@ export default class PreComputed extends Distribution {
     this.TABLE_SIZE = 1000
     this.MAX_NUMBER_OF_TABLES = 100
 
-    // Logarithmic pdf
+    // Logarithmic pdf — stored in this.c so it survives a save()/load() round-trip
+    Object.assign(this.c, { logP })
     this.logP = logP
 
     // Look-up tables
+    this.aliasTables = []
+    this.pdfTable = []
+    this.cdfTable = []
+  }
+
+  _afterLoad () {
+    this.TABLE_SIZE = 1000
+    this.MAX_NUMBER_OF_TABLES = 100
+    this.logP = this.c.logP
     this.aliasTables = []
     this.pdfTable = []
     this.cdfTable = []

--- a/src/dist/categorical.js
+++ b/src/dist/categorical.js
@@ -55,6 +55,19 @@ export default class Categorical extends Distribution {
       this.pdfTable.push(weight)
       this.cdfTable.push(this.cdfTable[i - 1] + weight)
     }
+
+    // Store normalized weights in this.c so they survive a save()/load() round-trip.
+    // Subclasses overwrite this.p, so this.c is the only stable serialized home for the table.
+    this.c.pdfTable = this.pdfTable
+  }
+
+  _afterLoad () {
+    this.aliasTable = new AliasTable(this.c.pdfTable)
+    this.pdfTable = this.c.pdfTable
+    this.cdfTable = [this.pdfTable[0]]
+    for (let i = 1; i < this.pdfTable.length; i++) {
+      this.cdfTable.push(this.cdfTable[i - 1] + this.pdfTable[i])
+    }
   }
 
   _generator () {

--- a/src/dist/conway-maxwell-poisson.js
+++ b/src/dist/conway-maxwell-poisson.js
@@ -52,9 +52,9 @@ export default class ConwayMaxwellPoisson extends PreComputed {
       logZ = m + Math.log(Math.exp(logZ - m) + Math.exp(logTerm - m))
     } while (logTerm > logZ + LOG_TOL)
 
-    this.c = {
+    Object.assign(this.c, {
       logP0: -logZ
-    }
+    })
   }
 
   static _fitInit (data) {

--- a/src/dist/delaporte.js
+++ b/src/dist/delaporte.js
@@ -44,11 +44,11 @@ export default class Delaporte extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = {
+    Object.assign(this.c, {
       r: beta / (lambda * (1 + beta)),
       baseLogProb: -lambda - alpha * Math.log(1 + beta),
       logLambda: Math.log(lambda)
-    }
+    })
   }
 
   static _fitInit (data) {

--- a/src/dist/generalized-hermite.js
+++ b/src/dist/generalized-hermite.js
@@ -47,11 +47,11 @@ export default class GeneralizedHermite extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = {
+    Object.assign(this.c, {
       logMu: Math.log(a1 + m * a2),
       d: (a1 + m * m * a2) / (a1 + m * a2),
       baseLogProb: -a1 - a2
-    }
+    })
   }
 
   static _fitInit (data) {

--- a/src/dist/heads-minus-tails.js
+++ b/src/dist/heads-minus-tails.js
@@ -42,9 +42,9 @@ export default class HeadsMinusTails extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = {
+    Object.assign(this.c, {
       baseLogProb: 2 * ni * Math.log(0.5)
-    }
+    })
   }
 
   static _fitInit (data) {

--- a/src/dist/hyperexponential.js
+++ b/src/dist/hyperexponential.js
@@ -55,6 +55,10 @@ export default class Hyperexponential extends Distribution {
     this.aliasTable = new AliasTable(weights)
   }
 
+  _afterLoad () {
+    this.aliasTable = new AliasTable(this.p.weights)
+  }
+
   _generator () {
     // Direct sampling
     const i = this.aliasTable.sample(this.r)

--- a/src/dist/neyman-a.js
+++ b/src/dist/neyman-a.js
@@ -40,10 +40,10 @@ export default class NeymanA extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = {
+    Object.assign(this.c, {
       p0: Math.exp(-lambda * (1 - Math.exp(-phi))),
       r: lambda * phi * Math.exp(-phi)
-    }
+    })
   }
 
   static _fitInit (data) {

--- a/src/dist/polya-aeppli.js
+++ b/src/dist/polya-aeppli.js
@@ -40,9 +40,9 @@ export default class PolyaAeppli extends PreComputed {
     }]
 
     // Speed-up constants
-    this.c = {
+    Object.assign(this.c, {
       logP1: Math.log(lambda * (1 - theta)) - lambda
-    }
+    })
   }
 
   static _fitInit (data) {

--- a/test/dist.js
+++ b/test/dist.js
@@ -72,9 +72,8 @@ const UnitTests = {
       generator.seed(s)
       const values1 = generator.sample(cut)
       const state = generator.save()
-      generator.seed(0)
-      generator.load(state)
-      const values2 = generator.sample(sampleSize - cut)
+      const restored = dist[tc.name].load(state)
+      const values2 = restored.sample(sampleSize - cut)
 
       // Compare samples
       assert(values1.concat(values2).reduce((acc, d, i) => acc || d === values[i], true))
@@ -90,8 +89,8 @@ const UnitTests = {
       const state = generator1.save()
       const values1 = generator1.sample(10)
 
-      // Generate new default generator and load state
-      const generator2 = new dist[tc.name](...tc.cases[0].params()).load(state)
+      // Generate new instance from saved state
+      const generator2 = dist[tc.name].load(state)
       const values2 = generator2.sample(10)
 
       // Compare samples
@@ -1581,7 +1580,7 @@ describe('dist', () => {
       describe(tc.name, () => {
         describe('constructor', () => UnitTests.constructor(tc))
         describe('.seed()', () => UnitTests.seed(tc))
-        describe('.load(), .save()', () => UnitTests.loadAndSave(tc))
+        describe('static .load(), .save()', () => UnitTests.loadAndSave(tc))
         describe('.pdf(), .cdf(), .q()', () => UnitTests.analytical(tc))
         describe('.sample()', () => UnitTests.sample(tc))
         describe('.test()', () => UnitTests.test(tc))

--- a/types-test.ts
+++ b/types-test.ts
@@ -29,7 +29,7 @@ const sp = n.support()
 const _sv: number = sp[0].value
 const _sc: boolean = sp[0].closed
 const state = n.save()
-n.load(state)
+ran.dist.Normal.load(state)
 n.seed(42)
 n.seed('test')
 const _fitted = ran.dist.Normal.fit([1, 2, 3, 4, 5])


### PR DESCRIPTION
Closes #537

> **⚠ Missing ADR**: This PR contains non-trivial changes but no Architecture Decision Record was found.
> Consider adding one at `decisions/` to document the design rationale.
> See `decisions/0000-template.md` for the format.

## Summary
- `Distribution.save()` now includes `type` and `k` fields so snapshots are self-contained — a round-trip no longer relies on the constructor having been called with the right arguments first
- `Distribution.load()` is converted from an instance method to a `static` factory using `Object.create(this.prototype)` — avoids a throw-away constructor call and works correctly even when the constructor has required parameters
- A `_afterLoad()` virtual hook is added so subclasses with non-serializable state (`AliasTable`, `PreComputed` look-up tables) can rebuild it after the base-class fields are restored

## Non-trivial changes
- **`src/dist/_distribution.js`**: `save()` gains `type` and `k` fields; `load()` becomes `static` and uses `Object.create` + `_afterLoad()` hook instead of mutating an existing instance; JSDoc and examples updated to reflect static call pattern
- **`src/dist/_pre-computed.js`**: `logP` moved into `this.c` (via `Object.assign`) so it survives serialization; `_afterLoad()` override reconstructs `TABLE_SIZE`, `MAX_NUMBER_OF_TABLES`, `logP`, and empties the lazy look-up table arrays
- **`src/dist/categorical.js`**: Normalized `pdfTable` stored in `this.c.pdfTable` at construction time (the only stable home — subclasses overwrite `this.p`); `_afterLoad()` rebuilds `aliasTable` and `cdfTable` from it
- **`src/dist/hyperexponential.js`**: `_afterLoad()` rebuilds the `AliasTable` from `this.p.weights`
- **`src/dist/neyman-a.js`, `polya-aeppli.js`, `generalized-hermite.js`, `heads-minus-tails.js`, `conway-maxwell-poisson.js`, `delaporte.js`**: `this.c = {...}` changed to `Object.assign(this.c, {...})` to avoid silently overwriting the `logP` key set by the `PreComputed` parent constructor
- **`test/dist.js`**: Both `loadAndSave` tests updated to use `dist[name].load(state)` (static) instead of `generator.load(state)` (instance); describe label updated to match
- **`README.md`**: `d.load(state)` corrected to `ran.dist.Gamma.load(state)` in the static methods reference table

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: New `### Changed` entry under `[Unreleased]` documenting the API change
- **`test/dist.js` line 1580**: Describe label updated from `.load(), .save()` to `static .load(), .save()`

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_017nZfAoAdCGVZGXedyqM5Y3)_