### PR TITLE
Add ADR-0019 for Distribution.load() static factory pattern

### DIFF
--- a/decisions/0019-distribution-load-static-factory.md
+++ b/decisions/0019-distribution-load-static-factory.md
@@ -1,0 +1,23 @@
+# ADR-0019: Distribution.load() as a Static Factory Method
+
+**Date**: 2026-07-01
+**Status**: Accepted
+
+## Context
+
+`Distribution.load(state)` reconstructs a distribution instance from a snapshot produced by `save()`. The earliest design made it an instance method, which forced callers to first invoke the constructor — allocating and initializing a fully-validated object — only to immediately discard everything the constructor produced and overwrite it with the saved state. That wasted constructor call also risked validation errors when the serialized parameter set was valid at save time but the constructor's guard had been tightened since.
+
+## Decision
+
+`load()` is a **static factory method**. It bypasses the constructor entirely by using `Object.create(this.prototype)`, then directly assigns the four serialized fields (`_type`, `k`, `p`, `s`, `c`, `r`) and delegates any subclass-specific post-load work to `_afterLoad()`. The method returns the fully initialized instance.
+
+## Consequences
+
+**Easier:**
+- The returned instance is fully initialized before any method is called — no partially-constructed object is ever exposed.
+- Subclasses that store non-serializable derived state (look-up tables, alias structures, etc.) have a single, well-defined hook (`_afterLoad()`) to rebuild it, rather than duplicating reconstruction logic in the constructor.
+- Callers use the natural static-factory idiom: `MyDist.load(state)` instead of `new MyDist().load(state)`.
+
+**Harder:**
+- Subclasses that accumulate state beyond the four standard fields must override `_afterLoad()`; forgetting to do so is a silent bug rather than a compile-time error.
+- The method cannot participate in prototype chains the way an instance method can — but no use case for that has arisen.

--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -447,6 +447,7 @@ class Distribution {
    * //      1.2587482868229616 ]
    *
    */
+  // decisions/0019-distribution-load-static-factory.md — static factory bypasses the constructor so the instance is fully initialized before any method is called
   static load (state) {
     const instance = Object.create(this.prototype)
     instance._type = state.type


### PR DESCRIPTION
Closes #789

## Summary
- Adds `decisions/0019-distribution-load-static-factory.md` documenting why `Distribution.load()` is a static factory method rather than an instance method
- Adds an inline WHY comment at `static load()` in `src/dist/_distribution.js` referencing the ADR

## Design decisions
- [ADR-0019: Distribution.load() as a Static Factory Method](decisions/0019-distribution-load-static-factory.md) — static factory bypasses the constructor so the instance is fully initialized before any method is called; avoids a throw-away constructor invocation and eliminates validation errors from schema drift

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`decisions/0019-distribution-load-static-factory.md`**: New ADR in Nygard format (Context / Decision / Consequences) explaining the static factory choice
- **`src/dist/_distribution.js`**: One-line WHY comment above `static load()` pointing to ADR-0019

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMK2EXdEqJwhU8nYq5U4vh)_