### PR TITLE
Fix release workflow to enforce nyc coverage thresholds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm run lint
       - run: npm run jsdoclint
       - run: npm run check-decl && ./node_modules/.bin/tsc -p tsconfig.build.json && npm run typecheck
-      - run: npx cross-env NODE_ENV=test ./node_modules/.bin/_mocha --require @babel/register
+      - run: npm test
       - run: npm whoami
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #807

## Summary
- The release workflow invoked Mocha directly, bypassing `nyc` entirely — coverage thresholds were never checked before an `npm publish`
- Replaced the bare Mocha invocation with `npm test`, which routes through `nyc` and enforces the declared thresholds (branches 90%, lines 98%, functions 100%, statements 98%)

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`.github/workflows/release.yml`**: `npm test` replaces direct Mocha invocation so nyc runs as the process parent and enforces coverage thresholds on every release build

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpmNeZimhYkhfxTpY8rb5o)_