### PR TITLE
docs(mc): clarify iterate() as advanced API, hide RWM.seed() override from docs

### DIFF
--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -132,8 +132,8 @@ export default class MCMC {
   /**
    * Performs a single iteration, updates accumulators, and optionally calls a callback.
    *
-   * Advanced/low-level: most callers should use {@link ran.mc.MCMC#warmUp} and
-   * {@link ran.mc.MCMC#sample} instead, which drive `iterate()` internally. Calling it manually is
+   * Advanced/low-level: most callers should use [warmUp]{@link ran.mc.MCMC#warmUp} and
+   * [sample]{@link ran.mc.MCMC#sample} instead, which drive `iterate()` internally. Calling it manually is
    * for cases that need per-step control (e.g. live progress plotting, custom stopping rules).
    * `sample()` resets the accumulators before it starts collecting, but interleaving manual
    * `iterate()` calls with `warmUp()`/`sample()` otherwise does not — mixing manual draws in can

--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -132,6 +132,13 @@ export default class MCMC {
   /**
    * Performs a single iteration, updates accumulators, and optionally calls a callback.
    *
+   * Advanced/low-level: most callers should use {@link ran.mc.MCMC#warmUp} and
+   * {@link ran.mc.MCMC#sample} instead, which drive `iterate()` internally. Calling it manually is
+   * for cases that need per-step control (e.g. live progress plotting, custom stopping rules).
+   * `sample()` resets the accumulators before it starts collecting, but interleaving manual
+   * `iterate()` calls with `warmUp()`/`sample()` otherwise does not — mixing manual draws in can
+   * blend adaptation-phase and equilibrium-phase observations into `statistics()`, `ar()`, and `ac()`.
+   *
    * @method iterate
    * @memberof ran.mc.MCMC
    * @param {Function=} callback Called with (x, accepted) after each iteration.

--- a/src/mc/rwm.js
+++ b/src/mc/rwm.js
@@ -35,6 +35,7 @@ export default class RWM extends MCMC {
    * @memberof ran.mc.RWM
    * @param {number|string} value The value of the seed, either a number or a string (for the ease of tracking seeds).
    * @returns {this} Reference to the current sampler.
+   * @ignore
    */
   seed (value) {
     super.seed(value)


### PR DESCRIPTION
- MCMC.iterate(): note that warmUp()/sample() should normally be used
  instead, and that manual calls can blend adaptation-phase and
  equilibrium-phase draws into statistics()/ar()/ac() if interleaved
  with warmUp()/sample().
- RWM.seed(): tag @ignore, consistent with how protected hooks are
  hidden elsewhere in _mcmc.js — it's a same-contract override needed
  to also seed the internal proposal distribution, not a distinct
  public method worth documenting twice.