### PR TITLE
Add CHANGELOG entry for CompoundPoissonProcess.seed() fix (#893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `CompoundPoissonProcess.seed(v)` now also seeds the jump distribution's internal PRNG with a derived seed, making consecutive `.path()` calls with the same seed before each produce identical arrays. Previously only the arrival PRNG (`this.r`) was seeded; jump magnitudes drawn from `jumpDist.r` were not reset, silently breaking the reproducibility contract advertised by `Process.seed()` (#893).
 - `gammaLowerIncomplete(s, x)` no longer silently returns a truncated (wrong) value for large shape parameters (e.g. `s = x = 1000`). The series loop in `_gli` now uses an adaptive per-call iteration limit `ceil(sqrt(2·(s+1)·log(1/ε)))` instead of the fixed `MAX_ITER = 100`; for s ≈ 1000 the old cap truncated at 100 iterations while convergence requires ~265. Downstream distributions (`Chi2`, `Gamma`, `Erlang`, `Poisson`, `Nakagami`) that delegate CDF computation to this function are also corrected (#837).
 - `docs/index.js` now uses `sass.compile()` instead of the deprecated `sass.renderSync()`, eliminating deprecation warnings on every `npm run docs` invocation (#817).
 


### PR DESCRIPTION
Closes #893

## Summary
- Adds a `### Fixed` CHANGELOG entry documenting that `CompoundPoissonProcess.seed(v)` now also seeds the jump distribution's internal PRNG, making `.path()` calls reproducible after seeding.
- The underlying code fix (`a84b8b3`) and tests were already merged to `main` via PR #894; this PR supplies the missing changelog entry only.

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: One bullet added to `### Fixed` under `[Unreleased]` describing the `CompoundPoissonProcess.seed()` reproducibility fix.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_012aYbc6cdJd65njFPaEKJwf)_