### PR TITLE
Add tests for ran.mc module (MCMC, RWM, gelmanRubin)

### DIFF
--- a/solutions/correctness/2026-07-11-1230-mcmc-state-key-mismatch-silent-sigma-loss.md
+++ b/solutions/correctness/2026-07-11-1230-mcmc-state-key-mismatch-silent-sigma-loss.md
@@ -1,0 +1,75 @@
+---
+date: 2026-07-11T12:30:00Z
+category: "correctness"
+problem: "MCMC.state() serialized internal state as 'internals' but constructor read 'internal', silently discarding all adapted proposal sigmas on resume"
+status: complete
+related_issue: "#616"
+related_plan: "thoughts/plans/2026-07-11-1201-mc-tests.md"
+tags: [mcmc, state-serialization, key-mismatch, round-trip, silent-data-loss, correctness, testing]
+---
+
+# Solution: MCMC State Key Mismatch — Silent Sigma Loss on Resume
+
+**Date**: 2026-07-11T12:30:00Z
+**Category**: correctness
+**Related Issue**: #616
+
+## Problem
+
+`MCMC.state()` returned `{ x, samplingRate, internals: this._internal() }` but the constructor
+read `initialState.internal` (singular). Every `state()` round-trip silently discarded all
+subclass-specific adaptive state. For RWM, this meant all proposal widths (`_sigma` values)
+tuned during `warmUp()` were reset to 1.0 on resume — the sampler restarted from the correct
+position but with a cold, unadapted proposal. No error was thrown and no warning was emitted.
+
+The primary visible fields (`x`, `samplingRate`) round-tripped correctly, so any test checking
+only those two fields passed even though the entire adaptive state was silently dropped.
+
+## Root Cause
+
+A singular/plural typo between the writer (`state()` emitted `internals: ...`) and the reader
+(constructor consumed `initialState.internal`) created a serialization contract mismatch.
+Because `internal` has a fallback (`|| {}`), the constructor never saw a missing-key error —
+it silently fell through to an empty object. The mismatch was invisible to tests that only
+asserted position and sampling rate restoration.
+
+## Fix
+
+Changed `src/mc/_mcmc.js` line 46 from `internals: this._internal()` to
+`internal: this._internal()`, aligning the serialized key with the constructor's reader.
+Updated the `state()` JSDoc `@returns` to explicitly name all three properties: `x`,
+`samplingRate`, and `internal`.
+
+Tightened the state round-trip test to assert `rwm2.state().internal.proposal` deep-equals
+`state.internal.proposal` — verifying that adapted proposal sigmas survive the round-trip, not
+just position.
+
+## Prevention Strategy
+
+State round-trip tests must assert **every field that `state()` serializes**, including
+subclass-specific fields such as adapted proposal widths — not just position and samplingRate.
+A test that only checks `state.x` and `state.samplingRate` passes even when the entire adaptive
+state is silently dropped.
+
+Canonical round-trip test pattern:
+1. Construct sampler, run `warmUp()` to drive adaptation
+2. Call `state()` to snapshot
+3. Construct a second sampler from that snapshot
+4. Assert `newSampler.state()` deep-equals the original snapshot in full, including
+   `internal.proposal`
+
+Additionally: key names between `state()` and the constructor should match exactly — derive
+both from a single named constant or write the round-trip test (TDD) before implementing
+either side.
+
+## Related Solutions
+
+- [`solutions/correctness/2026-07-07-1500-path-prng-save-restore.md`](2026-07-07-1500-path-prng-save-restore.md) — Analogous pattern for Process: saving only mathematical state but not PRNG stream position breaks reproducibility invisibly; state round-trips must cover all stateful components.
+- [`solutions/correctness/2026-07-07-1600-path-distinct-realizations-reset-not-path.md`](2026-07-07-1600-path-distinct-realizations-reset-not-path.md) — Round-trip restoration patterns for generating distinct realizations.
+
+## Key Insight
+
+When `state()` serializes internal state as `internals` but the constructor reads
+`initialState.internal`, the round-trip silently drops all adapted parameters with no error —
+only a test that explicitly checks the subclass-specific field (not just position) after a
+full round-trip can detect this class of silent-data-loss bug.

--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -43,7 +43,7 @@ export default class MCMC {
     return {
       x: this.x,
       samplingRate: this.samplingRate,
-      internals: this._internal()
+      internal: this._internal()
     }
   }
 

--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -37,7 +37,7 @@ export default class MCMC {
    *
    * @method state
    * @memberof ran.mc.MCMC
-   * @returns {Object} Object containing the current position, sampling rate, and subclass internals.
+   * @returns {Object} Object with properties: x (current position), samplingRate (thinning interval), and internal (subclass state).
    */
   state () {
     return {

--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -43,7 +43,7 @@ export default class MCMC {
     return {
       x: this.x,
       samplingRate: this.samplingRate,
-      internal: this._internal()
+      internal: this._internal() // key must match what constructor reads; see solutions/correctness/2026-07-11-1230-mcmc-state-key-mismatch-silent-sigma-loss.md
     }
   }
 

--- a/test/mc.js
+++ b/test/mc.js
@@ -149,7 +149,7 @@ describe('mc.RWM', () => {
       const rwm2 = new RWM(lnp, { dim: 1 }, state)
       assert.deepEqual(rwm2.x, state.x)
       assert.strictEqual(rwm2.samplingRate, state.samplingRate)
-      assert.deepEqual(rwm2._sigma, state.internal.proposal)
+      assert.deepEqual(rwm2.state().internal.proposal, state.internal.proposal)
     })
   })
 
@@ -228,7 +228,7 @@ describe('mc.gelmanRubin', () => {
       const chain1 = Array.from({ length: 500 }, () => [normal.sample()])
       const chain2 = Array.from({ length: 500 }, () => [normal.sample()])
       const result = gelmanRubin([chain1, chain2])
-      assert.closeTo(result[0][result[0].length - 1], 1.0, 0.2)
+      assert.closeTo(result[0][result[0].length - 1], 1.0, 0.05)
     })
   })
 })

--- a/test/mc.js
+++ b/test/mc.js
@@ -1,0 +1,234 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+import MCMC from '../src/mc/_mcmc'
+import RWM from '../src/mc/rwm'
+import gelmanRubin from '../src/mc/gelman-rubin'
+import { Normal } from '../src/dist'
+import { ksTest } from './test-utils'
+
+// Concrete subclass that replays a pre-built sequence, enabling deterministic
+// accumulator testing without involving the PRNG.
+class TestMCMC extends MCMC {
+  constructor (sequence) {
+    super(() => 0, { dim: 1 }, { x: [0] })
+    this._seq = sequence
+    this._i = 0
+  }
+
+  _internal () { return {} }
+  _adjust () {}
+  _iter () { return this._seq[this._i++] }
+}
+
+// Bare subclass with no method overrides, used to verify that the base-class
+// abstract stubs throw the expected errors when called unoverridden.
+class UnimplementedMCMC extends MCMC {
+  constructor () {
+    super(() => 0, { dim: 1 }, { x: [0] })
+  }
+}
+
+describe('mc.MCMC', () => {
+  describe('constructor', () => {
+    it('should throw when instantiated directly', () => {
+      assert.throws(() => new MCMC(() => 0), /abstract/)
+    })
+  })
+
+  describe('.statistics()', () => {
+    it('should compute Welford mean, std and cv for a known sequence', () => {
+      const mc = new TestMCMC([1, 2, 3, 4, 5].map(v => ({ x: [v], accepted: true })))
+      for (let i = 0; i < 5; i++) mc.iterate()
+      const stats = mc.statistics()
+      // exact rational: mean = 15/5 = 3
+      assert.closeTo(stats[0].mean, 3.0, 1e-14)
+      // mpmath mp.dps=50: sqrt(mpf('2.5')) → 1.5811388300841898
+      assert.closeTo(stats[0].std, 1.5811388300841898, 1e-14)
+      // mpmath: mpf('1.5811388300841898') / 3 → 0.5270462766947299
+      assert.closeTo(stats[0].cv, 0.5270462766947299, 1e-14)
+    })
+
+    it('should return NaN for cv when mean is 0', () => {
+      const mc = new TestMCMC([-1, 1].map(v => ({ x: [v], accepted: true })))
+      for (let i = 0; i < 2; i++) mc.iterate()
+      const stats = mc.statistics()
+      // exact rational: (-1 + 1) / 2 = 0
+      assert.strictEqual(stats[0].mean, 0)
+      // mpmath mp.dps=50: sqrt(mpf('2')) → 1.4142135623730951
+      assert.closeTo(stats[0].std, 1.4142135623730951, 1e-14)
+      assert(Number.isNaN(stats[0].cv))
+    })
+  })
+
+  describe('.ar()', () => {
+    it('should return 0 before any iterations', () => {
+      const mc = new TestMCMC([])
+      assert.strictEqual(mc.ar(), 0)
+    })
+
+    it('should return the correct acceptance fraction after mixed iterations', () => {
+      const seq = [
+        { x: [1], accepted: true },
+        { x: [2], accepted: true },
+        { x: [3], accepted: true },
+        { x: [4], accepted: false },
+        { x: [5], accepted: false }
+      ]
+      const mc = new TestMCMC(seq)
+      for (let i = 0; i < 5; i++) mc.iterate()
+      // exact rational: 3 accepted / 5 total = 0.6
+      assert.closeTo(mc.ar(), 0.6, 1e-14)
+    })
+  })
+
+  describe('.ac()', () => {
+    it('should return NaN for all lags before any iterations', () => {
+      const mc = new TestMCMC([])
+      const ac = mc.ac()
+      assert.strictEqual(ac.length, 1)
+      assert(Number.isNaN(ac[0][0]))
+    })
+
+    it('should return 1.0 at lag-0 after a known sequence', () => {
+      const mc = new TestMCMC([1, 2, 3, 4, 5].map(v => ({ x: [v], accepted: true })))
+      for (let i = 0; i < 5; i++) mc.iterate()
+      const ac = mc.ac()
+      // exact rational: (cross[0]/n - mean^2) / pop_var = (55/5 - 9) / 2 = 1.0
+      assert.closeTo(ac[0][0], 1.0, 1e-14)
+    })
+
+    it('should return NaN for lags beyond the number of samples seen', () => {
+      const mc = new TestMCMC([1, 2, 3, 4, 5].map(v => ({ x: [v], accepted: true })))
+      for (let i = 0; i < 5; i++) mc.iterate()
+      const ac = mc.ac()
+      assert(Number.isNaN(ac[0][5]))
+    })
+  })
+
+  describe('abstract method stubs', () => {
+    it('_internal() should throw when not overridden', () => {
+      const mc = new UnimplementedMCMC()
+      assert.throws(() => mc._internal(), /not implemented/)
+    })
+
+    it('_iter() should throw when not overridden', () => {
+      const mc = new UnimplementedMCMC()
+      assert.throws(() => mc._iter(), /not implemented/)
+    })
+
+    it('_adjust() should throw when not overridden', () => {
+      const mc = new UnimplementedMCMC()
+      assert.throws(() => mc._adjust(), /not implemented/)
+    })
+  })
+})
+
+describe('mc.RWM', () => {
+  describe('constructor', () => {
+    it('should instantiate without error for a 1D Normal target', () => {
+      assert.doesNotThrow(() => new RWM(x => -0.5 * x[0] * x[0], { dim: 1 }))
+    })
+  })
+
+  describe('._iter() rejection', () => {
+    it('should return accepted: false and leave position unchanged when all proposals are rejected', () => {
+      // lnp = () => -Infinity: Math.exp(-Inf - (-Inf)) = NaN; float() < NaN = false always
+      const rwm = new RWM(() => -Infinity, { dim: 1 }, { x: [42] })
+      const result = rwm.iterate()
+      assert.strictEqual(result.accepted, false)
+      assert.strictEqual(rwm.x[0], 42)
+    })
+  })
+
+  describe('.state() round-trip', () => {
+    it('should restore position, samplingRate, and proposal sigmas', () => {
+      const lnp = x => -0.5 * x[0] * x[0]
+      const rwm1 = new RWM(lnp, { dim: 1 })
+      for (let i = 0; i < 100; i++) rwm1.iterate()
+      const state = rwm1.state()
+      const rwm2 = new RWM(lnp, { dim: 1 }, state)
+      assert.deepEqual(rwm2.x, state.x)
+      assert.strictEqual(rwm2.samplingRate, state.samplingRate)
+      assert.deepEqual(rwm2._sigma, state.internal.proposal)
+    })
+  })
+
+  describe('.ar() during sampling', () => {
+    it('should lie in [0.2, 0.8] for a well-tuned 1D Normal target', () => {
+      const rwm = new RWM(x => -0.5 * x[0] * x[0], { dim: 1 })
+      rwm.warmUp(null, 5)
+      rwm.sample(null, 1000)
+      const ar = rwm.ar()
+      assert(ar >= 0.2 && ar <= 0.8, `acceptance rate ${ar} outside [0.2, 0.8]`)
+    })
+  })
+
+  describe('.sample() distributional test', () => {
+    it('should produce samples matching Normal(0,1) target (KS test)', () => {
+      const rwm = new RWM(x => -0.5 * x[0] * x[0], { dim: 1 })
+      rwm.warmUp(null, 10)
+      const samples = rwm.sample(null, 2000)
+      const values = samples.map(s => s[0])
+      const ref = new Normal(0, 1)
+      assert(ksTest(values, x => ref.cdf(x)))
+    })
+  })
+})
+
+describe('mc.gelmanRubin', () => {
+  describe('input validation', () => {
+    it('should throw when given an empty array', () => {
+      assert.throws(() => gelmanRubin([]), /at least two chains/)
+    })
+
+    it('should throw when given a single chain', () => {
+      const chain = Array.from({ length: 5 }, (_, i) => [i + 0.5])
+      assert.throws(() => gelmanRubin([chain]), /at least two chains/)
+    })
+
+    it('should throw for non-array input', () => {
+      assert.throws(() => gelmanRubin(null), /at least two chains/)
+    })
+
+    it('should not throw for two valid chains', () => {
+      const chain1 = Array.from({ length: 5 }, (_, i) => [i + 0.5])
+      const chain2 = Array.from({ length: 5 }, (_, i) => [i * 2 + 0.5])
+      assert.doesNotThrow(() => gelmanRubin([chain1, chain2]))
+    })
+  })
+
+  describe('maxLength', () => {
+    it('should cap output length to maxLength', () => {
+      const chain1 = Array.from({ length: 10 }, (_, i) => [i + 0.5])
+      const chain2 = Array.from({ length: 10 }, (_, i) => [i * 2 + 0.5])
+      const result = gelmanRubin([chain1, chain2], 3)
+      assert.strictEqual(result[0].length, 3)
+    })
+
+    it('should return chain.length - 1 values without maxLength', () => {
+      const chain1 = Array.from({ length: 10 }, (_, i) => [i + 0.5])
+      const chain2 = Array.from({ length: 10 }, (_, i) => [i * 2 + 0.5])
+      const result = gelmanRubin([chain1, chain2])
+      assert.strictEqual(result[0].length, 9)
+    })
+  })
+
+  describe('output shape', () => {
+    it('should return one array per state dimension', () => {
+      const chain1 = Array.from({ length: 20 }, (_, i) => [i * 0.1, -i * 0.1])
+      const chain2 = Array.from({ length: 20 }, (_, i) => [i * 0.1 + 0.5, -i * 0.1 + 0.5])
+      const result = gelmanRubin([chain1, chain2])
+      assert.strictEqual(result.length, 2)
+    })
+  })
+
+  describe('convergence', () => {
+    it('should return R-hat close to 1.0 for two well-mixed i.i.d. Normal chains', () => {
+      const normal = new Normal(0, 1)
+      const chain1 = Array.from({ length: 500 }, () => [normal.sample()])
+      const chain2 = Array.from({ length: 500 }, () => [normal.sample()])
+      const result = gelmanRubin([chain1, chain2])
+      assert.closeTo(result[0][result[0].length - 1], 1.0, 0.2)
+    })
+  })
+})


### PR DESCRIPTION
Closes #616

## Summary

- Adds `test/mc.js` with full Mocha + Chai coverage for the `ran.mc` module: MCMC base class, RWM sampler, and `gelmanRubin` convergence diagnostic.
- Fixes a silent state-serialization bug in `MCMC.state()`: the key `internals` (plural) was written but the constructor read `internal` (singular), silently discarding all adapted proposal sigmas on every `state()` round-trip.
- Documents the fix as a compound solution at `solutions/correctness/2026-07-11-1230-mcmc-state-key-mismatch-silent-sigma-loss.md`.

## Non-trivial changes

- **`src/mc/_mcmc.js:43–46`**: Renamed `internals:` → `internal:` in `state()` to match what the constructor reads from `initialState`. Added WHY comment pointing at the solution doc. Updated `@returns` JSDoc to explicitly list all three returned properties.

- **`test/mc.js`**: New test file. Uses two concrete subclasses:
  - `TestMCMC` — replays a pre-built `{x, accepted}` sequence without any PRNG involvement, enabling exact numeric assertions against Welford mean/std/cv and the online autocorrelation estimator.
  - `UnimplementedMCMC` — bare subclass with no overrides, used to verify that all three abstract method stubs throw `/not implemented/` when called unoverridden (needed to hit 100% function coverage on the stubs).

  Notable tests:
  - `statistics()` — Welford mean, std, cv verified against mpmath at `mp.dps=50`; NaN cv when mean=0.
  - `ac()` — lag-0 autocorrelation exactly 1.0 for a known sequence; NaN beyond observed count.
  - `RWM.state()` round-trip — asserts `internal.proposal` deep-equals the original snapshot (not just `x` and `samplingRate`), which is the test that would have caught the `internals`/`internal` key mismatch.
  - `gelmanRubin` convergence — R-hat within 0.05 of 1.0 for two 500-sample i.i.d. Normal chains.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`solutions/correctness/2026-07-11-1230-mcmc-state-key-mismatch-silent-sigma-loss.md`**: Compound solution document — problem, root cause, fix, prevention strategy, and key insight for the state key mismatch bug.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jf1gJMefdk9sDyPMynajo1)_