### PR TITLE
Extend docs-build CI check to all four generated HTML pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - run: npm ci
         if: steps.node-cache.outputs.cache-hit != 'true'
       - run: npm run docs
-      - run: test -f docs/index.html && test -f docs/porting-scipy.html && test -f docs/styles/style.css
+      - run: test -f docs/index.html && test -f docs/porting-scipy.html && test -f docs/parameter-estimation.html && test -f docs/demo.html && test -f docs/styles/style.css
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs


### PR DESCRIPTION
Closes #814

## Summary
- Extended the `docs-build` CI shell assertion to include `docs/parameter-estimation.html` and `docs/demo.html`, which the docs generator already produces but were never checked
- Prevents a Pug template error or missing data binding in either unchecked page from silently passing CI and deploying a broken page to GitHub Pages

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoLcu6TJ6XjJozj7S19tHi)_