### PR TITLE
Add besselK and besselKnu — Modified Bessel function of the second kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `besselK(n, x)` and `besselKnu(nu, x)` — Modified Bessel function of the second kind K_ν(x) for integer orders (combined series seeded upward recurrence + asymptotic expansion) and real orders (connection formula via `besselInu` for x ≤ 6, asymptotic expansion for x > 6), exported from `ran.special` (#809).
 - `TruncatedExponential(lambda, a, b)` distribution: exponential distribution restricted to a finite interval [a, b] (λ > 0, a ≥ 0, b > a). Subclass of `Exponential`. Implements closed-form `_pdf`, `_cdf`, `_q` (inverse CDF), `mean`, `variance`, inverse-CDF sampling, and method-of-moments `_fitInit` (#806).
 - `AsymmetricLaplace(mu, sigma, kappa)` distribution: a three-parameter two-sided exponential family parameterized by location μ ∈ ℝ, scale σ > 0, and asymmetry κ > 0. Reduces to Laplace(μ, σ/√2) at κ = 1. Implements closed-form `_pdf`, `_cdf`, `_q` (inverse CDF), `mean`, `variance`, `skewness`, and `kurtosis`, with exact inverse-CDF sampling and method-of-moments `_fitInit` (#805).
 

--- a/solutions/special-functions/2026-07-05-1530-bessel-k-second-kind-cancellation-strategy.md
+++ b/solutions/special-functions/2026-07-05-1530-bessel-k-second-kind-cancellation-strategy.md
@@ -1,0 +1,65 @@
+---
+date: 2026-07-05T15:30:00Z
+category: "special-functions"
+problem: "besselK series and besselKnu connection formula both produce wildly wrong results for large x due to exponentially large intermediate values"
+status: complete
+related_issue: "#809"
+related_plan: "thoughts/plans/2026-07-05-1512-bessel-k-second-kind.md"
+tags: [bessel, cancellation, asymptotic, series, connection-formula, K-function, exponential-decay]
+---
+
+# Solution: Bessel K Second Kind — Two-Level Cancellation Strategy
+
+**Date**: 2026-07-05
+**Category**: special-functions
+**Related Issue**: #809
+
+## Problem
+
+Both `_K0`/`_K1` and `besselKnu` produced wildly wrong results for moderate-to-large x:
+
+- `K_0(50)` returned −4,980,736 instead of ~3.41e-23 (split-series form)
+- `K_{0.5}(50)` returned ~308,831 instead of ~3.42e-23 (connection formula)
+- `besselKnu(-2, x)` silently returned K_1(x) instead of K_2(x) (integer-dispatch sign bug)
+
+## Root Cause
+
+Three separate but thematically related causes — all sharing the same underlying pattern: K_ν(x) is O(e^{-x}) but natural formulas route through O(e^x) intermediates.
+
+**1. K_0/K_1 split-form series cancellation.**
+The textbook decomposition `K_0(x) = −lnh·I_0(x) + Σ t_k·H_k` has two addends each of magnitude O(I_0(x)) ≈ O(e^x/√(2πx)). Their difference is O(e^{-x}). At x = 50 each term is ~10^21 and the result is ~10^{-23} — a 44-digit cancellation — consuming every guard digit in float64.
+
+**2. Connection-formula cancellation in besselKnu for large x.**
+`K_ν(x) = (π/2)·(I_{-ν}(x) − I_ν(x)) / sin(νπ)` computes two quantities of magnitude O(e^x) whose difference is O(e^{-x}), losing 2x/ln(10) decimal digits. At x = 50 this destroys 43 significant figures.
+
+**3. Negative-integer dispatch missing Math.abs.**
+The guard `besselK(Math.round(nu), x)` passed a negative integer to `besselK`. The upward recurrence loop `for (let i = 1; i < n; i++)` runs zero iterations when n < 1, so the function returned the k1 seed (K_1) instead of the correct K_{|n|}.
+
+## Fix
+
+**1. Combined-series form for K_0 and K_1 (small x).**
+Instead of computing `−lnh·I_0(x)` and `Σ t_k·H_k` separately, fold `lnh` into each summation term: `s.t * (s.h − lnh)`. The difference `H_k − lnh` is small and well-conditioned because `H_k` grows toward `lnh` as k → ∞. This is the DLMF §10.31.2 combined representation — the algebraic grouping ensures the cancellation happens at the level of individual terms (each small) rather than between two large sums.
+
+**2. Asymptotic expansion above a crossover threshold (x > 6).**
+A single constant `_X_K_SERIES = 6` governs both: `_K0` and `_K1` call `_KAsymptotic(nu, x)` for x > 6, and `besselKnu` bypasses the connection formula entirely in favour of `_KAsymptotic` for x > 6. The asymptotic expansion `K_ν(x) ~ √(π/(2x))·e^{-x}·Σ a_k(ν)/x^k` directly produces the exponentially small result without ever computing exponentially large intermediates. Optimal truncation (stop when |a_{k+1}| ≥ |a_k|) keeps the error bounded by the first omitted term.
+
+**3. Absolute value before integer dispatch.**
+Change `besselK(Math.round(nu), x)` to `besselK(Math.abs(Math.round(nu)), x)`, exploiting the mathematical identity K_{−n}(x) = K_n(x) (K is even in ν).
+
+## Prevention Strategy
+
+When implementing a special function that is exponentially small for large x (K_ν, E_1, erfc, etc.), immediately check whether any intermediate representation involves quantities of exponentially large magnitude. If so, plan for two distinct mitigations:
+
+- **Small x / series regime:** Look for an algebraically combined form in DLMF where the large-magnitude cancellation is handled symbolically inside each sum term, not between accumulated sums. DLMF §10.31.2 provides the combined form for K_0 and K_1.
+- **Large x regime:** Switch to a direct asymptotic expansion rather than transforming a formula designed for small x. Document the crossover constant and the digit-loss rate (2x/ln(10) digits for an O(e^x) subtraction) so future reviewers can verify the threshold is adequate.
+
+For integer-dispatch guards in real-order wrappers (`besselKnu`, future analogues), always apply `Math.abs` when the underlying integer function expects non-negative orders, and cover negative-integer inputs explicitly in the test suite.
+
+## Related Solutions
+
+- `solutions/special-functions/2026-05-17-1540-erfc-crossover-cancellation.md` — erfc large-x cancellation: complementary form avoids cancellation in the same way the asymptotic avoids it here
+- `solutions/special-functions/2026-06-14-1240-e1-asymptotic-vs-continued-fraction-crossover.md` — E_1 asymptotic crossover: divergent asymptotic series requires optimal truncation, same pattern as `_KAsymptotic`
+
+## Key Insight
+
+When K_ν(x) is O(e^{-x}) and the natural formula routes through O(e^x) intermediates, the remedies are structurally different depending on the regime: for the series use DLMF's algebraically combined form (fold the large constant into each summation term); for the connection formula switch formulas entirely to the asymptotic expansion — both remedies share a single crossover threshold (here x = 6) that can be verified by checking that the series error budget at the threshold is below machine epsilon.

--- a/src/special/bessel.js
+++ b/src/special/bessel.js
@@ -191,6 +191,124 @@ export function besselISpherical (n, x) {
   }
 }
 
+// Crossover from series to asymptotic expansion for K_0 and K_1.
+// Below X_K_SERIES the combined-series form (DLMF §10.31.2) retains ≥10 significant
+// figures; above it, the series accumulates O(e^{2x}) intermediate values that nearly
+// cancel against the tiny e^{-x} result, losing all precision.
+const _X_K_SERIES = 6
+
+/**
+ * Asymptotic expansion of K_ν(x) for large x (DLMF §10.40.2):
+ *   K_ν(x) ~ sqrt(π/(2x)) * exp(-x) * Σ_{k=0}^M a_k(ν) / x^k
+ * where a_0 = 1 and a_{k+1} = a_k * (4ν² − (2k+1)²) / (8(k+1)x).
+ * Optimal truncation (stop when |a_{k+1}/x| ≥ |a_k/x^k|) bounds the error by the
+ * first omitted term, avoiding divergence of the asymptotic series.
+ *
+ * @method _KAsymptotic
+ * @memberof ran.special
+ * @param {number} nu Order (real).
+ * @param {number} x Positive value to evaluate at.
+ * @returns {number} K_nu(x).
+ * @private
+ */
+function _KAsymptotic (nu, x) {
+  const nu2 = 4 * nu * nu
+  let term = 1
+  let sum = 1
+  for (let k = 1; k < MAX_ITER; k++) {
+    const next = term * (nu2 - (2 * k - 1) * (2 * k - 1)) / (8 * k * x)
+    // Optimal truncation: stop when the asymptotic series starts to diverge
+    if (Math.abs(next) >= Math.abs(term)) { break }
+    term = next
+    sum += term
+    if (Math.abs(term) < EPS * Math.abs(sum)) { break }
+  }
+  return Math.sqrt(Math.PI / (2 * x)) * Math.exp(-x) * sum
+}
+
+/**
+ * Computes the modified Bessel function of the second kind with order zero.
+ * For x ≤ _X_K_SERIES: combined series K_0(x) = Σ_{k=0}^∞ (x²/4)^k / (k!)² · (H_k − lnh)
+ * where H_k are harmonic numbers and lnh = ln(x/2) + γ (DLMF §10.31.2).
+ * The combined form avoids catastrophic cancellation by grouping the two large terms.
+ * For x > _X_K_SERIES: asymptotic expansion (DLMF §10.40.2).
+ *
+ * @method _K0
+ * @memberof ran.special
+ * @param {number} x Positive value to evaluate at.
+ * @returns {number} K_0(x).
+ * @private
+ */
+function _K0 (x) {
+  if (x > _X_K_SERIES) { return _KAsymptotic(0, x) }
+  const x2 = x * x / 4
+  // ln(x/2) + γ, where γ = 0.5772156649015329 (Euler–Mascheroni constant)
+  const lnh = Math.log(x / 2) + 0.5772156649015329
+  return recursiveSum(
+    { t: 1, h: 0 },
+    (s, i) => {
+      s.h += 1 / i
+      s.t *= x2 / (i * i)
+      return s
+    },
+    s => s.t * (s.h - lnh)
+  )
+}
+
+/**
+ * Computes the modified Bessel function of the second kind with order one.
+ * For x ≤ _X_K_SERIES: combined series K_1(x) = 1/x + (x/2)·Σ_{k=0}^∞ (x²/4)^k / (k!(k+1)!)
+ * · [(ln(x/2)+γ) − (H_k+H_{k+1})/2] where H_k are harmonic numbers (DLMF §10.31.2).
+ * For x > _X_K_SERIES: asymptotic expansion (DLMF §10.40.2).
+ *
+ * @method _K1
+ * @memberof ran.special
+ * @param {number} x Positive value to evaluate at.
+ * @returns {number} K_1(x).
+ * @private
+ */
+function _K1 (x) {
+  if (x > _X_K_SERIES) { return _KAsymptotic(1, x) }
+  const x2 = x * x / 4
+  const lnh = Math.log(x / 2) + 0.5772156649015329
+  const sum = recursiveSum(
+    { t: 1, hk: 0, hk1: 1 },
+    (s, i) => {
+      s.hk = s.hk1
+      s.hk1 += 1 / (i + 1)
+      s.t *= x2 / (i * (i + 1))
+      return s
+    },
+    s => s.t * (lnh - (s.hk + s.hk1) / 2)
+  )
+  return 1 / x + (x / 2) * sum
+}
+
+/**
+ * Computes the modified Bessel function of the second kind. Only integer order.
+ *
+ * @method besselK
+ * @memberof ran.special
+ * @param {number} n Order of the Bessel function. Must be a non-negative integer.
+ * @param {number} x Value to evaluate the function at.
+ * @returns {number} The modified Bessel function of the second kind.
+ */
+export function besselK (n, x) {
+  if (x === 0) return Infinity
+  if (n === 0) return _K0(x)
+  if (n === 1) return _K1(x)
+  // Upward recurrence K_{n+1}(x) = (2n/x)*K_n(x) + K_{n-1}(x) is forward-stable
+  // for K because K grows with n (dominant component is preserved). DLMF §10.29.1.
+  let k0 = _K0(x)
+  let k1 = _K1(x)
+  for (let i = 1; i < n; i++) {
+    const k = (2 * i / x) * k1 + k0
+    k0 = k1
+    k1 = k
+  }
+  return k1
+}
+
 /**
  * Computes the modified Bessel function of the first kind for fractional order.
  *
@@ -201,6 +319,33 @@ export function besselISpherical (n, x) {
  * @returns {number} The modified Bessel function of the first kind.
  * @private
  */
+/**
+ * Computes the modified Bessel function of the second kind for real order.
+ * Uses the connection formula K_ν(x) = (π/2)·(I_{-ν}(x) − I_ν(x))/sin(νπ) (DLMF 10.27.4).
+ * Dispatches to `besselK` for near-integer ν to avoid the 0/0 indeterminate form.
+ *
+ * @method besselKnu
+ * @memberof ran.special
+ * @param {number} nu Order of the Bessel function. Should be fractional.
+ * @param {number} x Value to evaluate the function at.
+ * @returns {number} The modified Bessel function of the second kind.
+ * @private
+ */
+export function besselKnu (nu, x) {
+  if (x === 0) return Infinity
+  // Near-integer ν: connection formula becomes 0/0; dispatch to integer path
+  if (Math.abs(nu - Math.round(nu)) < 1e-8) {
+    return besselK(Math.round(nu), x)
+  }
+  // Large x: connection formula loses ~2x/ln(10) digits from catastrophic cancellation
+  // between I_{-ν}(x) and I_ν(x) (both O(exp(x)) while K_ν is O(exp(-x))).
+  // Asymptotic expansion avoids this and terminates exactly for half-integer ν.
+  if (x > _X_K_SERIES) {
+    return _KAsymptotic(nu, x)
+  }
+  return (Math.PI / 2) * (besselInu(-nu, x) - besselInu(nu, x)) / Math.sin(Math.PI * nu)
+}
+
 // Taylor series converges for x ≤ ~710 with MAX_SERIES_ITER=500; see
 // solutions/testing/2026-06-02-1200-besselInu-infrastructure-fix-coverage-gap.md
 export function besselInu (nu, x) {

--- a/src/special/bessel.js
+++ b/src/special/bessel.js
@@ -292,6 +292,7 @@ function _K1 (x) {
  * @param {number} n Order of the Bessel function. Must be a non-negative integer.
  * @param {number} x Value to evaluate the function at.
  * @returns {number} The modified Bessel function of the second kind.
+ * @private
  */
 export function besselK (n, x) {
   if (x === 0) return Infinity

--- a/src/special/bessel.js
+++ b/src/special/bessel.js
@@ -310,16 +310,6 @@ export function besselK (n, x) {
 }
 
 /**
- * Computes the modified Bessel function of the first kind for fractional order.
- *
- * @method besselInu
- * @memberof ran.special
- * @param {number} nu Order of the Bessel function. Should be fractional.
- * @param {number} x Value to evaluate the function at.
- * @returns {number} The modified Bessel function of the first kind.
- * @private
- */
-/**
  * Computes the modified Bessel function of the second kind for real order.
  * Uses the connection formula K_ν(x) = (π/2)·(I_{-ν}(x) − I_ν(x))/sin(νπ) (DLMF 10.27.4).
  * Dispatches to `besselK` for near-integer ν to avoid the 0/0 indeterminate form.
@@ -333,9 +323,10 @@ export function besselK (n, x) {
  */
 export function besselKnu (nu, x) {
   if (x === 0) return Infinity
-  // Near-integer ν: connection formula becomes 0/0; dispatch to integer path
+  // Near-integer ν: connection formula becomes 0/0; dispatch to integer path.
+  // Use Math.abs so negative integers forward the correct non-negative order to besselK.
   if (Math.abs(nu - Math.round(nu)) < 1e-8) {
-    return besselK(Math.round(nu), x)
+    return besselK(Math.abs(Math.round(nu)), x)
   }
   // Large x: connection formula loses ~2x/ln(10) digits from catastrophic cancellation
   // between I_{-ν}(x) and I_ν(x) (both O(exp(x)) while K_ν is O(exp(-x))).
@@ -346,6 +337,16 @@ export function besselKnu (nu, x) {
   return (Math.PI / 2) * (besselInu(-nu, x) - besselInu(nu, x)) / Math.sin(Math.PI * nu)
 }
 
+/**
+ * Computes the modified Bessel function of the first kind for fractional order.
+ *
+ * @method besselInu
+ * @memberof ran.special
+ * @param {number} nu Order of the Bessel function. Should be fractional.
+ * @param {number} x Value to evaluate the function at.
+ * @returns {number} The modified Bessel function of the first kind.
+ * @private
+ */
 // Taylor series converges for x ≤ ~710 with MAX_SERIES_ITER=500; see
 // solutions/testing/2026-06-02-1200-besselInu-infrastructure-fix-coverage-gap.md
 export function besselInu (nu, x) {

--- a/src/special/bessel.js
+++ b/src/special/bessel.js
@@ -195,6 +195,7 @@ export function besselISpherical (n, x) {
 // Below X_K_SERIES the combined-series form (DLMF §10.31.2) retains ≥10 significant
 // figures; above it, the series accumulates O(e^{2x}) intermediate values that nearly
 // cancel against the tiny e^{-x} result, losing all precision.
+// See solutions/special-functions/2026-07-05-1530-bessel-k-second-kind-cancellation-strategy.md
 const _X_K_SERIES = 6
 
 /**

--- a/src/special/index.js
+++ b/src/special/index.js
@@ -5,7 +5,7 @@
  * @memberof ran
  * @private
  */
-export { besselI, besselInu, besselISpherical } from './bessel'
+export { besselI, besselInu, besselISpherical, besselK, besselKnu } from './bessel'
 export { default as beta } from './beta'
 export { betaIncomplete, regularizedBetaIncomplete } from './beta-incomplete'
 export { default as digamma } from './digamma'

--- a/test/special.js
+++ b/test/special.js
@@ -224,6 +224,94 @@ describe('special', () => {
     })
   })
 
+  describe('.besselK()', () => {
+    it('K_n(0) should be Infinity for all n', () => {
+      // K_ν diverges at x=0 for all ν: ADR-0015 divergence → Infinity
+      for (const n of [0, 1, 2, 3]) {
+        assert.strictEqual(special.besselK(n, 0), Infinity)
+      }
+    })
+
+    it('K_0(x) should match mpmath reference values', () => {
+      // mpmath mp.dps=50: besselk(0, x) for x in {0.5, 1, 5, 10}
+      // x=10 uses asymptotic; optimal-truncation error bound ~3.7e-10 limits to 9 sig figs there
+      assert(equal(special.besselK(0, 0.5), 0.9244190712276659))
+      assert(equal(special.besselK(0, 1), 0.42102443824070834))
+      assert(equal(special.besselK(0, 5), 0.0036910983340425942))
+      assert(equal(special.besselK(0, 10), 1.778006231616765e-05, 9))
+    })
+
+    it('K_1(x) should match mpmath reference values', () => {
+      // mpmath mp.dps=50: besselk(1, x)
+      // x=10 uses asymptotic; optimal-truncation error bound limits to 9 sig figs there
+      assert(equal(special.besselK(1, 0.5), 1.656441120003301))
+      assert(equal(special.besselK(1, 1), 0.6019072301972346))
+      assert(equal(special.besselK(1, 5), 0.004044613445452165))
+      assert(equal(special.besselK(1, 10), 1.8648773453825585e-05, 9))
+    })
+
+    it('K_n(x) should match mpmath reference values for n=2,3,4', () => {
+      // mpmath mp.dps=50: besselk(n, x)
+      assert(equal(special.besselK(2, 1), 1.6248388986351774))
+      assert(equal(special.besselK(3, 1), 7.101262824737945))
+      assert(equal(special.besselK(4, 1), 44.232415847062846))
+      assert(equal(special.besselK(2, 5), 0.00530894371222346))
+      assert(equal(special.besselK(3, 5), 0.008291768415230933))
+    })
+
+    it('K_0(x) should satisfy the asymptotic leading term at large x', () => {
+      // K_ν(x) ~ sqrt(π/(2x)) * exp(-x) for large x; 1% tolerance at x=50
+      const x = 50
+      assert(Math.abs(special.besselK(0, x) * Math.exp(x) * Math.sqrt(2 * x / Math.PI) - 1) < 0.01)
+    })
+
+    it('should satisfy the recurrence K_{n+1}(x) = (2n/x)*K_n(x) + K_{n-1}(x)', () => {
+      for (const [n, x] of [[1, 1], [2, 1], [1, 5], [2, 5]]) {
+        const lhs = special.besselK(n + 1, x)
+        const rhs = (2 * n / x) * special.besselK(n, x) + special.besselK(n - 1, x)
+        assert(equal(lhs, rhs))
+      }
+    })
+  })
+
+  describe('.besselKnu()', () => {
+    it('K_nu(0) should be Infinity', () => {
+      assert.strictEqual(special.besselKnu(0.5, 0), Infinity)
+      assert.strictEqual(special.besselKnu(1.5, 0), Infinity)
+    })
+
+    it('K_{0.5}(x) should match the exact closed form sqrt(pi/(2x))*exp(-x)', () => {
+      // K_{1/2}(x) = sqrt(pi/(2x)) * exp(-x) exactly (DLMF 10.39.2)
+      for (const x of [1, 5, 10, 50]) {
+        const exact = Math.sqrt(Math.PI / (2 * x)) * Math.exp(-x)
+        assert(equal(special.besselKnu(0.5, x), exact))
+      }
+    })
+
+    it('K_{1.5}(x) should match the exact closed form sqrt(pi/(2x))*exp(-x)*(1+1/x)', () => {
+      // K_{3/2}(x) = sqrt(pi/(2x)) * exp(-x) * (1 + 1/x) exactly (DLMF 10.39.2)
+      for (const x of [1, 5, 10, 50]) {
+        const exact = Math.sqrt(Math.PI / (2 * x)) * Math.exp(-x) * (1 + 1 / x)
+        assert(equal(special.besselKnu(1.5, x), exact))
+      }
+    })
+
+    it('K_{2.5}(x) should match mpmath reference values', () => {
+      // mpmath mp.dps=50: besselk(2.5, x)
+      assert(equal(special.besselKnu(2.5, 1), 3.2274795311352618))
+      assert(equal(special.besselKnu(2.5, 5), 0.006495775004385758))
+      assert(equal(special.besselKnu(2.5, 10), 2.393132586462789e-05))
+    })
+
+    it('should dispatch to besselK for integer nu', () => {
+      for (const x of [1, 5]) {
+        assert.strictEqual(special.besselKnu(0, x), special.besselK(0, x))
+        assert.strictEqual(special.besselKnu(1, x), special.besselK(1, x))
+        assert.strictEqual(special.besselKnu(2, x), special.besselK(2, x))
+      }
+    })
+  })
+
   describe('.beta()', () => {
     it('should return exact values for small positive integer arguments', () => {
       // B(1,1) = 1 exactly

--- a/test/special.js
+++ b/test/special.js
@@ -272,6 +272,18 @@ describe('special', () => {
         assert(equal(lhs, rhs))
       }
     })
+
+    it('K_0 and K_1 should be continuous across the series/asymptotic crossover at x=6', () => {
+      // x≤6 uses combined series; x>6 uses asymptotic (_X_K_SERIES=6)
+      // Over a 0.02 step the natural variation is ~2.2% (K decreases at ~1/unit near x=6)
+      // A large discontinuity would produce a ratio outside [1, 1.1] or a sign flip
+      const k0b = special.besselK(0, 5.99)
+      const k0a = special.besselK(0, 6.01)
+      const k1b = special.besselK(1, 5.99)
+      const k1a = special.besselK(1, 6.01)
+      assert(k0b > k0a && k0b / k0a < 1.1)
+      assert(k1b > k1a && k1b / k1a < 1.1)
+    })
   })
 
   describe('.besselKnu()', () => {
@@ -298,6 +310,8 @@ describe('special', () => {
 
     it('K_{2.5}(x) should match mpmath reference values', () => {
       // mpmath mp.dps=50: besselk(2.5, x)
+      // x=10 uses asymptotic; for nu=2.5 the series terminates at k=3 (4nu²-25=0),
+      // so the only error is floating-point rounding — precision=10 is correct here
       assert(equal(special.besselKnu(2.5, 1), 3.2274795311352618))
       assert(equal(special.besselKnu(2.5, 5), 0.006495775004385758))
       assert(equal(special.besselKnu(2.5, 10), 2.393132586462789e-05))

--- a/test/special.js
+++ b/test/special.js
@@ -310,6 +310,15 @@ describe('special', () => {
         assert.strictEqual(special.besselKnu(2, x), special.besselK(2, x))
       }
     })
+
+    it('should dispatch negative-integer nu to the correct absolute order', () => {
+      // K_ν is even in ν: K_{-n}(x) = K_n(x); negative-integer dispatch must abs() the order
+      for (const x of [1, 5]) {
+        assert.strictEqual(special.besselKnu(-1, x), special.besselK(1, x))
+        assert.strictEqual(special.besselKnu(-2, x), special.besselK(2, x))
+        assert.strictEqual(special.besselKnu(-3, x), special.besselK(3, x))
+      }
+    })
   })
 
   describe('.beta()', () => {


### PR DESCRIPTION
Closes #809

## Summary

- Implement `besselK(n, x)` (integer order) and `besselKnu(nu, x)` (real order) in `src/special/bessel.js`, exported from `src/special/index.js`
- Use combined-series form (DLMF §10.31.2) for small x to avoid catastrophic cancellation, plus a shared asymptotic expansion (DLMF §10.40.2) with optimal truncation for large x
- Connection formula `K_ν = (π/2)(I_{-ν} − I_ν)/sin(νπ)` is used only for fractional ν and small x; asymptotic replaces it for x > 6 where it would lose ~2x/ln(10) digits

## Design decisions

No ADR required — implementation follows established `besselInu` / `recursiveSum` patterns with no new public API surface or cross-cutting conventions.

## Non-trivial changes

- **`src/special/bessel.js`**: Five new functions added:
  - `_KAsymptotic(nu, x)` — asymptotic expansion with optimal truncation; shared by `_K0`, `_K1`, and `besselKnu` above the crossover threshold
  - `_K0(x)` / `_K1(x)` — combined-series form (DLMF §10.31.2) that folds `lnh = ln(x/2)+γ` into each summation term so no two O(e^x) quantities ever appear separately; falls back to asymptotic for x > 6
  - `besselK(n, x)` — seeds from K_0/K_1 and propagates via forward-stable upward recurrence K_{n+1} = (2n/x)·K_n + K_{n-1} (DLMF §10.29.1)
  - `besselKnu(nu, x)` — near-integer ν dispatches to `besselK(Math.abs(Math.round(nu)), x)` (uses `Math.abs` so negative integers forward the correct order); fractional ν uses connection formula for x ≤ 6 and asymptotic for x > 6

- **`test/special.js`**: Tests added for `besselK` and `besselKnu` covering boundary (x=0 → Infinity), mpmath reference values, upward-recurrence identity, asymptotic leading-term sanity at x=50, crossover continuity at x=6, half-integer closed forms, and negative-integer dispatch.

## Comprehension checklist

- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/special/index.js`**: Added `besselK` and `besselKnu` to exports
- **`CHANGELOG.md`**: Added `## [Unreleased]` entry
- **`solutions/special-functions/2026-07-05-1530-bessel-k-second-kind-cancellation-strategy.md`**: Solution document capturing the two-level cancellation problem and fixes

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_0132ReTYygq33eiMbBLTCK3i)_