### PR TITLE
Add OrnsteinUhlenbeck to ran.process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ran.process.OrnsteinUhlenbeck(theta, mu, sigma, dt)`: mean-reverting stochastic process with exact discrete-time sampler (`x = x·exp(−θ·dt) + μ·(1−exp(−θ·dt)) + σ·√((1−exp(−2θ·dt))/(2θ))·N(0,1)`). Exposes `mean(t)` and `variance(t)` with closed-form analytical values; converges to stationary Normal(μ, σ²/(2θ)) (#846).
 - `ran.process.BrownianMotion(mu, sigma, dt)`: Brownian motion (Wiener process) with drift, using an exact O(1) discrete-time sampler (`x += μ·dt + σ·√dt·N(0,1)`). Exposes `mean(t)` and `variance(t)` with closed-form analytical values (#848).
 - `Process.seed(s)` method: seeds the internal PRNG for reproducible paths; delegates to `this.r.seed(s)` and returns `this` for chaining, mirroring `Distribution.seed()` (#861).
 - `ran.process`: new `Process` abstract base class (`src/process/_process.js`) with `next()`, `path(n)`, `reset()`, and `state()` public interface; prerequisite for BrownianMotion and OrnsteinUhlenbeck (#847).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ This cycle applies to every new distribution, every new method, every bug fix. D
 - When performing multi-step tasks, show a progress list with checkboxes (e.g., `- [x]` done, `- [ ]` pending) and update it as you go.
 - **Always use selectable options** (via the `AskUserQuestion` tool) when asking the user to make a choice or design decision during planning or implementation. Never ask the user to type their choice as free text. Always include a final option labeled "Other" or "Type something" so the user can provide a custom answer if none of the options fit.
 - **Never stop mid-pipeline.** When a sub-skill (`/commit`, `/push`, `/pr`, etc.) is invoked from within a parent skill (`/hotfix`, `/build`, `/implement`, etc.), continue executing the parent workflow immediately after the sub-skill returns. Do not pause for user input between steps unless the parent skill explicitly requires it. Do not output text that implies completion (e.g. "Done!", "Committed!") between steps — save all status reporting for the parent skill's final report.
+- **`/review` vs `/code-review`**: `/code-review` is for standalone ad-hoc reviews only (e.g. the user types `/code-review` directly). When a parent skill (`/fix`, `/hotfix`, `/build`, `/implement`) instructs you to run a review step, **always** invoke `/review` via the Skill tool — never `/code-review`. `/review` runs spec-compliance + 8 parallel specialized agents; `/code-review` runs a single-agent inline scan and is not a substitute inside pipelines.
 
 ## Code Style
 

--- a/src/process/index.js
+++ b/src/process/index.js
@@ -5,4 +5,5 @@
  * @memberof ran
  */
 export { default as BrownianMotion } from './brownian-motion'
+export { default as OrnsteinUhlenbeck } from './ornstein-uhlenbeck'
 export { default as Process } from './_process'

--- a/src/process/ornstein-uhlenbeck.js
+++ b/src/process/ornstein-uhlenbeck.js
@@ -1,0 +1,66 @@
+import normal from '../dist/_normal'
+import Process from './_process'
+
+/**
+ * Ornstein-Uhlenbeck mean-reverting process, using an exact discrete-time sampler.
+ *
+ * The update rule per step is X(t+dt) = X(t)·exp(−θ·dt) + μ·(1−exp(−θ·dt)) + σ·√((1−exp(−2θ·dt))/(2θ))·Z
+ * where Z ~ N(0,1).
+ *
+ * @class OrnsteinUhlenbeck
+ * @memberof ran.process
+ * @constructor
+ */
+export default class OrnsteinUhlenbeck extends Process {
+  /**
+   * @param {number} [theta=1] Mean-reversion speed (must be > 0).
+   * @param {number} [mu=0] Long-run mean.
+   * @param {number} [sigma=1] Diffusion coefficient (must be > 0).
+   * @param {number} [dt=1] Time step (must be > 0).
+   */
+  constructor (theta = 1, mu = 0, sigma = 1, dt = 1) {
+    super()
+    Process.validate({ theta, mu, sigma, dt }, ['theta > 0', 'sigma > 0', 'dt > 0'])
+    this.p = { theta, mu, sigma, dt }
+    this.x = 0
+    this.x0 = 0
+    const decay = Math.exp(-theta * dt)
+    this.c = {
+      decay,
+      noise: sigma * Math.sqrt((1 - decay * decay) / (2 * theta))
+    }
+  }
+
+  _next () {
+    const { mu } = this.p
+    const { decay, noise } = this.c
+    return this.x * decay + mu * (1 - decay) + noise * normal(this.r)
+  }
+
+  /**
+   * Returns the analytical mean of the process at time t.
+   *
+   * @method mean
+   * @memberof ran.process.OrnsteinUhlenbeck
+   * @param {number} t Time.
+   * @returns {number} Expected value x₀·exp(−θ·t) + μ·(1−exp(−θ·t)).
+   */
+  mean (t) {
+    if (t < 0) return NaN
+    const e = Math.exp(-this.p.theta * t)
+    return this.x0 * e + this.p.mu * (1 - e)
+  }
+
+  /**
+   * Returns the analytical variance of the process at time t.
+   *
+   * @method variance
+   * @memberof ran.process.OrnsteinUhlenbeck
+   * @param {number} t Time.
+   * @returns {number} Variance σ²·(1−exp(−2θ·t))/(2θ).
+   */
+  variance (t) {
+    if (t < 0) return NaN
+    return this.p.sigma * this.p.sigma * (1 - Math.exp(-2 * this.p.theta * t)) / (2 * this.p.theta)
+  }
+}

--- a/test/process.js
+++ b/test/process.js
@@ -2,6 +2,7 @@ import { assert } from 'chai'
 import { describe, it } from 'mocha'
 import Process from '../src/process/_process'
 import BrownianMotion from '../src/process/brownian-motion'
+import OrnsteinUhlenbeck from '../src/process/ornstein-uhlenbeck'
 import { Normal } from '../src/dist'
 import { ksTest } from './test-utils'
 
@@ -296,6 +297,126 @@ describe('process.BrownianMotion', () => {
       }
       const ref = new Normal(mu * dt, sigma * Math.sqrt(dt))
       assert(ksTest(increments, x => ref.cdf(x)))
+    })
+  })
+})
+
+describe('process.OrnsteinUhlenbeck', () => {
+  describe('constructor', () => {
+    it('should throw on theta = 0', () => {
+      assert.throws(() => new OrnsteinUhlenbeck(0, 0, 1, 1), /Invalid parameters/)
+    })
+
+    it('should throw on theta < 0', () => {
+      assert.throws(() => new OrnsteinUhlenbeck(-1, 0, 1, 1), /Invalid parameters/)
+    })
+
+    it('should throw on sigma = 0', () => {
+      assert.throws(() => new OrnsteinUhlenbeck(1, 0, 0, 1), /Invalid parameters/)
+    })
+
+    it('should throw on sigma < 0', () => {
+      assert.throws(() => new OrnsteinUhlenbeck(1, 0, -1, 1), /Invalid parameters/)
+    })
+
+    it('should throw on dt = 0', () => {
+      assert.throws(() => new OrnsteinUhlenbeck(1, 0, 1, 0), /Invalid parameters/)
+    })
+
+    it('should throw on dt < 0', () => {
+      assert.throws(() => new OrnsteinUhlenbeck(1, 0, 1, -0.5), /Invalid parameters/)
+    })
+
+    it('should throw on mu = NaN', () => {
+      assert.throws(() => new OrnsteinUhlenbeck(1, NaN, 1, 1), /Invalid parameters/)
+    })
+
+    it('should accept valid parameters', () => {
+      assert.doesNotThrow(() => new OrnsteinUhlenbeck(2, 1, 0.5, 0.1))
+    })
+
+    it('should start at state 0', () => {
+      const ou = new OrnsteinUhlenbeck(1, 2, 0.5, 0.1)
+      assert.strictEqual(ou.state(), 0)
+    })
+  })
+
+  describe('.mean()', () => {
+    it('should return mu*(1 - exp(-theta*t)) for zero initial state', () => {
+      const ou = new OrnsteinUhlenbeck(2, 3, 1, 0.1)
+      assert.closeTo(ou.mean(1), 3 * (1 - Math.exp(-2)), 1e-10)
+    })
+
+    it('should return 0 at t=0', () => {
+      const ou = new OrnsteinUhlenbeck(1, 5, 1, 0.1)
+      assert.strictEqual(ou.mean(0), 0)
+    })
+
+    it('should approach mu as t -> infinity', () => {
+      const ou = new OrnsteinUhlenbeck(1, 4, 1, 0.1)
+      assert.closeTo(ou.mean(1000), 4, 1e-6)
+    })
+
+    it('should return NaN for t < 0', () => {
+      const ou = new OrnsteinUhlenbeck(1, 0, 1, 1)
+      assert(isNaN(ou.mean(-1)))
+    })
+
+    it('should be stable after advancing the simulation', () => {
+      const ou = new OrnsteinUhlenbeck(2, 3, 1, 0.1)
+      const before = ou.mean(1)
+      for (let i = 0; i < 20; i++) ou.next()
+      assert.closeTo(ou.mean(1), before, 1e-10)
+    })
+  })
+
+  describe('.variance()', () => {
+    it('should return sigma^2*(1-exp(-2*theta*t))/(2*theta)', () => {
+      const theta = 2; const sigma = 0.5; const t = 1
+      const ou = new OrnsteinUhlenbeck(theta, 0, sigma, 0.1)
+      const expected = sigma * sigma * (1 - Math.exp(-2 * theta * t)) / (2 * theta)
+      assert.closeTo(ou.variance(t), expected, 1e-10)
+    })
+
+    it('should return 0 at t=0', () => {
+      const ou = new OrnsteinUhlenbeck(1, 0, 1, 1)
+      assert.strictEqual(ou.variance(0), 0)
+    })
+
+    it('should approach stationary variance sigma^2/(2*theta) as t -> infinity', () => {
+      const theta = 2; const sigma = 0.5
+      const ou = new OrnsteinUhlenbeck(theta, 0, sigma, 0.1)
+      assert.closeTo(ou.variance(1000), sigma * sigma / (2 * theta), 1e-6)
+    })
+
+    it('should return NaN for t < 0', () => {
+      const ou = new OrnsteinUhlenbeck(1, 0, 1, 1)
+      assert(isNaN(ou.variance(-1)))
+    })
+  })
+
+  describe('.reset()', () => {
+    it('should restore initial state to 0', () => {
+      const ou = new OrnsteinUhlenbeck(1, 2, 0.5, 0.1)
+      for (let i = 0; i < 10; i++) ou.next()
+      ou.reset()
+      assert.strictEqual(ou.state(), 0)
+    })
+  })
+
+  describe('stationarity', () => {
+    it('should converge to stationary distribution (KS test)', () => {
+      const theta = 2; const mu = 3; const sigma = 1; const dt = 0.1
+      const ou = new OrnsteinUhlenbeck(theta, mu, sigma, dt)
+      for (let i = 0; i < 500; i++) ou.next()
+      const samples = []
+      for (let i = 0; i < 1000; i++) {
+        ou.next()
+        samples.push(ou.state())
+      }
+      const stationaryStd = sigma / Math.sqrt(2 * theta)
+      const ref = new Normal(mu, stationaryStd)
+      assert(ksTest(samples, x => ref.cdf(x)))
     })
   })
 })


### PR DESCRIPTION
Closes #846

## Summary
- Implements `OrnsteinUhlenbeck` as a concrete `Process` subclass using the exact discrete-time sampler: `x = x·exp(−θ·dt) + μ·(1−exp(−θ·dt)) + σ·√((1−exp(−2θ·dt))/(2θ))·N(0,1)`
- Exposes `mean(t)` and `variance(t)` with closed-form analytical values
- Exports the class from `src/process/index.js`

## Design decisions

No ADR required — this is a straightforward concrete implementation of an established mathematical process using the same pattern as `BrownianMotion`.

## Non-trivial changes

- **`src/process/ornstein-uhlenbeck.js`**: New `OrnsteinUhlenbeck` class extending `Process`. Pre-computes `decay = exp(−θ·dt)` and `noise = σ·√((1−decay²)/(2θ))` in `this.c` to avoid redundant `exp` calls per step. `mean(t)` and `variance(t)` use only `this.x0` and `this.p`, not the current simulation state, so they remain stable after `next()` calls.
- **`test/process.js`**: Full test suite for `OrnsteinUhlenbeck` including constructor validation, `mean()`/`variance()` analytical correctness, a stability test (verifies `mean(t)` is unaffected by advancing the simulation), `reset()`, and a stationarity KS test (500-step burn-in, 1000 samples vs `Normal(μ, σ/√(2θ))`).

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/process/index.js`**: Added one-line `OrnsteinUhlenbeck` export in alphabetical order
- **`CHANGELOG.md`**: Added `### Added` bullet for `ran.process.OrnsteinUhlenbeck`
- **`CLAUDE.md`**: Added `/review` vs `/code-review` distinction rule in Workflow section

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZW2YWnRKKQYtPDEWw2KHc)_