### PR TITLE
refactor(algorithms): fix code smells in powell.js (6.44 → 9.38)

### DIFF
--- a/src/algorithms/powell.js
+++ b/src/algorithms/powell.js
@@ -21,6 +21,112 @@ function sign (a, b) {
   return b >= 0 ? Math.abs(a) : -Math.abs(a)
 }
 
+// Parabolic interpolation coefficients through (x, w, v); normalises sign convention so q > 0.
+function _computeParabolicStep (state) {
+  const { x, w, v, fx, fw, fv } = state
+  const r = (x - w) * (fx - fv)
+  let q = (x - v) * (fx - fw)
+  let p = (x - v) * q - (x - w) * r
+  q = 2 * (q - r)
+  if (q > 0) p = -p
+  q = Math.abs(q)
+  return { p, q }
+}
+
+// True when the parabolic trial step is too large, or falls outside either end of the bracket.
+function _isParabolicStepRejected (p, q, etemp, state) {
+  const { a, b, x } = state
+  return (
+    Math.abs(p) >= Math.abs(0.5 * q * etemp) ||
+    p <= q * (a - x) ||
+    p >= q * (b - x)
+  )
+}
+
+// Chooses {d, e} for one Brent iteration: parabolic when valid, golden-section otherwise.
+function _chooseBrentStep (state, tol1) {
+  const { x, a, b, e: e0, d: d0 } = state
+  const xm = 0.5 * (a + b)
+  if (Math.abs(e0) > tol1) {
+    const { p, q } = _computeParabolicStep(state)
+    if (_isParabolicStepRejected(p, q, e0, state)) {
+      const e = x >= xm ? a - x : b - x
+      return { d: CGOLD * e, e }
+    }
+    const d = p / q
+    const u = x + d
+    const tol2 = 2 * tol1
+    return {
+      d: (u - a < tol2 || b - u < tol2) ? sign(tol1, xm - x) : d,
+      e: d0
+    }
+  }
+  const e = x >= xm ? a - x : b - x
+  return { d: CGOLD * e, e }
+}
+
+// Which three-point tracking slot (w=best secondary, v=third best, null=none) should absorb u.
+function _brentSlot (fu, state) {
+  const { fw, fv, w, v, x } = state
+  if (fu <= fw || w === x) return 'w'
+  if (fu <= fv || v === x || v === w) return 'v'
+  return null
+}
+
+// Updates the Brent bracket and three-point tracker after evaluating the trial point (u, fu).
+function _updateBrentState (state, u, fu) {
+  const { a, b, x, w, v, fx, fw, fv } = state
+  if (fu <= fx) {
+    return {
+      a: u >= x ? x : a,
+      b: u >= x ? b : x,
+      x: u,
+      w: x,
+      v: w,
+      fx: fu,
+      fw: fx,
+      fv: fw
+    }
+  }
+  const newA = u < x ? u : a
+  const newB = u < x ? b : u
+  const slot = _brentSlot(fu, state)
+  if (slot === 'w') return { a: newA, b: newB, x, w: u, v: w, fx, fw: fu, fv: fw }
+  if (slot === 'v') return { a: newA, b: newB, x, w, v: u, fx, fw, fv: fu }
+  return { a: newA, b: newB, x, w, v, fx, fw, fv }
+}
+
+// One step of the bracketMin search: dispatches on u's position and returns the next bracket state.
+function _bracketAdvance (phi, bracket, u, ulim) {
+  const { a, b, c, fb, fc } = bracket
+  if ((b - u) * (u - c) > 0) {
+    // Parabolic minimum between b and c.
+    const fu = phi(u)
+    if (fu < fc) return { done: true, triple: [b, u, c] }
+    if (fu > fb) return { done: true, triple: [a, b, u] }
+    const newU = c + GOLD * (c - b)
+    return { done: false, a: b, b: c, c: newU, fa: fb, fb: fc, fc: phi(newU) }
+  }
+  if ((c - u) * (u - ulim) > 0) {
+    // Parabolic minimum between c and its allowed limit.
+    const fu = phi(u)
+    if (fu < fc) {
+      const newB = c
+      const newC = u
+      const extraU = newC + GOLD * (newC - newB)
+      return { done: false, a: newB, b: newC, c: extraU, fa: fc, fb: fu, fc: phi(extraU) }
+    }
+    return { done: false, a: b, b: c, c: u, fa: fb, fb: fc, fc: fu }
+  }
+  if ((u - ulim) * (ulim - c) >= 0) {
+    // Limit parabolic u to its maximum allowed value.
+    return { done: false, a: b, b: c, c: ulim, fa: fb, fb: fc, fc: phi(ulim) }
+  }
+  // Reject parabolic u, use default magnification.
+  const goldenU = c + GOLD * (c - b)
+  return { done: false, a: b, b: c, c: goldenU, fa: fb, fb: fc, fc: phi(goldenU) }
+}
+
 /**
  * Brackets a minimum of a 1-D function. Given two initial abscissas, searches downhill until it
  * finds a triple (a, b, c) with phi(b) below both phi(a) and phi(c).
@@ -45,48 +151,13 @@ function bracketMin (phi, a0, b0) {
   let fc = phi(c)
   let iter = 0
   while (fb > fc && iter++ < GLIMIT) {
-    // Parabolic extrapolation through a, b, c.
     const r = (b - a) * (fb - fc)
     const q = (b - c) * (fb - fa)
-    let u = b - ((b - c) * q - (b - a) * r) / (2 * sign(Math.max(Math.abs(q - r), TINY), q - r))
+    const u = b - ((b - c) * q - (b - a) * r) / (2 * sign(Math.max(Math.abs(q - r), TINY), q - r))
     const ulim = b + GLIMIT * (c - b)
-    let fu
-    if ((b - u) * (u - c) > 0) {
-      // Parabolic minimum between b and c.
-      fu = phi(u)
-      if (fu < fc) {
-        return [b, u, c]
-      } else if (fu > fb) {
-        return [a, b, u]
-      }
-      u = c + GOLD * (c - b)
-      fu = phi(u)
-    } else if ((c - u) * (u - ulim) > 0) {
-      // Parabolic minimum between c and its allowed limit.
-      fu = phi(u)
-      if (fu < fc) {
-        b = c
-        c = u
-        u = c + GOLD * (c - b)
-        fb = fc
-        fc = fu
-        fu = phi(u)
-      }
-    } else if ((u - ulim) * (ulim - c) >= 0) {
-      // Limit parabolic u to its maximum allowed value.
-      u = ulim
-      fu = phi(u)
-    } else {
-      // Reject parabolic u, use default magnification.
-      u = c + GOLD * (c - b)
-      fu = phi(u)
-    }
-    a = b
-    b = c
-    c = u
-    fa = fb
-    fb = fc
-    fc = fu
+    const step = _bracketAdvance(phi, { a, b, c, fb, fc }, u, ulim)
+    if (step.done) return step.triple
+    ;({ a, b, c, fa, fb, fc } = step)
   }
   return [a, b, c]
 }
@@ -96,100 +167,47 @@ function bracketMin (phi, a0, b0) {
  * golden-section fallback).
  *
  * @param {Function} phi 1-D function to minimise.
- * @param {number} ax Lower bracket abscissa.
- * @param {number} bx Interior abscissa with the lowest value.
- * @param {number} cx Upper bracket abscissa.
- * @param {number} tol Fractional tolerance on the abscissa.
- * @param {number} maxIter Maximum iterations.
+ * @param {number[]} bracket [ax, bx, cx] bracketing triple from bracketMin.
+ * @param {Object} opts
+ * @param {number} opts.tol Fractional tolerance on the abscissa.
+ * @param {number} opts.maxIter Maximum iterations.
  * @returns {number[]} [xmin, fmin].
  * @private
  */
-function brentMin (phi, ax, bx, cx, tol, maxIter) {
-  let a = Math.min(ax, cx)
-  let b = Math.max(ax, cx)
-  let x = bx
-  let w = bx
-  let v = bx
-  let fx = phi(x)
-  let fw = fx
-  let fv = fx
-  let d = 0
-  let e = 0
-  for (let iter = 0; iter < maxIter; iter++) {
-    const xm = 0.5 * (a + b)
-    const tol1 = tol * Math.abs(x) + ZEPS
-    const tol2 = 2 * tol1
-    if (Math.abs(x - xm) <= tol2 - 0.5 * (b - a)) {
-      break
-    }
-    if (Math.abs(e) > tol1) {
-      // Trial parabolic fit through x, w, v.
-      const r = (x - w) * (fx - fv)
-      let q = (x - v) * (fx - fw)
-      let p = (x - v) * q - (x - w) * r
-      q = 2 * (q - r)
-      if (q > 0) {
-        p = -p
-      }
-      q = Math.abs(q)
-      const etemp = e
-      e = d
-      if (Math.abs(p) >= Math.abs(0.5 * q * etemp) || p <= q * (a - x) || p >= q * (b - x)) {
-        // Parabolic step unacceptable: take a golden-section step instead.
-        e = x >= xm ? a - x : b - x
-        d = CGOLD * e
-      } else {
-        // Accept the parabolic step.
-        d = p / q
-        const u = x + d
-        if (u - a < tol2 || b - u < tol2) {
-          d = sign(tol1, xm - x)
-        }
-      }
-    } else {
-      e = x >= xm ? a - x : b - x
-      d = CGOLD * e
-    }
-    const u = Math.abs(d) >= tol1 ? x + d : x + sign(tol1, d)
-    const fu = phi(u)
-    if (fu <= fx) {
-      if (u >= x) {
-        a = x
-      } else {
-        b = x
-      }
-      v = w
-      w = x
-      x = u
-      fv = fw
-      fw = fx
-      fx = fu
-    } else {
-      if (u < x) {
-        a = u
-      } else {
-        b = u
-      }
-      if (fu <= fw || w === x) {
-        v = w
-        w = u
-        fv = fw
-        fw = fu
-      } else if (fu <= fv || v === x || v === w) {
-        v = u
-        fv = fu
-      }
-    }
+function brentMin (phi, bracket, opts) {
+  const [ax, bx, cx] = bracket
+  const { tol, maxIter } = opts
+  const fInit = phi(bx)
+  const state = {
+    a: Math.min(ax, cx),
+    b: Math.max(ax, cx),
+    x: bx,
+    w: bx,
+    v: bx,
+    fx: fInit,
+    fw: fInit,
+    fv: fInit,
+    d: 0,
+    e: 0
   }
-  return [x, fx]
+  for (let iter = 0; iter < maxIter; iter++) {
+    const xm = 0.5 * (state.a + state.b)
+    const tol1 = tol * Math.abs(state.x) + ZEPS
+    if (Math.abs(state.x - xm) <= 2 * tol1 - 0.5 * (state.b - state.a)) break
+    Object.assign(state, _chooseBrentStep(state, tol1))
+    const u = Math.abs(state.d) >= tol1 ? state.x + state.d : state.x + sign(tol1, state.d)
+    const fu = phi(u)
+    Object.assign(state, _updateBrentState(state, u, fu))
+  }
+  return [state.x, state.fx]
 }
 
 // Minimises f along the line p + lambda * dir; returns the new point and its value.
-function lineMin (f, p, dir, tol, maxIter) {
+function lineMin (f, p, dir, opts) {
   const f0 = f(p)
   const phi = lambda => f(p.map((pi, j) => pi + lambda * dir[j]))
   const [a, b, c] = bracketMin(phi, 0, 1)
-  const [lambda, fret] = brentMin(phi, a, b, c, tol, maxIter)
+  const [lambda, fret] = brentMin(phi, [a, b, c], opts)
   // Never take an uphill step: if the line search found nothing below the current point — e.g.
   // the whole line lies in the Infinity-barrier infeasible region — stay put. Without this guard
   // a degenerate all-Infinity bracket returns a nonzero lambda and the iterate drifts away.
@@ -197,6 +215,31 @@ function lineMin (f, p, dir, tol, maxIter) {
     return { p, fret: f0 }
   }
   return { p: p.map((pi, j) => pi + lambda * dir[j]), fret }
+}
+
+// True when Powell's curvature test passes: the net direction warrants replacing the direction of
+// largest drop. Only called after confirming fExtrap < fStart (short-circuit guard in powell).
+function _powellCriterionMet (fStart, fret, fExtrap, biggestDrop) {
+  return 2 * (fStart - 2 * fret + fExtrap) * (fStart - fret - biggestDrop) ** 2 -
+    biggestDrop * (fStart - fExtrap) ** 2 < 0
+}
+
+// Minimises f along each direction in dirs, tracking which direction gave the largest decrease.
+function _directionSweep (f, dirs, initial, opts) {
+  let { p, fret } = initial
+  let biggestDrop = 0
+  let iBig = 0
+  for (let i = 0; i < dirs.length; i++) {
+    const fBefore = fret
+    const res = lineMin(f, p, dirs[i], opts)
+    p = res.p
+    fret = res.fret
+    if (fBefore - fret > biggestDrop) {
+      biggestDrop = fBefore - fret
+      iBig = i
+    }
+  }
+  return { p, fret, biggestDrop, iBig }
 }
 
 /**
@@ -225,23 +268,14 @@ export default function powell (f, x0, opts = {}) {
   })
 
   let fret = f(p)
+  const lineOpts = { tol, maxIter }
   for (let iter = 0; iter < maxIter; iter++) {
     const pStart = p.slice()
     const fStart = fret
-    let biggestDrop = 0
-    let iBig = 0
-
-    // Minimise along each direction in turn, tracking the direction of largest decrease.
-    for (let i = 0; i < n; i++) {
-      const fBefore = fret
-      const res = lineMin(f, p, dirs[i], tol, maxIter)
-      p = res.p
-      fret = res.fret
-      if (fBefore - fret > biggestDrop) {
-        biggestDrop = fBefore - fret
-        iBig = i
-      }
-    }
+    const sweep = _directionSweep(f, dirs, { p, fret }, lineOpts)
+    p = sweep.p
+    fret = sweep.fret
+    const { biggestDrop, iBig } = sweep
 
     // Convergence: relative decrease in the objective value falls below tolerance.
     if (2 * Math.abs(fStart - fret) <= tol * (Math.abs(fStart) + Math.abs(fret)) + TINY) {
@@ -253,16 +287,12 @@ export default function powell (f, x0, opts = {}) {
     const pExtrap = p.map((pi, j) => 2 * pi - pStart[j])
     const dirNew = p.map((pi, j) => pi - pStart[j])
     const fExtrap = f(pExtrap)
-    if (fExtrap < fStart) {
-      const t = 2 * (fStart - 2 * fret + fExtrap) * (fStart - fret - biggestDrop) ** 2 -
-        biggestDrop * (fStart - fExtrap) ** 2
-      if (t < 0) {
-        const res = lineMin(f, p, dirNew, tol, maxIter)
-        p = res.p
-        fret = res.fret
-        dirs[iBig] = dirs[n - 1]
-        dirs[n - 1] = dirNew
-      }
+    if (fExtrap < fStart && _powellCriterionMet(fStart, fret, fExtrap, biggestDrop)) {
+      const res = lineMin(f, p, dirNew, lineOpts)
+      p = res.p
+      fret = res.fret
+      dirs[iBig] = dirs[n - 1]
+      dirs[n - 1] = dirNew
     }
   }
 


### PR DESCRIPTION
## Summary

Decompose `src/algorithms/powell.js` into focused single-purpose helpers to eliminate the Brain Method, Deep Nesting, Bumpy Road, Complex Method, Complex Conditional, and Excess Args smells identified by CodeScene. Code Health score improves from **6.44 → 9.38** (yellow → green). No algorithmic changes; all 7 712 tests pass.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior — N/A (pure refactor, no behavioral changes)
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [x] `CHANGELOG.md` updated under `## [Unreleased]` — N/A (pure internal refactor, no public API change)
- [x] Production-code diff is under ~400 lines (tests excluded) — 175 ins / 145 del in one file

## Non-trivial changes

- **`src/algorithms/powell.js`**: Eight new module-private helpers extracted to break the Brain Method (`brentMin`, 76 lines, nesting depth 4) and reduce cyclomatic complexity across `bracketMin`, `_updateBrentState`, and `powell`:

  | Helper | Smell fixed |
  |---|---|
  | `_computeParabolicStep(state)` | isolates parabolic interpolation arithmetic from `brentMin` |
  | `_isParabolicStepRejected(p, q, etemp, state)` | names the three-part rejection predicate (was inline Complex Conditional at line 137) |
  | `_chooseBrentStep(state, tol1)` | encapsulates parabolic-vs-golden decision; reduces `brentMin` nesting depth from 4 to 1 |
  | `_brentSlot(fu, state)` | names the tracking-slot conditions; reduces `_updateBrentState` cc from 11 to 8, fixes Complex Conditional at line 178 |
  | `_updateBrentState(state, u, fu)` | isolates bracket + three-point tracker update; removes all 5 Bumpy Road chunks from `brentMin` |
  | `_bracketAdvance(phi, bracket, u, ulim)` | owns all 4 dispatch branches of `bracketMin`; reduces `bracketMin` cc from 10 to ~4 |
  | `_directionSweep(f, dirs, initial, opts)` | extracts `powell`'s inner direction sweep; removes the inner-loop bump |
  | `_powellCriterionMet(fStart, fret, fExtrap, biggestDrop)` | names Powell's curvature test; collapses the nested `if (fExtrap < fStart) { if (t < 0) }` to a flat `&&` condition |

  Signature changes (all module-private, no public API impact):
  - `brentMin`: `(phi, ax, bx, cx, tol, maxIter)` → `(phi, bracket, opts)` (6 args → 3)
  - `lineMin`: `(f, p, dir, tol, maxIter)` → `(f, p, dir, opts)` (5 args → 4)

**Remaining smell (score 9.38, not 10.0):** CodeScene still flags a Bumpy Road (bumps = 2) in `powell`. Both remaining bumps are simple `if` statements inside the outer `for` loop (the convergence break and the direction-update condition). Eliminating them would require extracting a function with ≥ 10 arguments, which would introduce a worse smell than it removes.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_013rdJMZBZCQP8HqMiCWfTfb)_