### PR TITLE
Fix reduce-based difference assertion in seed test

### DIFF
--- a/test/dist.js
+++ b/test/dist.js
@@ -52,7 +52,7 @@ const UnitTests = {
       const values1 = self.sample(sampleSize)
       self.seed(987654321) // different fixed seed to guarantee distinct sequence
       const values2 = self.sample(sampleSize)
-      assert(values1.reduce((acc, d, i) => acc || d !== values2[i], false))
+      assert(values1.some((d, i) => d !== values2[i]))
     })
   },
 


### PR DESCRIPTION
## Summary

Replaces the `reduce`-based "find any difference" assertion in `UnitTests.seed` with `Array.prototype.some()`, which is the idiomatic predicate-any check and short-circuits on first match.

Closes #796

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js`
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical)
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (skip for pure refactors/docs/tests)
- [x] Production-code diff is under ~400 lines (tests excluded)

---
_Generated by [Claude Code](https://claude.ai/code/session_019xCVQi1iAVv7V7waNj6fQg)_