### PR TITLE
Fix CodeScene badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Docs](https://img.shields.io/github/actions/workflow/status/synesenom/ran/ci.yml?branch=main&job=docs-build&label=docs)](https://github.com/synesenom/ran/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/ranjs.svg)](https://www.npmjs.com/package/ranjs)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
-[![Code Health](https://codescene.io/projects/82366/status-badges/code-health)](https://codescene.io/projects/82366)
+[![CodeScene Average Code Health](https://codescene.io/projects/82366/status-badges/average-code-health)](https://codescene.io/projects/82366)
 
 A comprehensive JavaScript library for probability distributions, random variate generation, and statistical analysis.
 


### PR DESCRIPTION
## Summary
- Corrects the CodeScene badge image URL from `status-badges/code-health` to `status-badges/average-code-health`, which is the endpoint CodeScene actually serves
- Updates the alt text to match CodeScene's recommended label ("CodeScene Average Code Health")

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`README.md`**: Badge image URL corrected from `code-health` to `average-code-health`; alt text updated to match

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01TV49f5RjY36HmGJCMPHZp1)_