### PR TITLE
Add MCMC dim upper bound to prevent OOM crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ran.mc.MCMC` (and all subclasses, e.g. `ran.mc.RWM`) now reject `config.dim` above 10000, throwing a clear `Error` instead of allocating oversized per-dimension arrays and crashing the process with an out-of-memory error (#916).
+
 ### Added
 
 - `seed(value)` method on `ran.mc.MCMC` (and `ran.mc.RWM`, which additionally reseeds its internal proposal distribution) for deterministic, reproducible sampling. Internally, both classes now use a per-instance `Xoshiro128p` PRNG instead of the shared module-level generator, so seeding a sampler no longer affects unrelated code sharing that singleton. If the initial position was not explicitly supplied, `seed()` also redraws it from the newly seeded generator so that `.seed(s).sample(n)` is fully reproducible (#912).

--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -16,7 +16,7 @@ import Xoshiro128p from '../core/xoshiro'
  * @param {Object=} initialState Initial state of the sampler. Supported properties: {x} (starting
  * position), {samplingRate} (thinning interval), and {internal} for subclass-specific state.
  * @constructor
- * @throws {Error} If config.dim is provided but is not a positive integer.
+ * @throws {Error} If config.dim is provided but is not a positive integer, or exceeds the maximum allowed dimension.
  */
 // decisions/0020-mcmc-design.md — accumulator design and the _iter/_adjust/_internal subclass contract
 export default class MCMC {
@@ -290,13 +290,24 @@ export default class MCMC {
 
   // Kept out of the constructor to avoid a Complex Conditional / Complex Method smell there.
   static _validateDim (dim) {
-    if (dim === undefined || MCMC._isPositiveInteger(dim)) {
+    if (dim === undefined) {
       return
     }
-    throw Error('MCMC: dim must be a positive integer')
+    if (!MCMC._isPositiveInteger(dim)) {
+      throw Error('MCMC: dim must be a positive integer')
+    }
+    // Bounds per-dimension array allocations (Welford accumulators, autocorrelation buffers)
+    // in the constructor; unbounded dim otherwise lets a caller trigger an OOM crash. See #916.
+    if (dim > MCMC._MAX_DIM) {
+      throw Error(`MCMC: dim must be at most ${MCMC._MAX_DIM}`)
+    }
   }
 
   static _isPositiveInteger (dim) {
     return Number.isInteger(dim) && dim >= 1
+  }
+
+  static get _MAX_DIM () {
+    return 10000
   }
 }

--- a/test/mc.js
+++ b/test/mc.js
@@ -46,6 +46,15 @@ describe('mc.MCMC', () => {
       assert.throws(() => new RWM(() => 0, { dim: 1.5 }), /dim must be a positive integer/)
     })
 
+    it('should throw for a dim above the maximum allowed', () => {
+      assert.throws(() => new RWM(() => 0, { dim: 1e9 }), /dim must be at most/)
+      assert.throws(() => new RWM(() => 0, { dim: 10001 }), /dim must be at most/)
+    })
+
+    it('should not throw for a dim at the maximum allowed', () => {
+      assert.doesNotThrow(() => new RWM(() => 0, { dim: 10000 }))
+    })
+
     it('should default to dim: 1 when omitted', () => {
       const rwm = new RWM(x => -0.5 * x[0] * x[0])
       assert.strictEqual(rwm.dim, 1)


### PR DESCRIPTION
Closes #916

## Summary

- `MCMC._validateDim` now rejects `config.dim` above 10000, throwing a clear `Error` before the constructor allocates any per-dimension arrays (Welford accumulators, autocorrelation buffers), closing the memory-exhaustion DoS gap left open by #912.
- Added boundary tests in `test/mc.js` (rejects `1e9` and `10001`, accepts exactly `10000`) and a `### Fixed` CHANGELOG entry.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Production-code diff is under ~400 lines (tests excluded) — 14 net lines in `src/mc/_mcmc.js`

## Non-trivial changes

- **`src/mc/_mcmc.js`**: `_validateDim` now tightens the constructor's accepted `dim` range (previously any positive integer, now capped at `MCMC._MAX_DIM = 10000`). This is a genuine parameter-constraint change, not purely mechanical — it can reject a `dim` value that would previously have been accepted (only above 10000, which crashed the process anyway). No ADR was added: per `CLAUDE.md`'s ADR criteria, this is a defensive validation bound (an implementation-technique choice), not a decision about the `Distribution`/`MCMC` public API shape, module structure, or cross-cutting convention — the existing `decisions/0020-mcmc-design.md` already covers the base `MCMC` design this fix operates within.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/mc.js`**: two new `it` blocks covering the upper-bound rejection and boundary acceptance.
- **`CHANGELOG.md`**: `### Fixed` bullet under `[Unreleased]`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEYiJ5PL7ik5We3dGrtsFE)_