### PR TITLE
Add divergent/undefined moment overrides for Alpha, UniformRatio, LogCauchy, DoublyNoncentralF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `YuleSimon.kurtosis()` falling-factorial coefficients corrected: `E[K^(n)] = n!·(n-1)!·ρ/∏(ρ−i)`, so f3 = 12ρ and f4 = 144ρ (previously 6ρ and 24ρ, missing the `(n-1)!` factor for n≥3). At ρ=5 the old code returned excess kurtosis ≈19 instead of 118.8 (#587).
 - `FlorySchulz._fitInit` seed corrected from `2/mean` to `2/(mean+1)`, matching the distribution's mean formula `E[X]=(2−a)/a` (previously the comment and implementation used the wrong formula `E[X]=2/a`) (#587).
 - `Zeta.kurtosis()` now returns `Infinity` (not `NaN`) for `3 < s ≤ 4`, where the variance is finite (requires only `s > 3`) but the 4th central moment diverges. The previous `s ≤ 4 → NaN` boundary conflated a divergent moment with an undefined one, contradicting the divergence convention and the sibling `Zeta.skewness()` logic.
+- `Alpha.mean()`, `.variance()`, `.skewness()`, and `.kurtosis()` now correctly return `Infinity`/`NaN` (PDF f(x)~C/x² makes E[X] diverge; variance/skewness/kurtosis are undefined when the mean diverges). `UniformRatio` gets the same fix (PDF 1/(2x²) for x>1 gives a divergent mean). `LogCauchy.mean()` now returns `Infinity` — the integral ∫ x·f(x) dx substituting u=ln x converges only one-sidedly unlike the Cauchy case, so E[X]=+∞. `DoublyNoncentralF.skewness()` and `.kurtosis()` now guard on d2>6 / d2>8, returning `Infinity` when the moments do not exist — matching the analogous guards in `F` and `NoncentralF` (#570).
 
 ### Changed
 

--- a/src/dist/alpha.js
+++ b/src/dist/alpha.js
@@ -81,4 +81,24 @@ export default class Alpha extends Distribution {
   _q (p) {
     return this.p.beta / (this.p.alpha - this._phiInv(p * this.c.phiAlpha))
   }
+
+  /**
+   * @returns {number} Infinity (mean diverges — f(x) ~ C/x² as x→∞ so E[X] ~ ∫C/x dx = ∞).
+   */
+  mean () { return Infinity }
+
+  /**
+   * @returns {number} Infinity (E[X²] diverges — the second raw moment shares the same tail).
+   */
+  variance () { return Infinity }
+
+  /**
+   * @returns {number} NaN (skewness undefined when mean and variance both diverge).
+   */
+  skewness () { return NaN }
+
+  /**
+   * @returns {number} NaN (kurtosis undefined when variance diverges).
+   */
+  kurtosis () { return NaN }
 }

--- a/src/dist/doubly-noncentral-f.js
+++ b/src/dist/doubly-noncentral-f.js
@@ -53,6 +53,20 @@ export default class DoublyNoncentralF extends DoublyNoncentralBeta {
     return super._cdf(x / (this.p.d2 / this.p.d1 + x))
   }
 
+  /**
+   * @returns {number} The skewness of the distribution.
+   */
+  skewness () {
+    return this.p.d2 > 6 ? super.skewness() : Infinity
+  }
+
+  /**
+   * @returns {number} The excess kurtosis of the distribution.
+   */
+  kurtosis () {
+    return this.p.d2 > 8 ? super.kurtosis() : Infinity
+  }
+
   static _fitInit (data) {
     // Central F moment matching for d1, d2; total λ split symmetrically between λ1 and λ2
     const n = data.length

--- a/src/dist/log-cauchy.js
+++ b/src/dist/log-cauchy.js
@@ -55,6 +55,11 @@ export default class LogCauchy extends Cauchy {
     return Math.exp(this.p.mu + this.p.sigma * Math.tan(Math.PI * (p - 0.5)))
   }
 
+  /**
+   * @returns {number} Infinity (E[X] = ∫ x·f(x) dx substituting u=ln x gives ∫ e^u·Cauchy(u) du, which diverges to +∞ one-sidedly).
+   */
+  mean () { return Infinity }
+
   static _fitInit (data) {
     // log(Y) ~ Cauchy(x0, gamma): IQR on log scale avoids reliance on moments that don't exist
     const logData = data.map(x => Math.log(x)).sort((a, b) => a - b)

--- a/src/dist/uniform-ratio.js
+++ b/src/dist/uniform-ratio.js
@@ -1,6 +1,5 @@
 import Distribution from './_distribution'
 
-// TODO Docs
 /**
  * Probability density function for the [uniform ratio distribution]{@link https://en.wikipedia.org/wiki/Ratio_distribution#Uniform_ratio_distribution}:
  *
@@ -42,4 +41,24 @@ export default class UniformRatio extends Distribution {
   _q (p) {
     return p <= 0.5 ? 2 * p : 0.5 / (1 - p)
   }
+
+  /**
+   * @returns {number} Infinity (E[X] = ½∫₁^∞ 1/x dx diverges).
+   */
+  mean () { return Infinity }
+
+  /**
+   * @returns {number} Infinity (E[X²] diverges for the same reason).
+   */
+  variance () { return Infinity }
+
+  /**
+   * @returns {number} NaN (skewness undefined when mean and variance both diverge).
+   */
+  skewness () { return NaN }
+
+  /**
+   * @returns {number} NaN (kurtosis undefined when variance diverges).
+   */
+  kurtosis () { return NaN }
 }

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -23,6 +23,9 @@ export default [{
     [-1, 1], [0, 1], // alpha > 0
     [1, -1], [1, 0] // beta > 0
   ],
+  moments: [
+    { params: [3, 1], mean: Infinity, variance: Infinity, skewness: NaN, kurtosis: NaN }
+  ],
   cases: [{
     params: () => [2, 2]
   }, {
@@ -1152,6 +1155,9 @@ export default [{
     [1, 1, -1, 1], // lambda1 >= 0
     [1, 1, 1, -1] // lambda2 >= 0
   ],
+  moments: [
+    { params: [2, 3, 1, 1], mean: 0.4145532940573077, variance: 0.04010485941777667, skewness: 0.2277065418955376, kurtosis: -0.674101860008792, tol: 1e-4 }
+  ],
   cases: [{
     params: () => [2, 2, 2, 2]
   }, {
@@ -1198,6 +1204,10 @@ export default [{
     [1, 1, -1, 1], // lambda1 >= 0
     [1, 1, 1, -1] // lambda2 >= 0
   ],
+  // DNCχ²(k1,k2,λ1,λ2) ≡ NCχ²(k1+k2,λ1+λ2); exact formulas inherited from NoncentralChi2
+  moments: [
+    { params: [2, 3, 1, 1], mean: 7, variance: 18, skewness: 22 * Math.SQRT2 / 27, kurtosis: 52 / 27 }
+  ],
   cases: [{
     name: 'odd k',
     params: () => [3, 4, 2, 3]
@@ -1241,6 +1251,12 @@ export default [{
     [2, -1, 1, 1], [2, 0, 1, 1], // n2 > 0
     [2, 2, -1, 1], // lambda1 >= 0
     [2, 2, 1, -1] // lambda2 >= 0
+  ],
+  // d2=10>8 ensures all four moments exist; values from tanh-sinh fallback
+  // d2=5<=6: skewness and kurtosis both diverge; mean and variance still finite
+  moments: [
+    { params: [3, 10, 1, 1], mean: 1.5129555479435952, variance: 2.662960179035406, skewness: 4.088629901681505, kurtosis: 54.46393601139288, tol: 1e-4 },
+    { params: [5, 5, 2, 2], skewness: Infinity, kurtosis: Infinity }
   ],
   cases: [{
     params: () => [5, 5, 2, 2]
@@ -1286,6 +1302,10 @@ export default [{
     [], // all params required
     [-1, 1, 1], [0, 1, 1], // nu > 0
     [1, 1, -1] // theta >= 0
+  ],
+  // nu=5>4: all moments exist; values from tanh-sinh fallback (PRNG-seeded bounds → tol is wide)
+  moments: [
+    { params: [5, 1, 2], mean: 0.4197, variance: 1.226, skewness: 3.234, kurtosis: 16.60, tol: { mean: 0.003, variance: 0.005, skewness: 0.02, kurtosis: 0.1 } }
   ],
   cases: [{
     params: () => [5, 1, 2]
@@ -3085,6 +3105,9 @@ export default [{
   invalidParams: [
     [], // all params required
     [0, -1], [0, 0] // sigma > 0
+  ],
+  moments: [
+    { params: [0, 1], mean: Infinity, variance: NaN, skewness: NaN, kurtosis: NaN }
   ],
   cases: [{
     params: () => [0, 2]
@@ -5260,6 +5283,10 @@ export default [{
     generator: 'Exponential',
     params: () => [1]
   },
+  // lambda>0: bounded support [-1/lambda, 1/lambda]; mean=0 and skewness=0 exact by symmetry
+  moments: [
+    { params: [0.5], mean: 0, variance: 0.8584073464102088, skewness: 0, kurtosis: -0.9183035664374528, tol: { mean: 1e-12, variance: 1e-8, skewness: 1e-12, kurtosis: 1e-6 } }
+  ],
   cases: [{
     name: 'zero shape parameter',
     params: () => [0],
@@ -5460,6 +5487,9 @@ export default [{
   name: 'UniformRatio',
   fit: { data: [0.5, 1, 2, 3], usableAt: 0.5 },
   invalidParams: [],
+  moments: [
+    { params: [], mean: Infinity, variance: Infinity, skewness: NaN, kurtosis: NaN }
+  ],
   cases: [{
     params: () => []
   }],
@@ -5490,6 +5520,11 @@ export default [{
   invalidParams: [
     [], // all params required
     [-1], [0] // kappa > 0
+  ],
+  // bounded support [-pi, pi]; mean=0 and skewness=0 exact by symmetry
+  moments: [
+    { params: [2], mean: 0, variance: 0.7644618798111271, skewness: 0, kurtosis: 0.8847265900332291, tol: { mean: 1e-12, variance: 1e-6, skewness: 1e-12, kurtosis: 1e-6 } },
+    { params: [1], mean: 0, variance: 1.604254298825305, skewness: 0, kurtosis: -0.15414638902997568, tol: { mean: 1e-12, variance: 1e-6, skewness: 1e-12, kurtosis: 1e-6 } }
   ],
   cases: [{
     params: () => [2],


### PR DESCRIPTION
Closes #570

## Summary
- Adds explicit `mean()`/`variance()`/`skewness()`/`kurtosis()` overrides to `Alpha`, `UniformRatio`, `LogCauchy`, and `DoublyNoncentralF` so that mathematically divergent or undefined moments return `Infinity`/`NaN` instead of a plausible-looking finite value from the numerical integration fallback.
- Adds `moments:` test entries for 9 distributions that previously had no moment coverage: `Alpha`, `DoublyNoncentralBeta`, `DoublyNoncentralChi2`, `DoublyNoncentralF`, `DoublyNoncentralT`, `LogCauchy`, `TukeyLambda`, `UniformRatio`, and `VonMises`.
- All changes follow the return-value convention in `decisions/0015-return-value-and-error-conventions.md`: divergent moments → `Infinity`, undefined/indeterminate moments → `NaN`.

## Non-trivial changes
- **`src/dist/alpha.js`**: Added `mean()→Infinity`, `variance()→Infinity`, `skewness()→NaN`, `kurtosis()→NaN`. The Alpha PDF f(x)∼C/x² as x→∞ makes E[X]=∫C/x dx diverge; the numerical fallback was silently returning a finite truncation.
- **`src/dist/uniform-ratio.js`**: Same four overrides. PDF = 1/(2x²) for x>1 gives the same divergent tail; also removed a stale `// TODO Docs` comment.
- **`src/dist/log-cauchy.js`**: Added `mean()→Infinity`. Unlike the Cauchy distribution (where E[X] is indeterminate due to symmetric cancellation), substituting u=ln x into ∫x·f(x)dx gives ∫eᵘ·Cauchy(u)du which diverges one-sidedly to +∞. The inherited `NaN` from `Cauchy` was incorrect.
- **`src/dist/doubly-noncentral-f.js`**: Added `skewness()` and `kurtosis()` with d2>6 / d2>8 guards, returning `Infinity` when the moments do not exist — matching the analogous guards already in `F` and `NoncentralF`. Without this, the numerical fallback returned finite values for d2≤6/d2≤8.
- **`test/dist-cases-continuous.js`**: Added `moments:` entries for the 9 distributions listed above, closing all outstanding gaps in moment test coverage.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added `### Fixed` bullet describing all four behavioral corrections.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJRTiMGSJpRrJNosjkq9ws)_