### PR TITLE
docs: expose Process base class in ran.process namespace

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -23,6 +23,9 @@ hljs.registerLanguage('javascript', require('highlight.js/lib/languages/javascri
 const PRIORITY = {
   dist: [
     'Distribution'
+  ],
+  process: [
+    'Process'
   ]
 }
 

--- a/src/process/_process.js
+++ b/src/process/_process.js
@@ -1,11 +1,11 @@
 import Xoshiro128p from '../core/xoshiro'
 
 /**
- * The stochastic process generator base class, all process generators extend this class.
+ * The stochastic process generator base class, all process generators extend this class. The methods listed here
+ * are available for all process generators.
  *
  * @class Process
  * @memberof ran.process
- * @constructor
  */
 export default class Process {
   constructor () {

--- a/src/process/index.js
+++ b/src/process/index.js
@@ -4,3 +4,4 @@
  * @namespace process
  * @memberof ran
  */
+export { default as Process } from './_process'


### PR DESCRIPTION
Export Process from src/process/index.js so documentation.js traverses
_process.js and picks up the @class/@memberof annotations. Without an
export, the namespace was empty and documentation.js never visited the
file.

Add process: ['Process'] to the PRIORITY map in docs/index.js so Process
appears first in the ran.process section, mirroring how Distribution leads
ran.dist.

Remove the spurious @constructor tag from the Process class-level JSDoc
(Distribution does not carry it at the class level; only concrete
subclasses do) and expand the class description to match Distribution's
phrasing.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CmgrXaimBb9Z2ieLapgYHf