### PR TITLE
fix: pre-warm cs-mcp binary in hook and mcp.json to avoid cold-download race

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -10,6 +10,12 @@ npm install
 # Install CodeScene MCP server globally so cs-mcp is on PATH for the MCP server entry in settings.json.
 npm install -g @codescene/codehealth-mcp
 
+# Pre-warm the cs-mcp binary. npm install -g above reinstalls the package,
+# wiping the .cache/ directory where the downloaded binary lives. Running
+# --version triggers the download now so the MCP server starts instantly
+# rather than racing against a 30-second cold download at session init.
+cs-mcp --version >/dev/null 2>&1
+
 # Install the project's stop hook so pipeline working dirs (thoughts/, solutions/)
 # are excluded from the untracked-files check, matching local machine behaviour.
 cp "$CLAUDE_PROJECT_DIR/.claude/hooks/stop-hook-git-check.sh" ~/.claude/stop-hook-git-check.sh

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,8 @@
 {
   "mcpServers": {
     "codescene": {
-      "command": "cs-mcp"
+      "command": "bash",
+      "args": ["-c", "cs-mcp --version >/dev/null 2>&1; exec cs-mcp"]
     }
   }
 }


### PR DESCRIPTION
npm install -g reinstalls the package each session, wiping the .cache/
directory that holds the downloaded binary. The MCP server then races a
30-second binary download against Claude Code's initialization timeout,
losing intermittently.

Fix 1 (hook): run cs-mcp --version after the npm install to download
the binary while the hook still has the session's attention.

Fix 2 (.mcp.json): wrap the command so the binary is always pre-warmed
inside the MCP server's own startup sequence before exec hands off,
covering the case where the MCP server starts before the hook finishes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WV8wPBMh6krZrPUSQ2jCxh