### PR TITLE
Fix Zeta.kurtosis() divergence sentinel for 3 &lt; s ≤ 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `YuleSimon.skewness()` now returns `(ρ+1)²·√(ρ−2)/(ρ·(ρ−3))`. The previous formula `(ρ+1)/(ρ−3)·√((ρ−2)/ρ)` was missing a factor of `(ρ+1)/√ρ` — e.g. at ρ=5 the old code returned 2.324 instead of 6.235 (#587).
 - `YuleSimon.kurtosis()` falling-factorial coefficients corrected: `E[K^(n)] = n!·(n-1)!·ρ/∏(ρ−i)`, so f3 = 12ρ and f4 = 144ρ (previously 6ρ and 24ρ, missing the `(n-1)!` factor for n≥3). At ρ=5 the old code returned excess kurtosis ≈19 instead of 118.8 (#587).
 - `FlorySchulz._fitInit` seed corrected from `2/mean` to `2/(mean+1)`, matching the distribution's mean formula `E[X]=(2−a)/a` (previously the comment and implementation used the wrong formula `E[X]=2/a`) (#587).
+- `Zeta.kurtosis()` now returns `Infinity` (not `NaN`) for `3 < s ≤ 4`, where the variance is finite (requires only `s > 3`) but the 4th central moment diverges. The previous `s ≤ 4 → NaN` boundary conflated a divergent moment with an undefined one, contradicting the divergence convention and the sibling `Zeta.skewness()` logic.
 
 
 

--- a/src/dist/normal.js
+++ b/src/dist/normal.js
@@ -17,7 +17,7 @@ import Distribution from './_distribution'
 export default class Normal extends Distribution {
   /**
    * @param {number} mu Location parameter (mean).
-   * @param {number} sigma Squared scale parameter (variance).
+   * @param {number} sigma Scale parameter (standard deviation).
    */
   constructor (mu, sigma) {
     super('continuous', 2)

--- a/src/dist/zeta.js
+++ b/src/dist/zeta.js
@@ -88,7 +88,10 @@ export default class Zeta extends Distribution {
    */
   kurtosis () {
     const { s } = this.p
-    if (s <= 4) return NaN
+    // Variance is finite for s > 3 (E[X^2] = zeta(s-2)/zeta(s) converges); when the 4th
+    // central moment diverges over a finite variance the excess kurtosis is +Infinity, not
+    // undefined. Only s <= 3 (non-finite variance) makes the standardization undefined.
+    if (s <= 3) return NaN
     if (s <= 5) return Infinity
     const zs = this.c.zetaS
     const mu1 = riemannZeta(s - 1) / zs

--- a/test/dist-cases-discrete.js
+++ b/test/dist-cases-discrete.js
@@ -1477,7 +1477,7 @@ export default [{
   // mean=ζ(s-1)/ζ(s) for s>2; var=ζ(s-2)/ζ(s)-mean² for s>3; skew/kurt finite for s>4/s>5
   moments: [
     { params: [2.5], mean: 1.9473724663169567, variance: Infinity, skewness: NaN, kurtosis: NaN, tol: 1e-10 },
-    { params: [3.8], mean: 1.1362363598724141, variance: 0.42396600465009526, skewness: Infinity, kurtosis: NaN, tol: 1e-10 },
+    { params: [3.8], mean: 1.1362363598724141, variance: 0.42396600465009526, skewness: Infinity, kurtosis: Infinity, tol: 1e-10 },
     { params: [5.0], mean: 1.0437788248434812, variance: 0.06977422469107242, skewness: 12.516969344281788, kurtosis: Infinity, tol: 1e-10 },
     { params: [6.5], mean: 1.0130420979439072, variance: 0.01594072946042968, skewness: 12.561822565783675, kurtosis: 279.44610246008324, tol: 1e-8 }
   ],


### PR DESCRIPTION
## Summary

A correctness review of `mean()`/`variance()`/`skewness()`/`kurtosis()` across all 123 distributions surfaced one genuine error: `Zeta.kurtosis()` returned `NaN` for `3 < s ≤ 4`, where the variance is finite (it requires only `s > 3`, since `E[X²] = ζ(s−2)/ζ(s)` converges) but the 4th central moment diverges (needs `s > 5`). A divergent moment over a finite variance is `+Infinity`, not undefined — `NaN` should apply only when the variance itself is non-finite (`s ≤ 3`). The fix changes the boundary from `if (s <= 4) return NaN` to `if (s <= 3) return NaN; if (s <= 5) return Infinity`, matching the divergence convention (`decisions/0015-return-value-and-error-conventions.md`) and the sibling `Zeta.skewness()` in the same file. The impact is limited to the band `3 < s ≤ 4` and is an `Infinity`-vs-`NaN` distinction only — it never produced a wrong finite number.

Also included:
- `Normal` constructor JSDoc corrected — `sigma` was described as the "squared scale parameter (variance)"; it is the standard deviation, consistent with `_pdf` and `variance() = sigma**2`.
- `Zeta(3.8)` moment test reference updated (`kurtosis: NaN → Infinity`), which had encoded the buggy behavior.

The remaining 121 distributions reviewed clean — no raw-vs-excess kurtosis confusions, sign errors, or off-by-one threshold bugs.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 7184 passing, coverage thresholds met)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior (`Zeta(3.8)` kurtosis reference)
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — n/a
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — n/a
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Production-code diff is under ~400 lines (tests excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BF2jm4i7kYorEJWsao1zK2

---
_Generated by [Claude Code](https://claude.ai/code/session_01BF2jm4i7kYorEJWsao1zK2)_