### PR TITLE
Replace deprecated sass.renderSync() with sass.compile() in docs generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `docs/index.js` now uses `sass.compile()` instead of the deprecated `sass.renderSync()`, eliminating deprecation warnings on every `npm run docs` invocation (#817).
+
 ### Changed
 
 - `Distribution.test()` now uses the Anderson-Darling test (Marsaglia & Marsaglia 2004 asymptotic series + finite-n correction, α = 0.01) instead of Kolmogorov-Smirnov for continuous distributions. The `passed` field is unaffected. The `statistics` field now carries the A² statistic (typical scale 0.2–5) rather than the KS D-statistic (scale 0–1); code that reads the raw value will silently see a different number (#816).

--- a/docs/index.js
+++ b/docs/index.js
@@ -93,10 +93,7 @@ function parseEntry (entry) {
 (async () => {
   // Compile style to disk so every page links the same external stylesheet.
   console.log('Compiling style')
-  const compiledStyle = sass.renderSync({
-    file: './docs/styles/index.scss',
-    outputStyle: 'compressed'
-  }).css.toString()
+  const compiledStyle = sass.compile('./docs/styles/index.scss', { style: 'compressed' }).css
   fs.writeFileSync('./docs/styles/style.css', compiledStyle)
 
   // Parse documentation strings starting from index.js.


### PR DESCRIPTION
Closes #817

## Summary
- Replaces the deprecated `sass.renderSync({ file, outputStyle })` call in `docs/index.js` with the stable `sass.compile(path, { style })` API introduced in Dart Sass 1.45.0, eliminating deprecation warnings on every `npm run docs` invocation.
- The new API is synchronous with the same contract: returns an object with a `.css` string property (no `.toString()` conversion needed — `renderSync` returned a Buffer, `compile` returns a string directly).

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`docs/index.js`**: `sass.renderSync({ file: ..., outputStyle: 'compressed' }).css.toString()` → `sass.compile(..., { style: 'compressed' }).css`
- **`CHANGELOG.md`**: Added `### Fixed` entry for #817

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNpZrCQ1ZrL77fGpfMht7Y)_