### PR TITLE
Release v1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `CompoundPoissonProcess.seed(v)` now also seeds the jump distribution's internal PRNG with a derived seed, making consecutive `.path()` calls with the same seed before each produce identical arrays. Previously only the arrival PRNG (`this.r`) was seeded; jump magnitudes drawn from `jumpDist.r` were not reset, silently breaking the reproducibility contract advertised by `Process.seed()` (#893).
-- `gammaLowerIncomplete(s, x)` no longer silently returns a truncated (wrong) value for large shape parameters (e.g. `s = x = 1000`). The series loop in `_gli` now uses an adaptive per-call iteration limit `ceil(sqrt(2·(s+1)·log(1/ε)))` instead of the fixed `MAX_ITER = 100`; for s ≈ 1000 the old cap truncated at 100 iterations while convergence requires ~265. Downstream distributions (`Chi2`, `Gamma`, `Erlang`, `Poisson`, `Nakagami`) that delegate CDF computation to this function are also corrected (#837).
-- `docs/index.js` now uses `sass.compile()` instead of the deprecated `sass.renderSync()`, eliminating deprecation warnings on every `npm run docs` invocation (#817).
-
-### Changed
-
-- `Process.path(n)` now advances the PRNG by n steps on each call (matching `Distribution.sample()` behaviour) instead of restoring the PRNG stream afterward. Consecutive calls return independent realizations; seeding before a call still guarantees reproducibility. Code that called `path()` twice without re-seeding and expected identical results will now receive two distinct paths. No deprecation cycle was applied: `ran.process` was introduced in the same release cycle and repeated idempotent `path()` calls without re-seeding have no legitimate use case (#869).
-- `Distribution.test()` now uses the Anderson-Darling test (Marsaglia & Marsaglia 2004 asymptotic series + finite-n correction, α = 0.01) instead of Kolmogorov-Smirnov for continuous distributions. The `passed` field is unaffected. The `statistics` field now carries the A² statistic (typical scale 0.2–5) rather than the KS D-statistic (scale 0–1); code that reads the raw value will silently see a different number (#816).
+## [1.30.0] - 2026-07-09
 
 ### Added
 
@@ -41,6 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `besselK(n, x)` and `besselKnu(nu, x)` — Modified Bessel function of the second kind K_ν(x) for integer orders (combined series seeded upward recurrence + asymptotic expansion) and real orders (connection formula via `besselInu` for x ≤ 6, asymptotic expansion for x > 6), exported from `ran.special` (#809).
 - `TruncatedExponential(lambda, a, b)` distribution: exponential distribution restricted to a finite interval [a, b] (λ > 0, a ≥ 0, b > a). Subclass of `Exponential`. Implements closed-form `_pdf`, `_cdf`, `_q` (inverse CDF), `mean`, `variance`, inverse-CDF sampling, and method-of-moments `_fitInit` (#806).
 - `AsymmetricLaplace(mu, sigma, kappa)` distribution: a three-parameter two-sided exponential family parameterized by location μ ∈ ℝ, scale σ > 0, and asymmetry κ > 0. Reduces to Laplace(μ, σ/√2) at κ = 1. Implements closed-form `_pdf`, `_cdf`, `_q` (inverse CDF), `mean`, `variance`, `skewness`, and `kurtosis`, with exact inverse-CDF sampling and method-of-moments `_fitInit` (#805).
+
+### Changed
+
+- `Process.path(n)` now advances the PRNG by n steps on each call (matching `Distribution.sample()` behaviour) instead of restoring the PRNG stream afterward. Consecutive calls return independent realizations; seeding before a call still guarantees reproducibility. Code that called `path()` twice without re-seeding and expected identical results will now receive two distinct paths. No deprecation cycle was applied: `ran.process` was introduced in the same release cycle and repeated idempotent `path()` calls without re-seeding have no legitimate use case (#869).
+- `Distribution.test()` now uses the Anderson-Darling test (Marsaglia & Marsaglia 2004 asymptotic series + finite-n correction, α = 0.01) instead of Kolmogorov-Smirnov for continuous distributions. The `passed` field is unaffected. The `statistics` field now carries the A² statistic (typical scale 0.2–5) rather than the KS D-statistic (scale 0–1); code that reads the raw value will silently see a different number (#816).
+
+### Fixed
+
+- `CompoundPoissonProcess.seed(v)` now also seeds the jump distribution's internal PRNG with a derived seed, making consecutive `.path()` calls with the same seed before each produce identical arrays. Previously only the arrival PRNG (`this.r`) was seeded; jump magnitudes drawn from `jumpDist.r` were not reset, silently breaking the reproducibility contract advertised by `Process.seed()` (#893).
+- `gammaLowerIncomplete(s, x)` no longer silently returns a truncated (wrong) value for large shape parameters (e.g. `s = x = 1000`). The series loop in `_gli` now uses an adaptive per-call iteration limit `ceil(sqrt(2·(s+1)·log(1/ε)))` instead of the fixed `MAX_ITER = 100`; for s ≈ 1000 the old cap truncated at 100 iterations while convergence requires ~265. Downstream distributions (`Chi2`, `Gamma`, `Erlang`, `Poisson`, `Nakagami`) that delegate CDF computation to this function are also corrected (#837).
+- `docs/index.js` now uses `sass.compile()` instead of the deprecated `sass.renderSync()`, eliminating deprecation warnings on every `npm run docs` invocation (#817).
 
 ## [1.29.0] - 2026-07-04
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ranjs",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ranjs",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranjs",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Library for generating various random variables.",
   "keywords": [
     "random",


### PR DESCRIPTION
## Release v1.30.0

### Changes since v1.29.0

b05597ac Code of conduct written
aab489f8 CodeScene MCP added to dependencies
38378f5f docs: instruct Claude to use CodeScene MCP for code health queries
9c72edcb fix: pre-warm cs-mcp binary in hook and mcp.json to avoid cold-download race
7930084c Process update formula notation unified
460e283a fix: remove trailing spaces in process JSDoc comments
2b4f9212 Processes cleaned up
db70a44c Some clean-up for distributions
d3460210 Source removed from docs API
52bbf579 ci: retrigger CI run (flaky BrownianMotion KS test)
998c83a9 ci: retrigger CI run
4fe20c4c Fix CodeScene badge URL to use average-code-health endpoint
45a24bc0 Add CodeScene code health boy scout rule to CLAUDE.md and /pr skill
261e3d24 ci: retrigger CI run
d59f8e9e Add CodeScene Code Health badge to README
2706604d Set up CodeScene Code Health MCP server for cloud sessions
2c8c9a2c CHANGELOG entry added for CompoundPoissonProcess.seed() fix (#893)
4176e84b Pre-flight CI checks added to /pr skill
3eafb21b Blank line in AR1 constructor test block removed
0d1bb66c Process constructors made to require all parameters except dt
e2ee6141 CompoundPoissonProcess parameter order fixed to (jumpDist, lambda, dt)
79655b35 JSDoc added to CompoundPoissonProcess.seed()
5e5da4f9 Warmup comment in Xoshiro128p.seed() clarified
a84b8b36 CompoundPoissonProcess.seed() also seeds jumpDist
06395b0d CompoundPoissonProcess added to ran.process
59ab7424 CoxIngersollRoss process added
13b7129a RandomWalk process added (#859)
fb92a5fe docs(README): reorder Process API methods
62880f89 docs: update pill from 130+ to 140+ distributions
6e6839f5 docs(README): update distribution counts to 144 and add Process API section
b31e3009 AR1 test reference values and README updated
2222174d AR1 process added (#857)
75bd4955 ci: retrigger CI (flaky BrownianMotion KS test)
9c8c4819 docs(process): extend class JSDoc with SDE and exactness rationale for all subclasses
5b3239ea fix(BrownianBridge): use exact discrete-time transition instead of Euler-Maruyama
2a0535a6 Inline covariogram expected-value formulas replaced with scipy references
b1756249 fix(jsdoclint): replace full JSDoc with @inheritdoc on BrownianBridge.reset and .path
6df647d0 Remove JSDoc from BrownianBridge.path and .reset
ef81c9f2 ci: retrigger CI (flaky GBM KS test)
698b6d2a fix(jsdoclint): add @inheritdoc to process subclass method overrides
3f32711e Unify process subclass API: abstract mean/variance/pdf on base, rename PoissonProcess.pmf to pdf
ab0b09cd pdf(x, t) added to BrownianBridge
685b44a3 pdf(x, t) and pmf(x, t) added to process subclasses
6c1765e2 Add interactive stochastic processes demo page (demo.html)
b3719c63 Make covariogram a required method on Process; implement for BrownianBridge
39dc9d3f ci: retrigger CI (flaky GBM KS test)
b15683a9 Reviewer priority tiers added to /review conflict resolution
6944b789 Cross-PR conflict check added to /review to prevent implement-then-revert cycles
7fd2da45 Conflict resolution added to /review merge step
b8d07ceb Process.ensemble(m, n) method added
f2c74bee covariogram(s, t) added to all Process subclasses
d62c76ab test: require mpmath/scipy/R for all process reference values
46eb2089 ci: retrigger CI (flaky PoissonProcess chi-sq test)
48149026 fix: add BrownianBridge subpath export to package.json
5210c69a Review warnings fixed: stale path() comment, tautological variance test, GBM x0 hardcoding, README process namespace
6d73470a BrownianBridge process added
82b35154 ci: retrigger CI run
def28151 x0 parameter removed from GeometricBrownianMotion
e74d4be5 GeometricBrownianMotion process added
884b538a Analytical mean() and variance() added to PoissonProcess
83fc7487 PoissonProcess subpath export added to package.json
de735fcf Trivial rate multiplication inlined in PoissonProcess._next()
d0fb451a OU stationarity test fixed: seed added, samples thinned by 20
028dd9ca PoissonProcess counting process added (#853)
0db4a9b8 fix: untrack dist/process/ artifacts and extend .gitignore to cover subdirs
b96ab048 Re-trigger CI
01791bd1 feat: add tree-shakeable subpath exports for stochastic processes
2d7a3159 PRNG save/restore removed from Process.path()
51f44fdd docs(process): convert JSDoc formulas to LaTeX in process classes
c92b11cc /review vs /code-review distinction documented in CLAUDE.md
da29a98e OrnsteinUhlenbeck process added
117bda34 Solution compounded for #862 — path-distinct-realizations-reset-not-path
7a0cbb43 Split review-conventions back out of review-structure (8 agents total)
bea9e27a Consolidate 11 review agents to 7; fix review-callers model to Sonnet
729759ed Simplify /review output: replace P1/P2/P3 with Block/Warn, merge into one flat list
9eae7fab Add 5 review agents from /code-review angles into /review skill
6d453a21 fix(process): validate mu; guard mean/variance against negative t
2be7d722 feat(process): add BrownianMotion (#848)
5d3ccb5d docs: add number return type to Process.next, _next, and state
8a22df0d Process.seed(value) added for reproducible paths (#861)
364b6d18 docs: expose Process base class in ran.process namespace
6eb5ee5b this._type removed from Process (unused until save/load added)
e2a15b10 ran.la namespace excluded from docs
d9283d91 Process abstract base class added (#847)
2156037d Solution compounded for #847 — path-prng-save-restore
fee2b1a8 gammaLowerIncomplete series truncation for large shape fixed (#837)
be42f27a CHANGELOG reference updated to include #835
93744a0a sass.renderSync() replaced with sass.compile() in docs generator (#817)
fe9c1810 Empty-input guard added to andersonDarling
f0ee7ee0 Anderson-Darling test used in Distribution.test() for continuous distributions (#816)
e759b058 Welch's two-sample t-test added to ran.test (#815)
b269cd9d docs-build CI check extended to all four generated HTML pages
1335af50 test: regenerate DiscreteLaplace precision refs via mpmath at mp.dps=50
5ee996a8 Broken Wikipedia link replaced with Inusah & Kozubowski (2006) citation
a817062a DiscreteLaplace (bilateral geometric) distribution added (#812)
fd193c20 betaIncomplete interior precision tests added against mpmath references
6265a988 Solution compounded for #809 — bessel-k-second-kind-cancellation-strategy
62607310 fix: add @private to besselK JSDoc, crossover continuity test, K_{2.5}(10) comment
6a921c3d fix(special): besselKnu negative-integer dispatch and JSDoc placement (#809)
b9b76bfc feat(special): add besselK and besselKnu — Modified Bessel function of second kind (#809)
7467d05e CF precision gate tightened to 10 sig figs for extreme-tail Q values (#810)
4f2a8350 gammaLowerIncomplete precision tests replaced with mpmath reference values (#810)
2fbd25d6 test: add discriminating erfinv and intermediate far-tail precision probes (#808)
58e7a67f fix(erfinv): three-way erfc residual eliminates precision loss near |x|=1 (#808)
b136fb92 chore: fix stale comments in precision-refs generator after erfc fix (#808)
b1f57ba4 fix(normal,log-normal): eliminate far-tail cancellation and tighten precision gate (#808)
e2716a52 Far-tail precision probes added for Normal and LogNormal (#808)
375479ea chore: remove implemented entries from todo.md
00eb6fbc chore: update todo.md to reflect current implementation and issue state
28b198e5 Coverage thresholds enforced in release workflow
58f413e3 TDD requirement added to CLAUDE.md
6f6a0c17 TruncatedExponential distribution added (#806)
86fa66c9 fix(precision): restore FisherZ[1,1] qtol to 4e-14 after script regeneration
451f6528 fix(AsymmetricLaplace): cache hot-path constants in this.c; add kappa<1 moments and kappa=2 quantile tests
d957292f feat: add AsymmetricLaplace distribution (#805)

---
*Automated release PR — do not add commits to this branch.*