### PR TITLE
Fix DoublyNoncentralT non-deterministic moments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DoublyNoncentralT` moment estimates (`mean()`, `variance()`, `skewness()`, `kurtosis()`) were non-deterministic across runs because the numerical integration bounds were seeded through `_qInitialGuess`, which consumed PRNG state. Adding `_q(p)` with a deterministic bracket (center at μ, spread scaled by `√ν + √θ`) bypasses the PRNG-seeded fallback entirely; moment test tolerances tightened from ±0.003/0.005/0.02/0.1 to ±0.001/0.002/0.01/0.05 (#800).
 - `Distribution.load()` now correctly restores PRNG state. `Xoshiro128p.save()` was returning a live reference to the internal `_state` array; any sampling after `save()` mutated that array and corrupted the snapshot before `load()` could read it. Both `save()` and `load()` now copy the state array so each saved snapshot and each loaded generator hold independent copies (#792).
 
 - `BetaPrime.kurtosis()` denominator factor corrected from `(beta + 1)` to `(beta - 2)`, matching the Wikipedia formula. The typo caused silently wrong excess kurtosis for all valid inputs (β > 4); e.g. `BetaPrime(2, 5).kurtosis()` returned 66 instead of 54 (#752).

--- a/src/dist/doubly-noncentral-t.js
+++ b/src/dist/doubly-noncentral-t.js
@@ -3,7 +3,7 @@ import Distribution from './_distribution'
 import noncentralChi2 from './_noncentral-chi2'
 import normal from './_normal'
 import { f11, gamma, logGamma } from '../special'
-import { wynnEpsilon, recursiveSum } from '../algorithms'
+import { wynnEpsilon, recursiveSum, bracket, chandrupatla } from '../algorithms'
 import NoncentralT from './noncentral-t'
 
 /**
@@ -367,6 +367,19 @@ export default class DoublyNoncentralT extends Distribution {
       return t
     }, t => t.p * t.f)
     return clamp(x < 0 ? 1 - z : z)
+  }
+
+  _q (p) {
+    // Deterministic initial bracket: center at mu with spread scaled to distribution width.
+    // Avoids the PRNG-seeded fallback in _qInitialGuess, making moments deterministic.
+    const spread = Math.max(10, 5 * (Math.abs(this.p.mu) + Math.sqrt(this.p.nu) + Math.sqrt(this.p.theta)))
+    const bounds = bracket(t => this.cdf(t) - p, this.p.mu - spread, this.p.mu + spread, this.s)
+    if (Array.isArray(bounds)) {
+      return Math.min(Math.max(
+        chandrupatla(t => this.cdf(t) - p, ...bounds), this.s[0].value), this.s[1].value
+      )
+    }
+    return NaN
   }
 
   static _fitInit (data) {

--- a/src/dist/doubly-noncentral-t.js
+++ b/src/dist/doubly-noncentral-t.js
@@ -3,7 +3,7 @@ import Distribution from './_distribution'
 import noncentralChi2 from './_noncentral-chi2'
 import normal from './_normal'
 import { f11, gamma, logGamma } from '../special'
-import { wynnEpsilon, recursiveSum, bracket, chandrupatla } from '../algorithms'
+import { wynnEpsilon, recursiveSum } from '../algorithms'
 import NoncentralT from './noncentral-t'
 
 /**
@@ -47,7 +47,8 @@ export default class DoublyNoncentralT extends Distribution {
     // Speed-up constants
     this.c = {
       logScale: -0.5 * (theta + mu * mu + Math.log(Math.PI * nui)) - logGamma(nui / 2),
-      expHalfTheta: Math.exp(-theta / 2)
+      expHalfTheta: Math.exp(-theta / 2),
+      qSpread: Math.max(10, 5 * (Math.abs(mu) + Math.sqrt(nui) + Math.sqrt(theta)))
     }
   }
 
@@ -369,17 +370,10 @@ export default class DoublyNoncentralT extends Distribution {
     return clamp(x < 0 ? 1 - z : z)
   }
 
-  _q (p) {
-    // Deterministic initial bracket: center at mu with spread scaled to distribution width.
-    // Avoids the PRNG-seeded fallback in _qInitialGuess, making moments deterministic.
-    const spread = Math.max(10, 5 * (Math.abs(this.p.mu) + Math.sqrt(this.p.nu) + Math.sqrt(this.p.theta)))
-    const bounds = bracket(t => this.cdf(t) - p, this.p.mu - spread, this.p.mu + spread, this.s)
-    if (Array.isArray(bounds)) {
-      return Math.min(Math.max(
-        chandrupatla(t => this.cdf(t) - p, ...bounds), this.s[0].value), this.s[1].value
-      )
-    }
-    return NaN
+  _qInitialGuess () {
+    // Pre-computed spread bypasses the PRNG-seeded fallback in the base class,
+    // making _qEstimateRoot — and thus the numerical moments — deterministic.
+    return [this.p.mu - this.c.qSpread, this.p.mu + this.c.qSpread]
   }
 
   static _fitInit (data) {

--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -1303,9 +1303,9 @@ export default [{
     [-1, 1, 1], [0, 1, 1], // nu > 0
     [1, 1, -1] // theta >= 0
   ],
-  // nu=5>4: all moments exist; values from tanh-sinh fallback (PRNG-seeded bounds → tol is wide)
+  // nu=5>4: all moments exist; deterministic now that _q(p) bypasses PRNG-seeded bracket
   moments: [
-    { params: [5, 1, 2], mean: 0.4197, variance: 1.226, skewness: 3.234, kurtosis: 16.60, tol: { mean: 0.003, variance: 0.005, skewness: 0.02, kurtosis: 0.1 } }
+    { params: [5, 1, 2], mean: 0.4197, variance: 1.226, skewness: 3.234, kurtosis: 16.60, tol: { mean: 0.001, variance: 0.002, skewness: 0.01, kurtosis: 0.05 } }
   ],
   cases: [{
     params: () => [5, 1, 2]

--- a/test/dist.js
+++ b/test/dist.js
@@ -974,6 +974,15 @@ describe('dist', () => {
         assert(result.p.k2 >= 1)
       })
 
+      it('DoublyNoncentralT moments should be identical across independent instances', () => {
+        const d1 = new dist.DoublyNoncentralT(5, 1, 2)
+        const d2 = new dist.DoublyNoncentralT(5, 1, 2)
+        assert.strictEqual(d1.mean(), d2.mean())
+        assert.strictEqual(d1.variance(), d2.variance())
+        assert.strictEqual(d1.skewness(), d2.skewness())
+        assert.strictEqual(d1.kurtosis(), d2.kurtosis())
+      })
+
       it('InverseGaussian._fitInit should return the exact MLE mu=mean, lambda=n/Σ(1/xᵢ−1/x̄)', () => {
         const data = [1, 2, 3, 4]
         const init = dist.InverseGaussian._fitInit(data)


### PR DESCRIPTION
## Summary

Closes #800

Override `_qInitialGuess()` in `DoublyNoncentralT` to return a deterministic bracket `[μ − spread, μ + spread]`, where `spread = max(10, 5·(|μ| + √ν + √θ))` is pre-computed in the constructor. This bypasses the base class fallback that consumed PRNG state, making `mean()`, `variance()`, `skewness()`, and `kurtosis()` bit-for-bit identical across independent instances with the same parameters.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js`
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical)
- [x] `CHANGELOG.md` updated under `## [Unreleased]` (skip for pure refactors/docs/tests)
- [x] Production-code diff is under ~400 lines (tests excluded)

## Non-trivial changes

- **`src/dist/doubly-noncentral-t.js`**: Added `qSpread` to `this.c` in the constructor and overrode `_qInitialGuess()` to return a deterministic bracket centered at `μ`. This changes the quantile computation path: instead of using PRNG-seeded bounds as the initial root-finding bracket, `_qEstimateRoot` now starts from a deterministic interval whose width scales with `|μ| + √ν + √θ`.

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: Tightened DoublyNoncentralT moment tolerances (mean: 0.003→0.001, variance: 0.005→0.002, skewness: 0.02→0.01, kurtosis: 0.1→0.05); updated comment.
- **`test/dist.js`**: Added determinism test asserting two independent `DoublyNoncentralT(5, 1, 2)` instances return `strictEqual` moment values.
- **`CHANGELOG.md`**: Added `### Fixed` bullet under `## [Unreleased]`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01SouK7whynsPsRouLxN9XF5)_