### PR TITLE
refactor(doubly-noncentral-beta): improve code health 7.89 → 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Code Health of `src/dist/doubly-noncentral-beta.js` improved from 7.89 → 10.0 by extracting the r-direction and s-direction summation loops into named private helpers (`_pdfRForward`, `_pdfRBackward`, `_pdfSumOverS`, `_cdfRForward`, `_cdfRBackward`, `_cdfSumOverS`), eliminating deep nesting, bumpy road, large method, and complex method smells.
 - `Process.path(n)` now advances the PRNG by n steps on each call (matching `Distribution.sample()` behaviour) instead of restoring the PRNG stream afterward. Consecutive calls return independent realizations; seeding before a call still guarantees reproducibility. Code that called `path()` twice without re-seeding and expected identical results will now receive two distinct paths. No deprecation cycle was applied: `ran.process` was introduced in the same release cycle and repeated idempotent `path()` calls without re-seeding have no legitimate use case (#869).
 - `Distribution.test()` now uses the Anderson-Darling test (Marsaglia & Marsaglia 2004 asymptotic series + finite-n correction, α = 0.01) instead of Kolmogorov-Smirnov for continuous distributions. The `passed` field is unaffected. The `statistics` field now carries the A² statistic (typical scale 0.2–5) rather than the KS D-statistic (scale 0–1); code that reads the raw value will silently see a different number (#816).
 

--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -130,7 +130,6 @@ export default class DoublyNoncentralBeta extends Distribution {
 
   // ─── PRIVATE INSTANCE ─────────────────────────────────────────────────────
 
-  /** @private */
   _pdfRForward (ctx) {
     const { y, ab, l1, l2, r0, s0, ps0, yr0, pr0, ys0, b0 } = ctx
 
@@ -155,7 +154,6 @@ export default class DoublyNoncentralBeta extends Distribution {
     return z
   }
 
-  /** @private */
   _pdfRBackward (ctx, z) {
     const { y, ab, l1, l2, r0, s0, ps0, yr0, pr0, ys0, b0 } = ctx
 
@@ -177,7 +175,6 @@ export default class DoublyNoncentralBeta extends Distribution {
     return z
   }
 
-  /** @private */
   _pdfSumOverS ({ y, ab, l2, s0, ps0, r, pyr, ys, b }) {
     const betaParam = this.p.beta
 
@@ -217,7 +214,6 @@ export default class DoublyNoncentralBeta extends Distribution {
     return dz
   }
 
-  /** @private */
   _cdfRForward (ctx) {
     const { l1, l2, r0, s0, pr0, ps0, sBeta0, xa0, xb0, b0, ib0, x } = ctx
     const betaParam = this.p.beta
@@ -246,7 +242,6 @@ export default class DoublyNoncentralBeta extends Distribution {
     return z
   }
 
-  /** @private */
   _cdfRBackward (ctx, z) {
     const { l1, l2, r0, s0, pr0, ps0, sBeta0, xa0, xb0, b0, ib0, x } = ctx
     const betaParam = this.p.beta
@@ -272,7 +267,6 @@ export default class DoublyNoncentralBeta extends Distribution {
     return z
   }
 
-  /** @private */
   _cdfSumOverS ({ l2, s0, ps0, xb0, sBeta0, x, r, pr, xa, b, ib }) {
     const betaParam = this.p.beta
     const rAlpha = this.p.alpha + r

--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -133,7 +133,6 @@ export default class DoublyNoncentralBeta extends Distribution {
   /** @private */
   _pdfRForward (ctx) {
     const { y, ab, l1, l2, r0, s0, ps0, yr0, pr0, ys0, b0 } = ctx
-    const sCtx = { y, ab, l2, s0, ps0 }
 
     let z = 0
     let bf0 = b0
@@ -144,7 +143,7 @@ export default class DoublyNoncentralBeta extends Distribution {
       const r = r0 + kr
       ysf0 *= 1 + y
       pyrf *= y * l1 / Math.max(r, 1)
-      const dz = this._pdfSumOverS({ ...sCtx, r, pyr: pyrf, ys: ysf0, b: bf0 })
+      const dz = this._pdfSumOverS({ y, ab, l2, s0, ps0, r, pyr: pyrf, ys: ysf0, b: bf0 })
       z += dz
       if (Math.abs(dz / z) < EPS) {
         break
@@ -159,7 +158,6 @@ export default class DoublyNoncentralBeta extends Distribution {
   /** @private */
   _pdfRBackward (ctx, z) {
     const { y, ab, l1, l2, r0, s0, ps0, yr0, pr0, ys0, b0 } = ctx
-    const sCtx = { y, ab, l2, s0, ps0 }
 
     let bb0 = b0
     let ysb0 = (1 + y) * ys0
@@ -169,7 +167,7 @@ export default class DoublyNoncentralBeta extends Distribution {
       ysb0 /= 1 + y
       pyrb *= (r + 1) / (y * l1)
       bb0 *= (ab + r + s0) / (this.p.alpha + r)
-      const dz = this._pdfSumOverS({ ...sCtx, r, pyr: pyrb, ys: ysb0, b: bb0 })
+      const dz = this._pdfSumOverS({ y, ab, l2, s0, ps0, r, pyr: pyrb, ys: ysb0, b: bb0 })
       z += dz
       if (Math.abs(dz / z) < EPS) {
         break
@@ -223,7 +221,6 @@ export default class DoublyNoncentralBeta extends Distribution {
   _cdfRForward (ctx) {
     const { l1, l2, r0, s0, pr0, ps0, sBeta0, xa0, xb0, b0, ib0, x } = ctx
     const betaParam = this.p.beta
-    const sCtx = { l2, s0, ps0, xb0, sBeta0, x }
 
     let z = 0
     let prf = pr0 * Math.max(r0, 1) / l1
@@ -235,7 +232,7 @@ export default class DoublyNoncentralBeta extends Distribution {
       const r = r0 + kr
       const rAlpha = this.p.alpha + r
       prf *= l1 / Math.max(r, 1)
-      const dz = this._cdfSumOverS({ ...sCtx, r, pr: prf, xa: xaf, b: bf0, ib: ibf0 })
+      const dz = this._cdfSumOverS({ l2, s0, ps0, xb0, sBeta0, x, r, pr: prf, xa: xaf, b: bf0, ib: ibf0 })
       z += dz
       if (Math.abs(dz / z) < EPS) {
         break
@@ -253,7 +250,6 @@ export default class DoublyNoncentralBeta extends Distribution {
   _cdfRBackward (ctx, z) {
     const { l1, l2, r0, s0, pr0, ps0, sBeta0, xa0, xb0, b0, ib0, x } = ctx
     const betaParam = this.p.beta
-    const sCtx = { l2, s0, ps0, xb0, sBeta0, x }
 
     let prb = pr0
     let xab = xa0
@@ -266,7 +262,7 @@ export default class DoublyNoncentralBeta extends Distribution {
       xab /= x
       bb0 *= (rAlpha + betaParam + s0) / rAlpha
       ibb0 += xab * xb0 / (rAlpha * bb0)
-      const dz = this._cdfSumOverS({ ...sCtx, r, pr: prb, xa: xab, b: bb0, ib: ibb0 })
+      const dz = this._cdfSumOverS({ l2, s0, ps0, xb0, sBeta0, x, r, pr: prb, xa: xab, b: bb0, ib: ibb0 })
       z += dz
       if (Math.abs(dz / z) < EPS) {
         break

--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -46,6 +46,8 @@ export default class DoublyNoncentralBeta extends Distribution {
     }]
   }
 
+  // ─── PROTECTED INSTANCE ───────────────────────────────────────────────────
+
   _generator () {
     // Direct sampling from non-central chi2
     const x = noncentralChi2(this.r, 2 * this.p.alpha, this.p.lambda1)
@@ -71,143 +73,20 @@ export default class DoublyNoncentralBeta extends Distribution {
       return new NoncentralBeta(this.p.alpha, this.p.beta, this.p.lambda1)._pdf(x)
     }
 
-    // Using outward summation
     const y = x / (1 - x)
-    const ab = this.p.alpha + this.p.beta
-
-    // Speed-up constants
     const l1 = this.p.lambda1 / 2
     const l2 = this.p.lambda2 / 2
-
-    // Initial indices
     const r0 = Math.round(l1)
     const s0 = Math.round(l2)
-
-    // Init terms
     const pr0 = Math.exp(r0 * Math.log(l1) - logGamma(r0 + 1))
     const ps0 = Math.exp(s0 * Math.log(l2) - logGamma(s0 + 1))
-    const psf0 = (s0 > 0 ? s0 : 1) * ps0 / l2
+    const ab = this.p.alpha + this.p.beta
     const yr0 = Math.pow(y, this.p.alpha + r0 - 2)
     const ys0 = Math.pow(1 + y, this.p.alpha + r0 + this.p.beta + s0 - 2)
     const b0 = fnBeta(this.p.alpha + r0, this.p.beta + s0)
-    let bf0 = b0
-    let bb0 = b0
+    const ctx = { y, ab, l1, l2, r0, s0, pr0, ps0, yr0, ys0, b0 }
 
-    // Init delta and sum
-    let z = 0
-
-    // Forward r
-    let ysf0 = ys0
-    let pyrf = yr0 * pr0 * (r0 > 0 ? r0 : 1) / l1
-    for (let kr = 0; kr < MAX_ITER; kr++) {
-      const r = r0 + kr
-      const rAlpha = this.p.alpha + r
-      let dz = 0
-
-      // Update terms
-      ysf0 *= 1 + y
-      pyrf *= y * l1 / (r > 0 ? r : 1)
-
-      // Forward s
-      dz += recursiveSum({
-        y: ysf0 * (1 + y),
-        p: psf0 * l2 / (s0 > 0 ? s0 : 1),
-        b: bf0
-      }, (t, i) => {
-        const s = s0 + i
-        t.y *= 1 + y
-        t.p *= l2 / (s > 0 ? s : 1)
-        return t
-      }, t => pyrf * t.p / (t.b * t.y), (t, i) => {
-        const s = s0 + i
-        t.b *= (this.p.beta + s) / (ab + r + s)
-        return t
-      })
-
-      // Backward s
-      if (s0 > 0) {
-        dz += recursiveSum({
-          y: ysf0,
-          p: s0 * ps0 / l2,
-          b: bf0 * (ab + r + s0 - 1) / (this.p.beta + s0 - 1)
-        }, (t, i) => {
-          const s = s0 - i - 1
-          if (s >= 0) {
-            t.y /= 1 + y
-            t.p *= (s + 1) / l2
-            t.b *= (ab + r + s) / (this.p.beta + s)
-          } else {
-            t.p = 0
-          }
-          return t
-        }, t => pyrf * t.p / (t.b * t.y))
-      }
-
-      // Add s-terms
-      z += dz
-      if (Math.abs(dz / z) < EPS) {
-        break
-      } else {
-        bf0 *= rAlpha / (ab + r + s0)
-      }
-    }
-
-    // Backward r
-    if (r0 > 0) {
-      let ysb0 = (1 + y) * ys0
-      let pyrb = y * yr0 * pr0
-      for (let r = r0 - 1; r >= 0; r--) {
-        let dz = 0
-        const rAlpha = this.p.alpha + r
-
-        // Update terms
-        ysb0 /= 1 + y
-        pyrb *= (r + 1) / (y * l1)
-        bb0 *= (ab + r + s0) / rAlpha
-
-        // Forward s
-        dz += recursiveSum({
-          y: ysb0 * (1 + y),
-          p: psf0 * l2 / (s0 > 0 ? s0 : 1),
-          b: bb0
-        }, (t, i) => {
-          const s = s0 + i
-          t.y *= 1 + y
-          t.p *= l2 / (s > 0 ? s : 1)
-          return t
-        }, t => pyrb * t.p / (t.b * t.y), (t, i) => {
-          const s = s0 + i
-          t.b *= (this.p.beta + s) / (ab + r + s)
-          return t
-        })
-
-        // Backward s
-        if (s0 > 0) {
-          dz += recursiveSum({
-            y: ysb0,
-            p: ps0 * s0 / l2,
-            b: bb0 * (ab + r + s0 - 1) / (this.p.beta + s0 - 1)
-          }, (t, i) => {
-            const s = s0 - i - 1
-            if (s >= 0) {
-              t.y /= 1 + y
-              t.p *= (s + 1) / l2
-              t.b *= (ab + r + s) / (this.p.beta + s)
-            } else {
-              t.p = 0
-            }
-            return t
-          }, t => pyrb * t.p / (t.b * t.y))
-        }
-
-        // Add s-terms
-        z += dz
-        if (Math.abs(dz / z) < EPS) {
-          break
-        }
-      }
-    }
-
+    const z = this._pdfRBackward(ctx, this._pdfRForward(ctx))
     return Math.exp(-l1 - l2) * z / Math.pow(1 - x, 2)
   }
 
@@ -221,165 +100,24 @@ export default class DoublyNoncentralBeta extends Distribution {
       return new NoncentralBeta(this.p.alpha, this.p.beta, this.p.lambda1)._cdf(x)
     }
 
-    // Using outward summation
-    const r0 = Math.round(this.p.lambda1 / 2)
-    const s0 = Math.round(this.p.lambda2 / 2)
-    const sBeta0 = this.p.beta + s0 - 1
-
-    // Speed-up constants
     const l1 = this.p.lambda1 / 2
     const l2 = this.p.lambda2 / 2
-
-    // Init terms
+    const betaParam = this.p.beta
+    const r0 = Math.round(l1)
+    const s0 = Math.round(l2)
     const pr0 = Math.exp(r0 * Math.log(l1) - logGamma(r0 + 1))
     const ps0 = Math.exp(s0 * Math.log(l2) - logGamma(s0 + 1))
-    const psf0 = (s0 > 0 ? s0 : 1) * ps0 / l2
+    const sBeta0 = betaParam + s0 - 1
     const xa0 = Math.pow(x, this.p.alpha + r0)
-    const xb0 = Math.pow(1 - x, this.p.beta + s0)
-    const b0 = fnBeta(this.p.alpha + r0, this.p.beta + s0)
-    const ib0 = regularizedBetaIncomplete(this.p.alpha + r0, this.p.beta + s0, x)
+    const xb0 = Math.pow(1 - x, betaParam + s0)
+    const b0 = fnBeta(this.p.alpha + r0, betaParam + s0)
+    const ib0 = regularizedBetaIncomplete(this.p.alpha + r0, betaParam + s0, x)
+    const ctx = { l1, l2, r0, s0, pr0, ps0, sBeta0, xa0, xb0, b0, ib0, x }
 
-    // Delta and sum
-    let z = 0
-
-    // Forward r
-    let prf = (r0 > 0 ? r0 : 1) * pr0 / l1
-    let xaf = xa0
-    let bf0 = b0
-    let ibf0 = ib0
-    for (let kr = 0; kr < MAX_ITER; kr++) {
-      const r = r0 + kr
-      const rAlpha = this.p.alpha + r
-      let dz = 0
-
-      // Update terms
-      prf *= l1 / (r > 0 ? r : 1)
-
-      // Forward s
-      dz += recursiveSum({
-        p: psf0 * l2 / (s0 > 0 ? s0 : 1),
-        xb: xb0,
-        b: bf0,
-        ib: ibf0
-      }, (t, i) => {
-        const s = s0 + i
-        t.p *= l2 / (s > 0 ? s : 1)
-        return t
-      }, t => prf * t.p * t.ib, (t, i) => {
-        const s = s0 + i
-        const sBeta = this.p.beta + s
-        t.ib += xaf * t.xb / (sBeta * t.b)
-        t.b *= sBeta / (rAlpha + sBeta)
-        t.xb *= 1 - x
-        return t
-      })
-
-      // Backward s
-      if (s0 > 0) {
-        const xb = xb0 / (1 - x)
-        const bfb = bf0 * (rAlpha + sBeta0) / sBeta0
-        dz += recursiveSum({
-          p: ps0 * s0 / l2,
-          xb,
-          b: bfb,
-          ib: ibf0 - xaf * xb / (sBeta0 * bfb)
-        }, (t, i) => {
-          const s = s0 - i - 1
-          const sBeta = this.p.beta + s
-          if (s >= 0) {
-            t.p *= (s + 1) / l2
-            t.xb /= 1 - x
-            t.b *= (rAlpha + sBeta) / sBeta
-            t.ib -= xaf * t.xb / (sBeta * t.b)
-          } else {
-            t.p = 0
-            t.ib = 0
-          }
-
-          return t
-        }, t => prf * t.p * t.ib)
-      }
-
-      // Add s-terms
-      z += dz
-      if (Math.abs(dz / z) < EPS) {
-        break
-      } else {
-        ibf0 -= xaf * xb0 / (rAlpha * bf0)
-        bf0 *= rAlpha / (rAlpha + this.p.beta + s0)
-        xaf *= x
-      }
-    }
-
-    // Backward r
-    if (r0 > 0) {
-      let prb = pr0
-      let xab = xa0
-      let bb0 = b0
-      let ibb0 = ib0
-      for (let r = r0 - 1; r >= 0; r--) {
-        let dz = 0
-        const rAlpha = this.p.alpha + r
-
-        // Update terms
-        prb *= (r + 1) / l1
-        xab /= x
-        bb0 *= (rAlpha + this.p.beta + s0) / rAlpha
-        ibb0 += xab * xb0 / (rAlpha * bb0)
-
-        // Forward s
-        dz += recursiveSum({
-          p: psf0 * l2 / (s0 > 0 ? s0 : 1),
-          xb: xb0,
-          b: bb0,
-          ib: ibb0
-        }, (t, i) => {
-          const s = s0 + i
-          t.p *= l2 / (s > 0 ? s : 1)
-          return t
-        }, t => prb * t.p * t.ib, (t, i) => {
-          const s = s0 + i
-          const sBeta = this.p.beta + s
-          t.ib += xab * t.xb / (sBeta * t.b)
-          t.b *= sBeta / (rAlpha + sBeta)
-          t.xb *= 1 - x
-          return t
-        })
-
-        // Backward s
-        if (s0 > 0) {
-          const xbb = xb0 / (1 - x)
-          const bbb = bb0 * (rAlpha + sBeta0) / sBeta0
-          dz += recursiveSum({
-            p: ps0 * s0 / l2,
-            xb: xb0 / (1 - x),
-            b: bb0 * (rAlpha + sBeta0) / sBeta0,
-            ib: ibb0 - xab * xbb / (sBeta0 * bbb)
-          }, (t, i) => {
-            const s = s0 - i - 1
-            const sBeta = this.p.beta + s
-            if (s >= 0) {
-              t.p *= (s + 1) / l2
-              t.xb /= 1 - x
-              t.b *= (rAlpha + sBeta) / sBeta
-              t.ib -= xab * t.xb / (sBeta * t.b)
-            } else {
-              t.p = 0
-            }
-            return t
-          }, t => prb * t.p * t.ib)
-        }
-
-        // Add s-terms
-        z += dz
-        if (Math.abs(dz / z) < EPS) {
-          break
-        }
-      }
-    }
-
-    return clamp(Math.exp(-l1 - l2) * z)
+    return clamp(Math.exp(-l1 - l2) * this._cdfRBackward(ctx, this._cdfRForward(ctx)))
   }
+
+  // ─── PROTECTED STATIC ─────────────────────────────────────────────────────
 
   static _fitInit (data) {
     // Beta MOM for α, β; λ1=λ2 seeded at 0.5 since noncentrality is degenerate from moments
@@ -388,5 +126,203 @@ export default class DoublyNoncentralBeta extends Distribution {
     const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1e-4
     const factor = Math.max(mean * (1 - mean) / variance - 1, 0.1)
     return [mean * factor, (1 - mean) * factor, 0.5, 0.5]
+  }
+
+  // ─── PRIVATE INSTANCE ─────────────────────────────────────────────────────
+
+  /** @private */
+  _pdfRForward (ctx) {
+    const { y, ab, l1, l2, r0, s0, ps0, yr0, pr0, ys0, b0 } = ctx
+    const sCtx = { y, ab, l2, s0, ps0 }
+
+    let z = 0
+    let bf0 = b0
+    let ysf0 = ys0
+    let pyrf = yr0 * pr0 * Math.max(r0, 1) / l1
+
+    for (let kr = 0; kr < MAX_ITER; kr++) {
+      const r = r0 + kr
+      ysf0 *= 1 + y
+      pyrf *= y * l1 / Math.max(r, 1)
+      const dz = this._pdfSumOverS({ ...sCtx, r, pyr: pyrf, ys: ysf0, b: bf0 })
+      z += dz
+      if (Math.abs(dz / z) < EPS) {
+        break
+      } else {
+        bf0 *= (this.p.alpha + r) / (ab + r + s0)
+      }
+    }
+
+    return z
+  }
+
+  /** @private */
+  _pdfRBackward (ctx, z) {
+    const { y, ab, l1, l2, r0, s0, ps0, yr0, pr0, ys0, b0 } = ctx
+    const sCtx = { y, ab, l2, s0, ps0 }
+
+    let bb0 = b0
+    let ysb0 = (1 + y) * ys0
+    let pyrb = y * yr0 * pr0
+
+    for (let r = r0 - 1; r >= 0; r--) {
+      ysb0 /= 1 + y
+      pyrb *= (r + 1) / (y * l1)
+      bb0 *= (ab + r + s0) / (this.p.alpha + r)
+      const dz = this._pdfSumOverS({ ...sCtx, r, pyr: pyrb, ys: ysb0, b: bb0 })
+      z += dz
+      if (Math.abs(dz / z) < EPS) {
+        break
+      }
+    }
+
+    return z
+  }
+
+  /** @private */
+  _pdfSumOverS ({ y, ab, l2, s0, ps0, r, pyr, ys, b }) {
+    const betaParam = this.p.beta
+
+    let dz = recursiveSum({
+      y: ys * (1 + y),
+      p: ps0,
+      b
+    }, (t, i) => {
+      const s = s0 + i
+      t.y *= 1 + y
+      t.p *= l2 / Math.max(s, 1)
+      return t
+    }, t => pyr * t.p / (t.b * t.y), (t, i) => {
+      const s = s0 + i
+      t.b *= (betaParam + s) / (ab + r + s)
+      return t
+    })
+
+    if (s0 > 0) {
+      dz += recursiveSum({
+        y: ys,
+        p: s0 * ps0 / l2,
+        b: b * (ab + r + s0 - 1) / (betaParam + s0 - 1)
+      }, (t, i) => {
+        const s = s0 - i - 1
+        if (s >= 0) {
+          t.y /= 1 + y
+          t.p *= (s + 1) / l2
+          t.b *= (ab + r + s) / (betaParam + s)
+        } else {
+          t.p = 0
+        }
+        return t
+      }, t => pyr * t.p / (t.b * t.y))
+    }
+
+    return dz
+  }
+
+  /** @private */
+  _cdfRForward (ctx) {
+    const { l1, l2, r0, s0, pr0, ps0, sBeta0, xa0, xb0, b0, ib0, x } = ctx
+    const betaParam = this.p.beta
+    const sCtx = { l2, s0, ps0, xb0, sBeta0, x }
+
+    let z = 0
+    let prf = pr0 * Math.max(r0, 1) / l1
+    let xaf = xa0
+    let bf0 = b0
+    let ibf0 = ib0
+
+    for (let kr = 0; kr < MAX_ITER; kr++) {
+      const r = r0 + kr
+      const rAlpha = this.p.alpha + r
+      prf *= l1 / Math.max(r, 1)
+      const dz = this._cdfSumOverS({ ...sCtx, r, pr: prf, xa: xaf, b: bf0, ib: ibf0 })
+      z += dz
+      if (Math.abs(dz / z) < EPS) {
+        break
+      } else {
+        ibf0 -= xaf * xb0 / (rAlpha * bf0)
+        bf0 *= rAlpha / (rAlpha + betaParam + s0)
+        xaf *= x
+      }
+    }
+
+    return z
+  }
+
+  /** @private */
+  _cdfRBackward (ctx, z) {
+    const { l1, l2, r0, s0, pr0, ps0, sBeta0, xa0, xb0, b0, ib0, x } = ctx
+    const betaParam = this.p.beta
+    const sCtx = { l2, s0, ps0, xb0, sBeta0, x }
+
+    let prb = pr0
+    let xab = xa0
+    let bb0 = b0
+    let ibb0 = ib0
+
+    for (let r = r0 - 1; r >= 0; r--) {
+      const rAlpha = this.p.alpha + r
+      prb *= (r + 1) / l1
+      xab /= x
+      bb0 *= (rAlpha + betaParam + s0) / rAlpha
+      ibb0 += xab * xb0 / (rAlpha * bb0)
+      const dz = this._cdfSumOverS({ ...sCtx, r, pr: prb, xa: xab, b: bb0, ib: ibb0 })
+      z += dz
+      if (Math.abs(dz / z) < EPS) {
+        break
+      }
+    }
+
+    return z
+  }
+
+  /** @private */
+  _cdfSumOverS ({ l2, s0, ps0, xb0, sBeta0, x, r, pr, xa, b, ib }) {
+    const betaParam = this.p.beta
+    const rAlpha = this.p.alpha + r
+
+    let dz = recursiveSum({
+      p: ps0,
+      xb: xb0,
+      b,
+      ib
+    }, (t, i) => {
+      const s = s0 + i
+      t.p *= l2 / Math.max(s, 1)
+      return t
+    }, t => pr * t.p * t.ib, (t, i) => {
+      const s = s0 + i
+      const sBeta = betaParam + s
+      t.ib += xa * t.xb / (sBeta * t.b)
+      t.b *= sBeta / (rAlpha + sBeta)
+      t.xb *= 1 - x
+      return t
+    })
+
+    if (s0 > 0) {
+      const xbBack = xb0 / (1 - x)
+      const bBack = b * (rAlpha + sBeta0) / sBeta0
+      dz += recursiveSum({
+        p: ps0 * s0 / l2,
+        xb: xbBack,
+        b: bBack,
+        ib: ib - xa * xbBack / (sBeta0 * bBack)
+      }, (t, i) => {
+        const s = s0 - i - 1
+        const sBeta = betaParam + s
+        if (s >= 0) {
+          t.p *= (s + 1) / l2
+          t.xb /= 1 - x
+          t.b *= (rAlpha + sBeta) / sBeta
+          t.ib -= xa * t.xb / (sBeta * t.b)
+        } else {
+          t.p = 0
+          t.ib = 0
+        }
+        return t
+      }, t => pr * t.p * t.ib)
+    }
+
+    return dz
   }
 }


### PR DESCRIPTION
Extract forward/backward r-loops and s-summation into six named private
helpers (_pdfRForward, _pdfRBackward, _pdfSumOverS, _cdfRForward,
_cdfRBackward, _cdfSumOverS). Each helper carries at most one bump and
stays well under the 70-LoC and cc<9 thresholds.

All four CodeScene smells eliminated:
- Bumpy Road Ahead (bumps=2 in _pdf and _cdf)
- Deep Nested Complexity (depth=4)
- Complex Method (cc=19)
- Large Method (137/116 LoC)

No behavioural change; all 7712 tests pass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HcCKrEVq8VvdXN4p92VcE2