### PR TITLE
Replace inline covariogram formulas with scipy references

### DIFF
--- a/test/process.js
+++ b/test/process.js
@@ -594,10 +594,9 @@ describe('process.GeometricBrownianMotion', () => {
 
   describe('.covariogram()', () => {
     it('should return exp(mu*(s+t)) * (exp(sigma^2*min(s,t)) - 1)', () => {
-      const mu = 0.05; const sigma = 0.2; const s = 1; const t = 3
-      const gbm = new GeometricBrownianMotion(mu, sigma, 1)
-      const expected = Math.exp(mu * (s + t)) * (Math.exp(sigma * sigma * Math.min(s, t)) - 1)
-      assert.closeTo(gbm.covariogram(s, t), expected, 1e-10)
+      const gbm = new GeometricBrownianMotion(0.05, 0.2, 1)
+      // scipy: exp(0.05*(1+3)) * (exp(0.2**2*min(1,3)) - 1) → 0.049846392161234841
+      assert.closeTo(gbm.covariogram(1, 3), 0.049846392161234841, 1e-10)
     })
 
     it('should be symmetric', () => {
@@ -769,10 +768,9 @@ describe('process.OrnsteinUhlenbeck', () => {
 
   describe('.covariogram()', () => {
     it('should return (sigma^2/2theta)*(exp(-theta*|t-s|) - exp(-theta*(t+s)))', () => {
-      const theta = 2; const sigma = 0.5; const s = 1; const t = 3
-      const ou = new OrnsteinUhlenbeck(theta, 0, sigma, 0.1)
-      const expected = (sigma * sigma / (2 * theta)) * (Math.exp(-theta * Math.abs(t - s)) - Math.exp(-theta * (t + s)))
-      assert.closeTo(ou.covariogram(s, t), expected, 1e-10)
+      const ou = new OrnsteinUhlenbeck(2, 0, 0.5, 0.1)
+      // scipy: (0.5**2/(2*2)) * (exp(-2*abs(3-1)) - exp(-2*(3+1))) → 0.0011237610163019791
+      assert.closeTo(ou.covariogram(1, 3), 0.0011237610163019791, 1e-10)
     })
 
     it('should be symmetric', () => {


### PR DESCRIPTION
Closes #884

## Summary
- Two covariogram tests (`OrnsteinUhlenbeck`, `GeometricBrownianMotion`) were asserting against `const expected = <same formula as production code>`, which means a wrong formula in production would still pass the test — both sides carry the same error.
- Replaced with hardcoded scipy-sourced constants and comments showing the computation, per CLAUDE.md: "never write the same formula in both the production method and the test assertion."

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

<details>
<summary>Trivial changes</summary>

- **`test/process.js`**: Removed `const expected = formula(...)` from `OrnsteinUhlenbeck.covariogram` and `GeometricBrownianMotion.covariogram` tests; replaced with externally-verified constants (`0.0011237610163019791` and `0.049846392161234841`) attributed to scipy.

</details>

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdBkWDYYuBd2zk98FabWTu)_