### PR TITLE
Bound combined dim*maxLag and arWindow memory in MCMC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `ran.mc.MCMC` (and all subclasses, e.g. `ran.mc.RWM`) now reject `config.dim` above 10000 and `config.maxLag` above 10000, throwing a clear `Error` instead of allocating oversized arrays and crashing the process with an out-of-memory error (#916, #922).
+- `ran.mc.MCMC` (and all subclasses, e.g. `ran.mc.RWM`) now reject `config.dim` above 10000, `config.maxLag` above 10000, `config.arWindow` above 10000, and any individually-valid `dim`/`maxLag` combination whose combined accumulator footprint (`dim * maxLag * 16` bytes) exceeds 100MB, throwing a clear `Error` instead of allocating oversized arrays and crashing the process with an out-of-memory error (#916, #922, #928).
 - `ran.mc.MCMC` warm-up thinning no longer inverts for slow-mixing chains: when a dimension's autocorrelation never decays to ≤ 0.05 within `maxLag`, `_thinningLag()` now falls back to the largest measured lag instead of reporting 0. Previously a chain that mixed slower than `maxLag` could resolve was treated as already-decorrelated, driving `samplingRate` down toward 1 and under-thinning `sample()` — the opposite of the intended "slowest-mixing dimension wins" rule (ADR-0020 §3).
 - `ran.mc.MCMC.warmUp(progress, maxBatches)` now runs exactly `maxBatches` batches (was `maxBatches + 1` due to a `batch <= maxBatches` loop bound) and reports `100` at completion instead of firing a redundant `0%` callback at the start.
 - `ran.mc.MCMC.sample(progress, size)` now reports each integer percentage of progress exactly once. Previously the `i % (iMax/100)` check used a fractional modulus whenever the total iteration count was not a multiple of 100, silently skipping most progress callbacks.

--- a/solutions/correctness/2026-07-13-1624-mcmc-arwindow-sibling-bound-gap.md
+++ b/solutions/correctness/2026-07-13-1624-mcmc-arwindow-sibling-bound-gap.md
@@ -1,0 +1,109 @@
+---
+date: 2026-07-13T16:24:35Z
+category: "correctness"
+problem: "MCMC.arWindow had no upper bound, unlike its sibling fields dim/maxLag, allowing an unguarded Uint8Array(arWindow) OOM allocation"
+status: complete
+related_issue: "#928"
+related_plan: "thoughts/plans/2026-07-13-1221-mcmc-combined-dim-maxlag-bound.md"
+tags: [mcmc, oom, validation, sibling-field-audit, bug-triage, joint-validator, config-defaults]
+---
+
+# Solution: MCMC arWindow sibling-bound gap found during #928 bug triage
+
+**Date**: 2026-07-13T16:24:35Z
+**Category**: correctness
+**Related Issue**: #928
+
+## Problem
+
+`MCMC`'s constructor (`src/mc/_mcmc.js`) validates three config fields —
+`dim`, `maxLag`, and `arWindow` — each feeding an unguarded array allocation
+in `_initAccumulators()`: `_acBuf`/`_acCross` sized by `dim*maxLag`
+(`Float64Array`), `_arBuf` sized by `arWindow` (`Uint8Array`). `dim` and
+`maxLag` had each been individually capped at 10000 in prior issues (#916,
+#922), but neither cap prevented a caller from supplying both at their
+individual maximum simultaneously — `dim=10000, maxLag=10000` still allocated
+~1.6GB from the two `Float64Array` accumulators. That was issue #928's
+motivating bug.
+
+While fixing #928, a mandatory post-implementation bug-triage pass (the
+`ops-triage` agent, run between `/validate` and `/review` in the `/build`
+pipeline) found that the *third* sibling field, `arWindow`, had **no upper
+bound at all** — `_validateArWindow` only checked positive-integer-ness,
+despite guarding `new Uint8Array(arWindow)` in the exact same
+`_initAccumulators()` method. This is the identical OOM-vulnerability class
+#916/#922 had already closed for `dim`/`maxLag`, just never applied to the
+third structurally-identical field.
+
+## Root Cause
+
+`_validateDim`, `_validateMaxLag`, and `_validateArWindow` are three
+structurally parallel validators (same shape: positive-integer check,
+optional upper-bound check) added at different times by different issues.
+Each was added independently to close a narrowly-scoped bug report —
+`_validateDim`/`_validateMaxLag` got upper bounds because #916/#922
+specifically asked for them — but no one revisited the *sibling* fields at
+the time. A bound added to fix a *named* field does not automatically get
+applied to *structurally identical but unnamed* fields; that requires an
+explicit audit step, not just fixing what the triggering issue literally
+asked for.
+
+A secondary, smaller issue surfaced during design-critique of the fix itself:
+the first draft of the new joint `_validateCombinedFootprint(dim, maxLag)`
+validator resolved `undefined` dim/maxLag to their defaults *inside* the
+validator (mirroring `_resolveConfig`'s `config.dim || 1` logic), which would
+have created a second copy of that default-filling logic that could silently
+drift out of sync if the defaults were ever changed in one place but not the
+other.
+
+## Fix
+
+1. Added `_validateCombinedFootprint(dim, maxLag)` as a fourth static
+   validator in `src/mc/_mcmc.js`, called in the constructor *after*
+   `_resolveConfig` has filled in defaults — i.e. operating on the resolved
+   `this.dim`/`this.maxLag`, not raw `config.dim`/`config.maxLag`. This
+   avoids duplicating `_resolveConfig`'s default-filling logic.
+2. During bug triage, patched the missing `arWindow` bound inline in the
+   same branch: added `_MAX_AR_WINDOW = 10000` and the missing upper-bound
+   check in `_validateArWindow`, mirroring the existing
+   `_validateDim`/`_validateMaxLag` pattern exactly. Extended the same
+   `test/mc.js` boundary-test pattern (`arWindow: 1e9`/`10001` throws,
+   `arWindow: 10000` doesNotThrow) and folded the fix into the existing
+   `#916, #922, #928` CHANGELOG bullet rather than filing a separate issue,
+   since it was a trivial, same-class, same-file fix caught by triage
+   (`ops-triage` returned `definite`, `fix_inline: true`).
+
+## Prevention Strategy
+
+When a PR adds or tightens a bound on one field among several structurally
+parallel sibling fields (same validator shape, same class of
+allocation-guard purpose), explicitly audit whether every sibling has an
+equivalent bound — not just the field(s) the triggering issue named. This
+audit is cheap (grep for the validator pattern, check which ones have an
+upper-bound branch) and is exactly the kind of adjacent-red-flag check the
+mandatory bug-triage stage is designed to catch; this instance is a working
+example of that stage doing its job, not an argument that it should be
+skipped.
+
+Separately: when adding any *joint/derived* validator over multiple
+already-independently-validated fields, run it on the already-resolved
+(post-default-fill) values rather than raw config — resolving defaults a
+second time inside the joint validator creates a duplicate copy of the
+resolution logic that can silently drift if the defaults are ever changed in
+one place but not the other.
+
+## Related Solutions
+
+No related past solutions found (`#916`/`#922`, the two prior individual
+`dim`/`maxLag` bounds, have no dedicated solution documents — their
+rationale lives only in inline code comments and the CHANGELOG bullet this
+work extends).
+
+## Key Insight
+
+When hardening one field against unbounded allocation, treat every
+structurally identical sibling field (same validator shape, same class of
+allocation it guards) as in-scope for the same audit — the bug-triage stage
+exists precisely to catch this "fixed the named field, missed the identical
+unnamed one" pattern, as it did here for `arWindow` sitting unbounded next
+to the two fields #916/#922 had already hardened.

--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -19,7 +19,8 @@ import Xoshiro128p from '../core/xoshiro'
  * @constructor
  * @throws {Error} If config.dim is provided but is not a positive integer, or exceeds the maximum allowed dimension.
  * @throws {Error} If config.maxLag is provided but is not a positive integer, or exceeds the maximum allowed lag.
- * @throws {Error} If config.arWindow is provided but is not a positive integer.
+ * @throws {Error} If config.arWindow is provided but is not a positive integer, or exceeds the maximum allowed window.
+ * @throws {Error} If the combined dim*maxLag accumulator footprint exceeds the maximum allowed memory budget.
  */
 // decisions/0020-mcmc-design.md — accumulator design and the _iter/_adjust/_internal subclass contract
 export default class MCMC {
@@ -34,6 +35,7 @@ export default class MCMC {
     this.dim = resolved.dim
     this.maxLag = resolved.maxLag
     this._arWindow = resolved.arWindow
+    MCMC._validateCombinedFootprint(this.dim, this.maxLag)
     this.lnp = logDensity
     this.r = new Xoshiro128p()
     // Tracked so seed() can tell whether it should re-draw x — otherwise a random
@@ -362,6 +364,15 @@ export default class MCMC {
     }
   }
 
+  // Kept out of the constructor to avoid a Complex Method smell there. Runs on
+  // the resolved dim/maxLag (after _resolveConfig), not raw config, so it
+  // doesn't duplicate _resolveConfig's default-filling logic — see #928.
+  static _validateCombinedFootprint (dim, maxLag) {
+    if (dim * maxLag * 16 > MCMC._MAX_ACCUMULATOR_BYTES) {
+      throw Error(`MCMC: dim * maxLag must be at most ${Math.floor(MCMC._MAX_ACCUMULATOR_BYTES / 16)} (got ${dim * maxLag})`)
+    }
+  }
+
   // Guards new Uint8Array(arWindow) in _initAccumulators() the same way _validateDim guards the
   // per-dimension array allocations — an unvalidated non-integer arWindow silently corrupts the
   // ring-buffer cursor arithmetic in _updateAccumulators() into permanent NaN.
@@ -371,6 +382,13 @@ export default class MCMC {
     }
     if (!MCMC._isPositiveInteger(arWindow)) {
       throw Error('MCMC: arWindow must be a positive integer')
+    }
+    // Bounds the new Uint8Array(arWindow) allocation in _initAccumulators();
+    // unbounded arWindow otherwise lets a caller trigger an OOM crash, the
+    // same gap _MAX_DIM/_MAX_LAG closed for dim/maxLag. See #928 and
+    // solutions/correctness/2026-07-13-1624-mcmc-arwindow-sibling-bound-gap.md
+    if (arWindow > MCMC._MAX_AR_WINDOW) {
+      throw Error(`MCMC: arWindow must be at most ${MCMC._MAX_AR_WINDOW}`)
     }
   }
 
@@ -393,5 +411,22 @@ export default class MCMC {
 
   static get _MAX_LAG () {
     return 10000
+  }
+
+  // _arBuf = new Uint8Array(arWindow) is a single flat allocation, 1 byte per
+  // element — same order-of-magnitude cap as _MAX_DIM/_MAX_LAG for
+  // consistency, even though a Uint8Array is far cheaper per element than the
+  // Float64Arrays those bounds guard. See #928.
+  static get _MAX_AR_WINDOW () {
+    return 10000
+  }
+
+  // _acBuf/_acCross together allocate dim*maxLag*16 bytes (two Float64Arrays
+  // per dimension, 8 bytes/element each); 100MB is an order-of-magnitude
+  // budget well below typical heap limits while still permitting dim at its
+  // individual maximum (_MAX_DIM = 10000) with the default maxLag (100) —
+  // 16MB. See #928.
+  static get _MAX_ACCUMULATOR_BYTES () {
+    return 100e6
   }
 }

--- a/test/mc.js
+++ b/test/mc.js
@@ -76,6 +76,18 @@ describe('mc.MCMC', () => {
       assert.doesNotThrow(() => new RWM(() => 0, { maxLag: 10000 }))
     })
 
+    it('should throw when dim and maxLag are each individually valid but their product exceeds the combined bound', () => {
+      assert.throws(() => new RWM(() => 0, { dim: 10000, maxLag: 10000 }), /dim \* maxLag must be at most/)
+    })
+
+    it('should not throw when dim*maxLag is exactly at the combined bound', () => {
+      assert.doesNotThrow(() => new RWM(() => 0, { dim: 10000, maxLag: 625 }))
+    })
+
+    it('should throw when dim*maxLag is just above the combined bound', () => {
+      assert.throws(() => new RWM(() => 0, { dim: 10000, maxLag: 626 }), /dim \* maxLag must be at most/)
+    })
+
     it('should default to maxLag: 100 when omitted', () => {
       const rwm = new RWM(x => -0.5 * x[0] * x[0])
       assert.strictEqual(rwm.maxLag, 100)
@@ -103,6 +115,15 @@ describe('mc.MCMC', () => {
 
     it('should throw for a non-integer arWindow', () => {
       assert.throws(() => new RWM(() => 0, { arWindow: 2.5 }), /arWindow must be a positive integer/)
+    })
+
+    it('should throw for an arWindow above the maximum allowed', () => {
+      assert.throws(() => new RWM(() => 0, { arWindow: 1e9 }), /arWindow must be at most/)
+      assert.throws(() => new RWM(() => 0, { arWindow: 10001 }), /arWindow must be at most/)
+    })
+
+    it('should not throw for an arWindow at the maximum allowed', () => {
+      assert.doesNotThrow(() => new RWM(() => 0, { arWindow: 10000 }))
     })
 
     it('should not throw for a valid arWindow and use it for ar()', () => {


### PR DESCRIPTION
## Summary

Adds a joint `dim * maxLag` memory-footprint bound to `MCMC`'s constructor, closing the gap left after `config.dim` (#916) and `config.maxLag` (#922) were each individually capped at 10000 but their *product* was never checked — `dim=10000, maxLag=10000` still allocated ~1.6GB from the `_acBuf`/`_acCross` accumulators. While fixing this, a mandatory post-implementation bug-triage pass found and fixed inline a sibling gap: `config.arWindow` had no upper bound at all, despite guarding the same class of unbounded allocation (`new Uint8Array(arWindow)`).

Closes #928

## Design decisions

No new ADR. The design decision (joint byte-budget bound vs. lowering `_MAX_LAG` vs. won't-fix) was resolved via a design-propose/design-critique agent pair during planning, both converging with high confidence on a joint bound placed *after* config-resolution to avoid duplicating `_resolveConfig`'s default-filling logic. No ADR was written because #916 and #922 — the two prior individual `dim`/`maxLag` bounds this PR extends — did not warrant one either (confirmed via `git log`: both shipped touching only `src/mc/_mcmc.js`, `test/mc.js`, and `CHANGELOG.md`); ADR-0023's "superseding ADR" clause covers changes to accumulator *mechanics* (divisors, reset cadence, ring-buffer ordering), not the addition of a new validation-time cap that leaves those mechanics untouched. Full rationale: `thoughts/plans/2026-07-13-1221-mcmc-combined-dim-maxlag-bound.md`.

## Non-trivial changes

- **`src/mc/_mcmc.js`**: New `_MAX_ACCUMULATOR_BYTES` (100MB) static getter and `_validateCombinedFootprint(dim, maxLag)` static validator, called in the constructor after `_resolveConfig` — operates on the *resolved* `this.dim`/`this.maxLag`, not raw config, so it doesn't re-implement `_resolveConfig`'s default logic. This is a behavioral change: constructor calls with `dim`/`maxLag` each individually valid but whose product exceeds ~6.25M (100MB / 16 bytes-per-cell) now throw where they previously allocated unboundedly.
- **`src/mc/_mcmc.js`**: New `_MAX_AR_WINDOW` (10000) getter and upper-bound check added to the previously-unbounded `_validateArWindow` — found by a bug-triage pass auditing sibling fields of the same validator shape, and fixed in-scope per the triage protocol (trivial, same OOM-prevention class, no separate issue filed). Documented in `solutions/correctness/2026-07-13-1624-mcmc-arwindow-sibling-bound-gap.md`.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, no new distribution
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Production-code diff is under ~400 lines (tests excluded) — ~37 lines in `src/mc/_mcmc.js`

<details>
<summary>Trivial changes</summary>

- **`test/mc.js`**: Boundary tests for both new bounds (motivating combined case, exact bound, one-over-bound, `arWindow` above/at maximum), following the existing `_validateDim`/`_validateMaxLag` test pattern exactly.
- **`CHANGELOG.md`**: Extended the existing `#916, #922` `### Fixed` bullet to cover `#928` and the `arWindow` bound, per the changelog-placement rule (same OOM-prevention category).
- **`solutions/correctness/2026-07-13-1624-mcmc-arwindow-sibling-bound-gap.md`**: New solution document capturing the sibling-field-audit insight for future sessions.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhVy5ZGndQBzPQHTJEW9Ct)_