### PR TITLE
Fix PRNG state aliasing in Distribution.load()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Distribution.load()` now correctly restores PRNG state. `Xoshiro128p.save()` was returning a live reference to the internal `_state` array; any sampling after `save()` mutated that array and corrupted the snapshot before `load()` could read it. Both `save()` and `load()` now copy the state array so each saved snapshot and each loaded generator hold independent copies (#792).
+
 - `BetaPrime.kurtosis()` denominator factor corrected from `(beta + 1)` to `(beta - 2)`, matching the Wikipedia formula. The typo caused silently wrong excess kurtosis for all valid inputs (β > 4); e.g. `BetaPrime(2, 5).kurtosis()` returned 66 instead of 54 (#752).
 - `LogitNormal.mean()`, `.variance()`, `.skewness()`, and `.kurtosis()` now override the `Normal` base-class fallback with explicit tanh-sinh quadrature over `(0, 1)` instead of inheriting `Normal`'s hard-coded `μ`, `σ²`, `0`, `0` values. When `μ = 0` the distribution is symmetric about `x = 0.5`, giving `mean() = 0.5` and `skewness() = 0` exactly (#756).
 - `Rice.kurtosis()` returned `0` in the Bessel overflow regime (ν/σ > ~53.3, z = ν²/(4σ²) > 709). The correct leading-order asymptotic value is `−6σ²/ν²` from the noncentral-χ² 4th-cumulant expansion around the Gaussian limit; e.g. ≈ −0.00167 at ν/σ = 60 (#766).

--- a/src/core/xoshiro.js
+++ b/src/core/xoshiro.js
@@ -93,7 +93,7 @@ class Xoshiro128p {
    * @ignore
    */
   load (state) {
-    this._state = state
+    this._state = state.slice()
   }
 
   /**
@@ -106,7 +106,7 @@ class Xoshiro128p {
    * @ignore
    */
   save () {
-    return this._state
+    return this._state.slice()
   }
 }
 

--- a/test/dist.js
+++ b/test/dist.js
@@ -65,7 +65,8 @@ const UnitTests = {
       const s = 123456789 // fixed seed so CI failures are reproducible
       const cut = Math.floor(sampleSize / 3)
 
-      // Generate full sample
+      // Generate full sample from seeded generator
+      generator.seed(s)
       const values = generator.sample(sampleSize)
 
       // Reset generator, create two sub samples
@@ -75,8 +76,8 @@ const UnitTests = {
       const restored = dist[tc.name].load(state)
       const values2 = restored.sample(sampleSize - cut)
 
-      // Compare samples
-      assert(values1.concat(values2).reduce((acc, d, i) => acc || d === values[i], true))
+      // All values must match the seeded reference sequence
+      assert(values1.concat(values2).reduce((acc, d, i) => acc && d === values[i], true))
     })
 
     it('loaded state should copy full state of generator', () => {
@@ -93,8 +94,8 @@ const UnitTests = {
       const generator2 = dist[tc.name].load(state)
       const values2 = generator2.sample(10)
 
-      // Compare samples
-      assert(values1.reduce((acc, d, i) => acc || d !== values2[i], true) === true)
+      // Both generators must produce identical sequences from the same restored state
+      assert(values2.every((d, i) => d === values1[i]))
     })
   },
 


### PR DESCRIPTION
Closes #792

## Summary
- `Xoshiro128p.save()` was returning a live reference to its internal `_state` array. Any sampling after `save()` mutated the returned array, corrupting the snapshot before `load()` could consume it — causing `Distribution.load()` to silently restore the wrong PRNG state.
- Both `save()` and `load()` now copy the state array with `.slice()`, so each snapshot and each loaded instance hold fully independent copies.
- The two `loadAndSave` assertions in `UnitTests` were vacuously true (`reduce` with `||` and initial `true` short-circuits to `true` immediately); corrected to `&&` and `every` so they actually detect divergent sequences. Test 1 also seeds the reference sample from the same seed as the split-sample run.

## Non-trivial changes
- **`src/core/xoshiro.js`**: `save()` returns `this._state.slice()` and `load()` sets `this._state = state.slice()`. Without this, `save()` returned the live internal array — the caller held a reference that was mutated by subsequent PRNG calls, making `load()` restore the current state rather than the saved state.
- **`test/dist.js`**: Both `loadAndSave` assertions corrected from vacuous `reduce(…||…, true)` forms to `reduce(…&&…, true)` / `every(…)`. Also fixes test 1 to seed the generator before sampling the reference sequence.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVpb9nBfWxsuPjktNkrkd3)_