### PR TITLE
Unify Process API: abstract mean/variance/pdf, rename PoissonProcess.pmf to pdf

### DIFF
--- a/src/process/_process.js
+++ b/src/process/_process.js
@@ -122,6 +122,45 @@ export default class Process {
   }
 
   /**
+   * Returns the analytical mean of the process at time t. Must be implemented by subclasses.
+   *
+   * @method mean
+   * @memberof ran.process.Process
+   * @param {number} t Time.
+   * @returns {number} Expected value at time t, or NaN for t < 0.
+   */
+  mean (t) { // eslint-disable-line no-unused-vars
+    throw Error('Process.mean() is not implemented')
+  }
+
+  /**
+   * Returns the analytical variance of the process at time t. Must be implemented by subclasses.
+   *
+   * @method variance
+   * @memberof ran.process.Process
+   * @param {number} t Time.
+   * @returns {number} Variance at time t, or NaN for t < 0.
+   */
+  variance (t) { // eslint-disable-line no-unused-vars
+    throw Error('Process.variance() is not implemented')
+  }
+
+  /**
+   * Returns the marginal probability density or mass at state x and time t. For continuous
+   * processes this is a probability density; for discrete processes (e.g. Poisson) this is
+   * a probability mass. Must be implemented by subclasses.
+   *
+   * @method pdf
+   * @memberof ran.process.Process
+   * @param {number} x State value.
+   * @param {number} t Time.
+   * @returns {number} Marginal density or mass at (x, t), or NaN when t is out of domain.
+   */
+  pdf (x, t) { // eslint-disable-line no-unused-vars
+    throw Error('Process.pdf() is not implemented')
+  }
+
+  /**
    * Advances the process by one step, updates the current state, and returns the new state.
    *
    * @method next

--- a/src/process/brownian-bridge.js
+++ b/src/process/brownian-bridge.js
@@ -76,23 +76,27 @@ export default class BrownianBridge extends Process {
     return result
   }
 
+  /** @inheritdoc */
   mean (t) {
     if (t < 0) return NaN
     return 0
   }
 
+  /** @inheritdoc */
   variance (t) {
     if (t < 0) return NaN
     if (t >= this.p.T) return 0
     return this.p.sigma * this.p.sigma * t * (this.p.T - t) / this.p.T
   }
 
+  /** @inheritdoc */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     if (s > this.p.T || t > this.p.T) return 0
     return this.p.sigma * this.p.sigma * Math.min(s, t) * (this.p.T - Math.max(s, t)) / this.p.T
   }
 
+  /** @inheritdoc */
   pdf (x, t) {
     if (t < 0) return NaN
     const v = this.variance(t)

--- a/src/process/brownian-bridge.js
+++ b/src/process/brownian-bridge.js
@@ -76,60 +76,23 @@ export default class BrownianBridge extends Process {
     return result
   }
 
-  /**
-   * Returns the analytical mean of the process at time t.
-   *
-   * @method mean
-   * @memberof ran.process.BrownianBridge
-   * @param {number} t Time.
-   * @returns {number} Expected value 0 (bridge from 0 to 0).
-   */
   mean (t) {
     if (t < 0) return NaN
     return 0
   }
 
-  /**
-   * Returns the analytical variance of the process at time t.
-   *
-   * @method variance
-   * @memberof ran.process.BrownianBridge
-   * @param {number} t Time.
-   * @returns {number} Variance $\sigma^2 t(T-t)/T$ for $0 \le t \le T$, 0 for $t > T$.
-   */
   variance (t) {
     if (t < 0) return NaN
     if (t >= this.p.T) return 0
     return this.p.sigma * this.p.sigma * t * (this.p.T - t) / this.p.T
   }
 
-  /**
-   * Returns the analytical covariogram of the process at times s and t.
-   *
-   * @method covariogram
-   * @memberof ran.process.BrownianBridge
-   * @param {number} s First time point.
-   * @param {number} t Second time point.
-   * @returns {number} Covariance $\sigma^2 \min(s,t)(T - \max(s,t))/T$ for $0 \le s,t \le T$,
-   * 0 for $s > T$ or $t > T$.
-   */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     if (s > this.p.T || t > this.p.T) return 0
     return this.p.sigma * this.p.sigma * Math.min(s, t) * (this.p.T - Math.max(s, t)) / this.p.T
   }
 
-  /**
-   * Returns the marginal probability density of the process at state x and time t.
-   * X(t) ~ Normal(0, σ²t(T−t)/T) for 0 < t < T. At t = 0 or t ≥ T the process
-   * is pinned at 0 (Dirac delta), so the density is Infinity at x = 0 and 0 elsewhere.
-   *
-   * @method pdf
-   * @memberof ran.process.BrownianBridge
-   * @param {number} x State value.
-   * @param {number} t Time.
-   * @returns {number} Marginal density at (x, t), or NaN for t < 0.
-   */
   pdf (x, t) {
     if (t < 0) return NaN
     const v = this.variance(t)

--- a/src/process/brownian-motion.js
+++ b/src/process/brownian-motion.js
@@ -33,16 +33,19 @@ export default class BrownianMotion extends Process {
     return this.x + this.p.mu * this.p.dt + this.p.sigma * this.c.sqrtDt * normal(this.r)
   }
 
+  /** @inheritdoc */
   mean (t) {
     if (t < 0) return NaN
     return this.x0 + this.p.mu * t
   }
 
+  /** @inheritdoc */
   variance (t) {
     if (t < 0) return NaN
     return this.p.sigma * this.p.sigma * t
   }
 
+  /** @inheritdoc */
   pdf (x, t) {
     if (t <= 0) return NaN
     const mu = this.x0 + this.p.mu * t
@@ -51,6 +54,7 @@ export default class BrownianMotion extends Process {
     return Math.exp(-0.5 * z * z) / (sigma * Math.sqrt(2 * Math.PI))
   }
 
+  /** @inheritdoc */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     return this.p.sigma * this.p.sigma * Math.min(s, t)

--- a/src/process/brownian-motion.js
+++ b/src/process/brownian-motion.js
@@ -33,42 +33,16 @@ export default class BrownianMotion extends Process {
     return this.x + this.p.mu * this.p.dt + this.p.sigma * this.c.sqrtDt * normal(this.r)
   }
 
-  /**
-   * Returns the analytical mean of the process at time t.
-   *
-   * @method mean
-   * @memberof ran.process.BrownianMotion
-   * @param {number} t Time.
-   * @returns {number} Expected value $x_0 + \mu t$.
-   */
   mean (t) {
     if (t < 0) return NaN
     return this.x0 + this.p.mu * t
   }
 
-  /**
-   * Returns the analytical variance of the process at time t.
-   *
-   * @method variance
-   * @memberof ran.process.BrownianMotion
-   * @param {number} t Time.
-   * @returns {number} Variance $\sigma^2 t$.
-   */
   variance (t) {
     if (t < 0) return NaN
     return this.p.sigma * this.p.sigma * t
   }
 
-  /**
-   * Returns the marginal probability density of the process at state x and time t.
-   * X(t) ~ Normal(x₀ + μt, σ²t).
-   *
-   * @method pdf
-   * @memberof ran.process.BrownianMotion
-   * @param {number} x State value.
-   * @param {number} t Time (must be > 0).
-   * @returns {number} Marginal density at (x, t), or NaN for t ≤ 0.
-   */
   pdf (x, t) {
     if (t <= 0) return NaN
     const mu = this.x0 + this.p.mu * t
@@ -77,15 +51,6 @@ export default class BrownianMotion extends Process {
     return Math.exp(-0.5 * z * z) / (sigma * Math.sqrt(2 * Math.PI))
   }
 
-  /**
-   * Returns the analytical covariance between process values at times s and t.
-   *
-   * @method covariogram
-   * @memberof ran.process.BrownianMotion
-   * @param {number} s First time point.
-   * @param {number} t Second time point.
-   * @returns {number} Covariance $\sigma^2 \min(s, t)$.
-   */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     return this.p.sigma * this.p.sigma * Math.min(s, t)

--- a/src/process/geometric-brownian-motion.js
+++ b/src/process/geometric-brownian-motion.js
@@ -34,43 +34,17 @@ export default class GeometricBrownianMotion extends Process {
     return this.x * Math.exp(this.c.drift + this.c.noise * normal(this.r))
   }
 
-  /**
-   * Returns the analytical mean of the process at time t.
-   *
-   * @method mean
-   * @memberof ran.process.GeometricBrownianMotion
-   * @param {number} t Time.
-   * @returns {number} Expected value $x_0 e^{\mu t}$.
-   */
   mean (t) {
     if (t < 0) return NaN
     return this.x0 * Math.exp(this.p.mu * t)
   }
 
-  /**
-   * Returns the analytical variance of the process at time t.
-   *
-   * @method variance
-   * @memberof ran.process.GeometricBrownianMotion
-   * @param {number} t Time.
-   * @returns {number} Variance $x_0^2 e^{2\mu t}(e^{\sigma^2 t} - 1)$.
-   */
   variance (t) {
     if (t < 0) return NaN
     const s2 = this.p.sigma * this.p.sigma
     return this.x0 * this.x0 * Math.exp(2 * this.p.mu * t) * (Math.exp(s2 * t) - 1)
   }
 
-  /**
-   * Returns the marginal probability density of the process at state x and time t.
-   * log(X(t)) ~ Normal(log(x₀) + (μ − σ²/2)t, σ²t), so X(t) is log-normally distributed.
-   *
-   * @method pdf
-   * @memberof ran.process.GeometricBrownianMotion
-   * @param {number} x State value (must be > 0).
-   * @param {number} t Time (must be > 0).
-   * @returns {number} Marginal density at (x, t), or NaN for t ≤ 0 or x ≤ 0.
-   */
   pdf (x, t) {
     if (t <= 0) return NaN
     if (x <= 0) return 0
@@ -80,15 +54,6 @@ export default class GeometricBrownianMotion extends Process {
     return Math.exp(-0.5 * z * z) / (x * s * Math.sqrt(2 * Math.PI))
   }
 
-  /**
-   * Returns the analytical covariance between process values at times s and t.
-   *
-   * @method covariogram
-   * @memberof ran.process.GeometricBrownianMotion
-   * @param {number} s First time point.
-   * @param {number} t Second time point.
-   * @returns {number} Covariance $x_0^2 e^{\mu(s+t)}\left(e^{\sigma^2 \min(s,t)} - 1\right)$.
-   */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     const { mu, sigma } = this.p

--- a/src/process/geometric-brownian-motion.js
+++ b/src/process/geometric-brownian-motion.js
@@ -34,17 +34,20 @@ export default class GeometricBrownianMotion extends Process {
     return this.x * Math.exp(this.c.drift + this.c.noise * normal(this.r))
   }
 
+  /** @inheritdoc */
   mean (t) {
     if (t < 0) return NaN
     return this.x0 * Math.exp(this.p.mu * t)
   }
 
+  /** @inheritdoc */
   variance (t) {
     if (t < 0) return NaN
     const s2 = this.p.sigma * this.p.sigma
     return this.x0 * this.x0 * Math.exp(2 * this.p.mu * t) * (Math.exp(s2 * t) - 1)
   }
 
+  /** @inheritdoc */
   pdf (x, t) {
     if (t <= 0) return NaN
     if (x <= 0) return 0
@@ -54,6 +57,7 @@ export default class GeometricBrownianMotion extends Process {
     return Math.exp(-0.5 * z * z) / (x * s * Math.sqrt(2 * Math.PI))
   }
 
+  /** @inheritdoc */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     const { mu, sigma } = this.p

--- a/src/process/ornstein-uhlenbeck.js
+++ b/src/process/ornstein-uhlenbeck.js
@@ -40,17 +40,20 @@ export default class OrnsteinUhlenbeck extends Process {
     return this.x * decay + mu * (1 - decay) + noise * normal(this.r)
   }
 
+  /** @inheritdoc */
   mean (t) {
     if (t < 0) return NaN
     const e = Math.exp(-this.p.theta * t)
     return this.x0 * e + this.p.mu * (1 - e)
   }
 
+  /** @inheritdoc */
   variance (t) {
     if (t < 0) return NaN
     return this.p.sigma * this.p.sigma * (1 - Math.exp(-2 * this.p.theta * t)) / (2 * this.p.theta)
   }
 
+  /** @inheritdoc */
   pdf (x, t) {
     if (t <= 0) return NaN
     const mu = this.mean(t)
@@ -59,6 +62,7 @@ export default class OrnsteinUhlenbeck extends Process {
     return Math.exp(-0.5 * z * z) / (sigma * Math.sqrt(2 * Math.PI))
   }
 
+  /** @inheritdoc */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     const { theta, sigma } = this.p

--- a/src/process/ornstein-uhlenbeck.js
+++ b/src/process/ornstein-uhlenbeck.js
@@ -40,43 +40,17 @@ export default class OrnsteinUhlenbeck extends Process {
     return this.x * decay + mu * (1 - decay) + noise * normal(this.r)
   }
 
-  /**
-   * Returns the analytical mean of the process at time t.
-   *
-   * @method mean
-   * @memberof ran.process.OrnsteinUhlenbeck
-   * @param {number} t Time.
-   * @returns {number} Expected value $x_0 e^{-\theta t} + \mu(1 - e^{-\theta t})$.
-   */
   mean (t) {
     if (t < 0) return NaN
     const e = Math.exp(-this.p.theta * t)
     return this.x0 * e + this.p.mu * (1 - e)
   }
 
-  /**
-   * Returns the analytical variance of the process at time t.
-   *
-   * @method variance
-   * @memberof ran.process.OrnsteinUhlenbeck
-   * @param {number} t Time.
-   * @returns {number} Variance $\sigma^2 \frac{1 - e^{-2\theta t}}{2\theta}$.
-   */
   variance (t) {
     if (t < 0) return NaN
     return this.p.sigma * this.p.sigma * (1 - Math.exp(-2 * this.p.theta * t)) / (2 * this.p.theta)
   }
 
-  /**
-   * Returns the marginal probability density of the process at state x and time t.
-   * X(t) ~ Normal(mean(t), variance(t)).
-   *
-   * @method pdf
-   * @memberof ran.process.OrnsteinUhlenbeck
-   * @param {number} x State value.
-   * @param {number} t Time (must be > 0).
-   * @returns {number} Marginal density at (x, t), or NaN for t ≤ 0.
-   */
   pdf (x, t) {
     if (t <= 0) return NaN
     const mu = this.mean(t)
@@ -85,15 +59,6 @@ export default class OrnsteinUhlenbeck extends Process {
     return Math.exp(-0.5 * z * z) / (sigma * Math.sqrt(2 * Math.PI))
   }
 
-  /**
-   * Returns the analytical covariance between process values at times s and t.
-   *
-   * @method covariogram
-   * @memberof ran.process.OrnsteinUhlenbeck
-   * @param {number} s First time point.
-   * @param {number} t Second time point.
-   * @returns {number} Covariance $\frac{\sigma^2}{2\theta}\left(e^{-\theta|t-s|} - e^{-\theta(t+s)}\right)$.
-   */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     const { theta, sigma } = this.p

--- a/src/process/poisson-process.js
+++ b/src/process/poisson-process.js
@@ -28,43 +28,17 @@ export default class PoissonProcess extends Process {
     return this.x + poisson(this.r, this.p.lambda * this.p.dt)
   }
 
-  /**
-   * Returns the analytical mean of the process at time t.
-   *
-   * @method mean
-   * @memberof ran.process.PoissonProcess
-   * @param {number} t Time.
-   * @returns {number} Expected value λ·t.
-   */
   mean (t) {
     if (t < 0) return NaN
     return this.p.lambda * t
   }
 
-  /**
-   * Returns the analytical variance of the process at time t.
-   *
-   * @method variance
-   * @memberof ran.process.PoissonProcess
-   * @param {number} t Time.
-   * @returns {number} Variance λ·t.
-   */
   variance (t) {
     if (t < 0) return NaN
     return this.p.lambda * t
   }
 
-  /**
-   * Returns the marginal probability mass of the process at count x and time t.
-   * X(t) ~ Poisson(λt).
-   *
-   * @method pmf
-   * @memberof ran.process.PoissonProcess
-   * @param {number} x Count value (non-negative integer).
-   * @param {number} t Time.
-   * @returns {number} Marginal mass at (x, t), or NaN for t < 0.
-   */
-  pmf (x, t) {
+  pdf (x, t) {
     if (t < 0) return NaN
     if (!Number.isInteger(x) || x < 0) return 0
     if (t === 0) return x === 0 ? 1 : 0
@@ -72,15 +46,6 @@ export default class PoissonProcess extends Process {
     return Math.exp(-lt + x * Math.log(lt) - logGamma(x + 1))
   }
 
-  /**
-   * Returns the analytical covariance between process values at times s and t.
-   *
-   * @method covariogram
-   * @memberof ran.process.PoissonProcess
-   * @param {number} s First time point.
-   * @param {number} t Second time point.
-   * @returns {number} Covariance $\lambda \min(s, t)$.
-   */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     return this.p.lambda * Math.min(s, t)

--- a/src/process/poisson-process.js
+++ b/src/process/poisson-process.js
@@ -28,16 +28,19 @@ export default class PoissonProcess extends Process {
     return this.x + poisson(this.r, this.p.lambda * this.p.dt)
   }
 
+  /** @inheritdoc */
   mean (t) {
     if (t < 0) return NaN
     return this.p.lambda * t
   }
 
+  /** @inheritdoc */
   variance (t) {
     if (t < 0) return NaN
     return this.p.lambda * t
   }
 
+  /** @inheritdoc */
   pdf (x, t) {
     if (t < 0) return NaN
     if (!Number.isInteger(x) || x < 0) return 0
@@ -46,6 +49,7 @@ export default class PoissonProcess extends Process {
     return Math.exp(-lt + x * Math.log(lt) - logGamma(x + 1))
   }
 
+  /** @inheritdoc */
   covariogram (s, t) {
     if (s < 0 || t < 0) return NaN
     return this.p.lambda * Math.min(s, t)

--- a/test/process.js
+++ b/test/process.js
@@ -102,6 +102,27 @@ describe('process', () => {
       })
     })
 
+    describe('.mean()', () => {
+      it('should throw when not implemented', () => {
+        const p = new BareProcess()
+        assert.throws(() => p.mean(1), 'Process.mean() is not implemented')
+      })
+    })
+
+    describe('.variance()', () => {
+      it('should throw when not implemented', () => {
+        const p = new BareProcess()
+        assert.throws(() => p.variance(1), 'Process.variance() is not implemented')
+      })
+    })
+
+    describe('.pdf()', () => {
+      it('should throw when not implemented', () => {
+        const p = new BareProcess()
+        assert.throws(() => p.pdf(0, 1), 'Process.pdf() is not implemented')
+      })
+    })
+
     describe('.next()', () => {
       it('should advance state and return the new value', () => {
         const p = new StubProcess()
@@ -1193,48 +1214,48 @@ describe('process.PoissonProcess', () => {
     })
   })
 
-  describe('.pmf()', () => {
+  describe('.pdf()', () => {
     it('should return NaN for t < 0', () => {
       const pp = new PoissonProcess(1, 1)
-      assert(Number.isNaN(pp.pmf(0, -1)))
+      assert(Number.isNaN(pp.pdf(0, -1)))
     })
 
     it('should return 0 for non-integer x', () => {
       const pp = new PoissonProcess(2, 1)
-      assert.strictEqual(pp.pmf(1.5, 1), 0)
+      assert.strictEqual(pp.pdf(1.5, 1), 0)
     })
 
     it('should return 0 for negative integer x', () => {
       const pp = new PoissonProcess(2, 1)
-      assert.strictEqual(pp.pmf(-1, 1), 0)
+      assert.strictEqual(pp.pdf(-1, 1), 0)
     })
 
     it('should return 1 for x=0 at t=0', () => {
       const pp = new PoissonProcess(1, 1)
-      assert.strictEqual(pp.pmf(0, 0), 1)
+      assert.strictEqual(pp.pdf(0, 0), 1)
     })
 
     it('should return 0 for x=1 at t=0', () => {
       const pp = new PoissonProcess(1, 1)
-      assert.strictEqual(pp.pmf(1, 0), 0)
+      assert.strictEqual(pp.pdf(1, 0), 0)
     })
 
     it('should return Poisson(lambda*t) PMF for lambda=2 t=1 x=2', () => {
       const pp = new PoissonProcess(2, 1)
       // scipy: stats.poisson.pmf(2, 2) = 0.2706705664732255
-      assert.closeTo(pp.pmf(2, 1), 0.2706705664732255, 1e-10)
+      assert.closeTo(pp.pdf(2, 1), 0.2706705664732255, 1e-10)
     })
 
     it('should return Poisson(lambda*t) PMF for lambda=0.5 t=3 x=1', () => {
       const pp = new PoissonProcess(0.5, 1)
       // scipy: stats.poisson.pmf(1, 1.5) = 0.3346952402226447
-      assert.closeTo(pp.pmf(1, 3), 0.3346952402226447, 1e-10)
+      assert.closeTo(pp.pdf(1, 3), 0.3346952402226447, 1e-10)
     })
 
     it('should return Poisson(lambda*t) PMF for lambda=3 t=2 x=5', () => {
       const pp = new PoissonProcess(3, 1)
       // scipy: stats.poisson.pmf(5, 6) = 0.1606231410479798
-      assert.closeTo(pp.pmf(5, 2), 0.1606231410479798, 1e-10)
+      assert.closeTo(pp.pdf(5, 2), 0.1606231410479798, 1e-10)
     })
   })
 


### PR DESCRIPTION
 > **⚠ Missing ADR**: This PR contains non-trivial changes but no Architecture Decision Record was found.
> Consider adding one at `decisions/` to document the design rationale.
> See `decisions/0000-template.md` for the format.

## Summary
- Adds `mean(t)`, `variance(t)`, and `pdf(x, t)` as abstract stubs on the `Process` base class — throwing if not overridden — matching the pattern already used for `_next()` and `covariogram()`
- Consolidates all method documentation under `Process` (single source of truth); subclasses retain only the class-level process equation and constructor `@param` blocks
- Renames `PoissonProcess.pmf()` to `pdf()` so all five subclasses expose a uniform interface (`pdf` returns probability mass for discrete processes, density for continuous)

## Non-trivial changes
- **`src/process/_process.js`**: Three new abstract stubs (`mean`, `variance`, `pdf`) that throw `Error` if not overridden. Any existing `Process` subclass that omits these methods will now fail at runtime rather than silently returning `undefined`.
- **`src/process/poisson-process.js`**: `pmf()` renamed to `pdf()` — breaking rename for any caller using `PoissonProcess.pmf()`.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/process/brownian-motion.js`**, **`brownian-bridge.js`**, **`geometric-brownian-motion.js`**, **`ornstein-uhlenbeck.js`**: Removed per-method JSDoc blocks from `mean`, `variance`, `pdf`, `covariogram` — doc-only, no behaviour change.
- **`test/process.js`**: Three new throw tests for the new abstract stubs; `pp.pmf(...)` renamed to `pp.pdf(...)` throughout.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTP2BztrMTLqgHsooweC1w)_