### PR TITLE
Add PoissonProcess to ran.process (#853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ran.process.PoissonProcess(lambda, dt)`: Poisson counting process where arrivals in each interval Δt follow Poisson(λ·Δt); state is cumulative event count, guaranteed non-decreasing and integer-valued (#853).
 - `ran.process.OrnsteinUhlenbeck(theta, mu, sigma, dt)`: mean-reverting stochastic process with exact discrete-time sampler (`x = x·exp(−θ·dt) + μ·(1−exp(−θ·dt)) + σ·√((1−exp(−2θ·dt))/(2θ))·N(0,1)`). Exposes `mean(t)` and `variance(t)` with closed-form analytical values; converges to stationary Normal(μ, σ²/(2θ)) (#846).
 - Demo page (`demo.html`) now includes an interactive **Stochastic Processes** section below the Distributions section. Select `BrownianMotion`, adjust parameters (μ, σ, dt) and path length, and see 7 semi-transparent sample paths with a theoretical mean E[X(t)] line and ±1σ envelope overlaid (#862).
 - `ran.process.BrownianMotion(mu, sigma, dt)`: Brownian motion (Wiener process) with drift, using an exact O(1) discrete-time sampler (`x += μ·dt + σ·√dt·N(0,1)`). Exposes `mean(t)` and `variance(t)` with closed-form analytical values (#848).

--- a/package.json
+++ b/package.json
@@ -464,6 +464,9 @@
     },
     "./process/ornstein-uhlenbeck": {
       "import": "./dist/process/ornstein-uhlenbeck.esm.js"
+    },
+    "./process/poisson-process": {
+      "import": "./dist/process/poisson-process.esm.js"
     }
   },
   "sideEffects": false,

--- a/src/process/index.js
+++ b/src/process/index.js
@@ -6,4 +6,5 @@
  */
 export { default as BrownianMotion } from './brownian-motion'
 export { default as OrnsteinUhlenbeck } from './ornstein-uhlenbeck'
+export { default as PoissonProcess } from './poisson-process'
 export { default as Process } from './_process'

--- a/src/process/poisson-process.js
+++ b/src/process/poisson-process.js
@@ -26,4 +26,30 @@ export default class PoissonProcess extends Process {
   _next () {
     return this.x + poisson(this.r, this.p.lambda * this.p.dt)
   }
+
+  /**
+   * Returns the analytical mean of the process at time t.
+   *
+   * @method mean
+   * @memberof ran.process.PoissonProcess
+   * @param {number} t Time.
+   * @returns {number} Expected value λ·t.
+   */
+  mean (t) {
+    if (t < 0) return NaN
+    return this.p.lambda * t
+  }
+
+  /**
+   * Returns the analytical variance of the process at time t.
+   *
+   * @method variance
+   * @memberof ran.process.PoissonProcess
+   * @param {number} t Time.
+   * @returns {number} Variance λ·t.
+   */
+  variance (t) {
+    if (t < 0) return NaN
+    return this.p.lambda * t
+  }
 }

--- a/src/process/poisson-process.js
+++ b/src/process/poisson-process.js
@@ -1,0 +1,30 @@
+import poisson from '../dist/_poisson'
+import Process from './_process'
+
+/**
+ * Poisson process: a counting process where arrivals in [t, t+Δt] follow Poisson(λ·Δt).
+ *
+ * The update rule is X_{n+1} = X_n + Poisson(λ·Δt).
+ *
+ * @class PoissonProcess
+ * @memberof ran.process
+ * @constructor
+ */
+export default class PoissonProcess extends Process {
+  /**
+   * @param {number} [lambda=1] Event rate (must be > 0).
+   * @param {number} [dt=1] Time step (must be > 0).
+   */
+  constructor (lambda = 1, dt = 1) {
+    super()
+    Process.validate({ lambda, dt }, ['lambda > 0', 'dt > 0'])
+    this.p = { lambda, dt }
+    this.x = 0
+    this.x0 = 0
+    this.c = { rate: lambda * dt }
+  }
+
+  _next () {
+    return this.x + poisson(this.r, this.c.rate)
+  }
+}

--- a/src/process/poisson-process.js
+++ b/src/process/poisson-process.js
@@ -21,10 +21,9 @@ export default class PoissonProcess extends Process {
     this.p = { lambda, dt }
     this.x = 0
     this.x0 = 0
-    this.c = { rate: lambda * dt }
   }
 
   _next () {
-    return this.x + poisson(this.r, this.c.rate)
+    return this.x + poisson(this.r, this.p.lambda * this.p.dt)
   }
 }

--- a/test/process.js
+++ b/test/process.js
@@ -3,8 +3,9 @@ import { describe, it } from 'mocha'
 import Process from '../src/process/_process'
 import BrownianMotion from '../src/process/brownian-motion'
 import OrnsteinUhlenbeck from '../src/process/ornstein-uhlenbeck'
-import { Normal } from '../src/dist'
-import { ksTest } from './test-utils'
+import PoissonProcess from '../src/process/poisson-process'
+import { Normal, Poisson } from '../src/dist'
+import { ksTest, chiTest } from './test-utils'
 
 describe('process._Process', () => {
   describe('.validate()', () => {
@@ -417,6 +418,78 @@ describe('process.OrnsteinUhlenbeck', () => {
       const stationaryStd = sigma / Math.sqrt(2 * theta)
       const ref = new Normal(mu, stationaryStd)
       assert(ksTest(samples, x => ref.cdf(x)))
+    })
+  })
+})
+
+describe('process.PoissonProcess', () => {
+  describe('constructor', () => {
+    it('should throw on lambda = 0', () => {
+      assert.throws(() => new PoissonProcess(0, 1), /Invalid parameters/)
+    })
+
+    it('should throw on lambda < 0', () => {
+      assert.throws(() => new PoissonProcess(-1, 1), /Invalid parameters/)
+    })
+
+    it('should throw on dt = 0', () => {
+      assert.throws(() => new PoissonProcess(1, 0), /Invalid parameters/)
+    })
+
+    it('should throw on dt < 0', () => {
+      assert.throws(() => new PoissonProcess(1, -0.5), /Invalid parameters/)
+    })
+
+    it('should throw on lambda = NaN', () => {
+      assert.throws(() => new PoissonProcess(NaN, 1), /Invalid parameters/)
+    })
+
+    it('should accept valid parameters', () => {
+      assert.doesNotThrow(() => new PoissonProcess(2, 0.5))
+    })
+
+    it('should accept default parameters', () => {
+      assert.doesNotThrow(() => new PoissonProcess())
+    })
+
+    it('should start at state 0', () => {
+      const pp = new PoissonProcess(1, 1)
+      assert.strictEqual(pp.state(), 0)
+    })
+  })
+
+  describe('path', () => {
+    it('should be non-decreasing', () => {
+      const pp = new PoissonProcess(2, 0.1)
+      const path = pp.path(200)
+      for (let i = 1; i < path.length; i++) {
+        assert(path[i] >= path[i - 1])
+      }
+    })
+
+    it('should be integer-valued', () => {
+      const pp = new PoissonProcess(2, 0.1)
+      const path = pp.path(200)
+      for (const x of path) {
+        assert.strictEqual(x, Math.floor(x))
+      }
+    })
+  })
+
+  describe('increments', () => {
+    it('should follow Poisson(lambda*dt) distribution (chi-squared test)', () => {
+      const lambda = 3
+      const dt = 0.5
+      const pp = new PoissonProcess(lambda, dt)
+      const n = 2000
+      const increments = []
+      for (let i = 0; i < n; i++) {
+        const prev = pp.state()
+        pp.next()
+        increments.push(pp.state() - prev)
+      }
+      const ref = new Poisson(lambda * dt)
+      assert(chiTest(increments, k => ref.pdf(k), 0))
     })
   })
 })

--- a/test/process.js
+++ b/test/process.js
@@ -495,4 +495,38 @@ describe('process.PoissonProcess', () => {
       assert(chiTest(increments, k => ref.pdf(k), 0))
     })
   })
+
+  describe('.mean()', () => {
+    it('should return lambda*t', () => {
+      const pp = new PoissonProcess(2, 0.5)
+      assert.closeTo(pp.mean(3), 6, 1e-10)
+    })
+
+    it('should return 0 at t=0', () => {
+      const pp = new PoissonProcess(2, 0.5)
+      assert.strictEqual(pp.mean(0), 0)
+    })
+
+    it('should return NaN for t < 0', () => {
+      const pp = new PoissonProcess(2, 0.5)
+      assert(Number.isNaN(pp.mean(-1)))
+    })
+  })
+
+  describe('.variance()', () => {
+    it('should return lambda*t', () => {
+      const pp = new PoissonProcess(2, 0.5)
+      assert.closeTo(pp.variance(3), 6, 1e-10)
+    })
+
+    it('should return 0 at t=0', () => {
+      const pp = new PoissonProcess(2, 0.5)
+      assert.strictEqual(pp.variance(0), 0)
+    })
+
+    it('should return NaN for t < 0', () => {
+      const pp = new PoissonProcess(2, 0.5)
+      assert(Number.isNaN(pp.variance(-1)))
+    })
+  })
 })


### PR DESCRIPTION
Closes #853

## Summary
- Adds `PoissonProcess(lambda, dt)` to `ran.process`: a discrete-time counting process where each step increments state by a Poisson(λ·Δt) variate, producing a non-decreasing integer-valued path.
- Exports `PoissonProcess` from `src/process/index.js` alongside `BrownianMotion` and `OrnsteinUhlenbeck`.
- Tests cover parameter validation, non-decreasing/integer-valued path invariants, and a chi-squared distributional test on increments.

## Non-trivial changes
- **`src/process/poisson-process.js`**: New `PoissonProcess` class extending `Process`. Uses the internal `_poisson` sampler (same one used by `ran.dist.Poisson`) so the increment distribution is consistent with the rest of the library. Rate `lambda * dt` is computed inline in `_next()` rather than pre-cached in `this.c`, matching the convention that `this.c` is reserved for genuinely expensive pre-computations (sqrt, exp).

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/process/index.js`**: Added `PoissonProcess` export.
- **`test/process.js`**: Added `PoissonProcess` import and test block; updated `chiTest` import.
- **`CHANGELOG.md`**: Added `### Added` bullet for `PoissonProcess`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk5sDyTPr8GomL24oYA6Rn)_