### PR TITLE
Replace loose-tolerance gammaLowerIncomplete tests with mpmath reference values

### DIFF
--- a/test/special.js
+++ b/test/special.js
@@ -505,8 +505,8 @@ describe('special', () => {
     it('should match mpmath reference values in the deep CF branch (x >> a)', () => {
       // Continued-fraction path: x >= s+1; upper incomplete gamma computed directly.
       assert(equal(special.gammaUpperIncomplete(1, 20.0), 2.061153622438558e-9))
-      assert(equal(special.gammaUpperIncomplete(5, 50.0), 5.4497019829205295e-17, 8))
-      assert(equal(special.gammaUpperIncomplete(10, 100.0), 1.1253473960842733e-31, 5))
+      assert(equal(special.gammaUpperIncomplete(5, 50.0), 5.4497019829205295e-17, 10))
+      assert(equal(special.gammaUpperIncomplete(10, 100.0), 1.1253473960842733e-31, 10))
     })
 
     it('should match mpmath reference values for large a', () => {

--- a/test/special.js
+++ b/test/special.js
@@ -480,29 +480,54 @@ describe('special', () => {
       }
     })
 
-    it('should be equal to exp(-x) for s = 1', () => {
-      for (const x of [1, 5, 10, 50, 100]) {
-        const gui = special.gammaUpperIncomplete(1, x) * special.gamma(1)
-        assert(Math.abs(gui - Math.exp(-x)) / gui < 0.01)
-      }
+    // Reference values from mpmath at mp.dps=70.
+    it('should match mpmath reference values in the deep series branch (x << a)', () => {
+      // Series expansion path: x < s+1
+      assert(equal(special.gammaLowerIncomplete(5, 0.5), 1.7211562995584078e-4))
+      assert(equal(special.gammaLowerIncomplete(10, 1.0), 1.1142547833872067e-7))
+      assert(equal(special.gammaLowerIncomplete(50, 5.0), 2.1810592140784887e-32))
+      // Complementary upper values
+      assert(equal(special.gammaUpperIncomplete(5, 0.5), 0.9998278843700441))
+      assert(equal(special.gammaUpperIncomplete(10, 1.0), 0.9999998885745217))
     })
 
-    it('should be equal to sqrt(pi) * erf(sqrt(x)) for s = 1/2', () => {
-      for (const x of [1, 5, 10, 50, 100]) {
-        const gli = special.gammaLowerIncomplete(0.5, x) * special.gamma(0.5)
-        assert(Math.abs(gli - Math.sqrt(Math.PI) * special.erf(Math.sqrt(x))) / gli < 0.01)
-      }
+    it('should match mpmath reference values in the crossover region (x near a)', () => {
+      // Near x = a the series and CF both converge most slowly; the implementation uses
+      // the series branch (x < s+1) here.
+      assert(equal(special.gammaLowerIncomplete(5, 5.0), 0.5595067149347875))
+      assert(equal(special.gammaUpperIncomplete(5, 5.0), 0.4404932850652124))
+      assert(equal(special.gammaLowerIncomplete(10, 10.0), 0.5420702855281478))
+      assert(equal(special.gammaUpperIncomplete(10, 10.0), 0.4579297144718522))
+      assert(equal(special.gammaLowerIncomplete(50, 50.0), 0.5188083154720433))
+      assert(equal(special.gammaUpperIncomplete(50, 50.0), 0.48119168452795674))
     })
 
-    it('should converge to x^s / s as x -> 0', () => {
-      const x = 1e-5
-      for (const s of [0.5, 1, 2, 5, 10]) {
-        const xs = Math.pow(x, s)
+    it('should match mpmath reference values in the deep CF branch (x >> a)', () => {
+      // Continued-fraction path: x >= s+1; upper incomplete gamma computed directly.
+      assert(equal(special.gammaUpperIncomplete(1, 20.0), 2.061153622438558e-9))
+      assert(equal(special.gammaUpperIncomplete(5, 50.0), 5.4497019829205295e-17, 8))
+      assert(equal(special.gammaUpperIncomplete(10, 100.0), 1.1253473960842733e-31, 5))
+    })
 
-        const gli = special.gammaLowerIncomplete(s, x) * special.gamma(s)
-        if (xs > 1e-100) {
-          assert(Math.abs(gli / Math.pow(x, s) * s - 1) < 0.01)
-        }
+    it('should match mpmath reference values for large a', () => {
+      // Large shape parameter; series branch is used (x = a < a+1).
+      assert(equal(special.gammaLowerIncomplete(100, 100.0), 0.5132987982791487))
+      assert(equal(special.gammaUpperIncomplete(100, 100.0), 0.48670120172085135))
+      // s=1000 is excluded: MAX_ITER=100 truncates the series before convergence at this scale
+      // (~270 iterations needed), so 10-sig-fig accuracy is not achievable without an implementation change.
+    })
+
+    it('P + Q should equal 1 for all algorithm regions', () => {
+      const pairs = [
+        [5, 0.5], [10, 1.0], [50, 5.0],
+        [5, 5.0], [10, 10.0], [50, 50.0],
+        [1, 20.0], [5, 50.0], [10, 100.0],
+        [100, 100.0], [1000, 1000.0]
+      ]
+      for (const [s, x] of pairs) {
+        const p = special.gammaLowerIncomplete(s, x)
+        const q = special.gammaUpperIncomplete(s, x)
+        assert(equal(p + q, 1))
       }
     })
 


### PR DESCRIPTION
Closes #810

## Summary
- Replaced 3 loose-tolerance (1% relative error) tests for `gammaLowerIncomplete` / `gammaUpperIncomplete` with 5 precision test blocks covering all three algorithm regions
- Reference values computed with mpmath at `mp.dps=70` using `gammainc(s, 0, x, regularized=True)` and `gammainc(s, x, inf, regularized=True)`
- Filed #837 to track the MAX_ITER=100 truncation issue that prevents 10-sig-fig accuracy at s=1000

## Non-trivial changes
- **`test/special.js`**: Tests now cover the deep series branch (x≪a), crossover region (x≈a), deep CF branch (x≫a), and large-a cases with 10 significant figures of accuracy against high-precision references. The s=1000 case is explicitly excluded with a comment explaining the implementation limitation (series needs ~270 iterations but MAX_ITER=100 truncates at ~100, yielding only ~4 sig figs). A final complementarity test (`P + Q = 1`) is added covering all parameter regions including s=1000.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- Removed: "should be equal to exp(-x) for s = 1", "should be equal to sqrt(pi) * erf(sqrt(x)) for s = 1/2", "should converge to x^s / s as x → 0" — replaced by mpmath reference blocks

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4nJxMaRVjJkUEH7NzLh4y)_