### PR TITLE
Move save/load out of Distribution API table into own subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,24 @@ d.aic(data)       // Akaike information criterion
 d.bic(data)       // Bayesian information criterion
 d.test(data)      // KS test (continuous) or chi-squared test (discrete)
 d.seed(value)     // set PRNG seed; returns the instance
-d.save()          // serialise PRNG state + parameters to a plain object
 
-ran.dist.Gamma.load(state)  // static — restore from a saved state; returns a new instance
 ran.dist.Gamma.fit(data)    // static — MLE fit; returns a new instance
+```
+
+### State serialisation
+
+`save()` and `load(state)` let you snapshot and restore the exact PRNG state and parameters of a distribution instance, so a sequence of samples can be reproduced exactly across sessions or process restarts.
+
+```javascript
+const d = new ran.dist.Gamma(2, 1)
+d.seed(42)
+d.sample(10)                         // advance the internal PRNG
+
+const state = d.save()               // plain object: { type, params, prngState, ... }
+const d2 = ran.dist.Gamma.load(state)  // new instance with identical state
+
+d.sample(5)   // some sequence of variates
+d2.sample(5)  // identical sequence — same PRNG position, same parameters
 ```
 
 ## Return values and errors


### PR DESCRIPTION
Closes #538

## Summary
- Removes `d.save()` and `ran.dist.Gamma.load(state)` from the Distribution API code block, where they were buried among instance methods without context
- Adds a new `### State serialisation` subsection (between Distribution API and Return values and errors) with a short prose intro and a concrete round-trip example using `Gamma`
- State serialisation is a distinct persistence concern and benefits from its own narrative space

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`README.md`**: Removed `d.save()` and `ran.dist.Gamma.load(state)` from the API table; added `### State serialisation` subsection with prose and round-trip code example

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRGm6fJEiFDhfQ8kEpGknp)_