### PR TITLE
Add runChains() multi-chain convergence helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ran.mc` namespace (`RWM`, `gelmanRubin`) is now exported from the library's entry point, wiring it up to `ran.mc` after it was inadvertently left unexported during PR #615's cleanup (#617).
 - `seed(value)` method on `ran.mc.MCMC` (and `ran.mc.RWM`, which additionally reseeds its internal proposal distribution) for deterministic, reproducible sampling. Internally, both classes now use a per-instance `Xoshiro128p` PRNG instead of the shared module-level generator, so seeding a sampler no longer affects unrelated code sharing that singleton. If the initial position was not explicitly supplied, `seed()` also redraws it from the newly seeded generator so that `.seed(s).sample(n)` is fully reproducible (#912).
+- `ran.mc.runChains(logDensity, config, options)`: runs multiple independently-seeded `RWM` chains and computes the `gelmanRubin()` diagnostic across them in one call — the recommended workflow (ADR-0024) for gating MCMC convergence, since no signal computable from a single chain can distinguish "converged" from "stuck". Defaults to 2 chains seeded `[1, 2]`; `options.chains`, `options.warmUpBatches`, `options.sampleSize`, `options.seeds`, and `options.maxLength` are all configurable. Returns `{ samples, rhat }` (#935).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ const rHat = ran.mc.gelmanRubin([chain1.sample(null, 500), chain2.sample(null, 5
 // rHat[0] → R-hat vs. iteration count for dimension 0; values near 1 indicate convergence
 ```
 
+`ran.mc.runChains(logDensity, config, options)` mechanizes the pattern above: it constructs multiple independently-seeded `RWM` chains, warms up and samples each, and returns their samples plus the `gelmanRubin()` diagnostic in one call — the recommended workflow for gating MCMC convergence (single-chain diagnostics cannot distinguish "converged" from "stuck"):
+
+```javascript
+const { samples, rhat } = ran.mc.runChains(logDensity, { dim: 1 })
+// samples → one sample array per chain (2 chains, seeded [1, 2] by default)
+// rhat    → the gelmanRubin() diagnostic across those chains
+```
+
 ## Return values and errors
 
 `ranjs` signals an unusual result through one of four channels, chosen by the *kind* of situation:

--- a/solutions/testing/2026-07-14-1218-runchains-unbounded-chains-runaway-redtest.md
+++ b/solutions/testing/2026-07-14-1218-runchains-unbounded-chains-runaway-redtest.md
@@ -1,0 +1,51 @@
+---
+date: 2026-07-14T12:18:53Z
+category: "testing"
+problem: "runChains() had an unbounded chains multiplier and a silent seeds/chains mismatch; the red test for the missing bound became the runaway it was proving existed"
+status: complete
+related_issue: "#935"
+related_plan: "thoughts/plans/2026-07-14-0534-runchains-multi-chain-helper.md"
+tags: [mcmc, resource-exhaustion, bound-check, red-green-refactor, silent-truncation, testing-technique]
+---
+
+# Solution: runChains() unbounded chains multiplier + a red test that became the runaway it was testing for
+
+**Date**: 2026-07-14T12:18:53Z
+**Category**: testing
+**Related Issue**: #935
+
+## Problem
+
+`ran.mc.runChains(logDensity, config, options)` (new in this session, `src/mc/run-chains.js`) validated `options.chains >= 2` but had **no upper bound**. It also accepted an optional `options.seeds` array without checking its length against `options.chains` — `runChains(f, {}, { chains: 5, seeds: [1, 2, 3] })` silently ran only 3 chains (`Array.prototype.map` over `seeds` simply ignored the requested `chains: 5`), returning an `rhat` diagnostic computed from fewer chains than the caller asked for, with no error and no warning.
+
+While writing the red test to prove the missing upper bound — `runChains(f, { dim: 1 }, { chains: 10001 })`, using the function's own defaults (`warmUpBatches: 100`, `sampleSize: 1000`) to keep the test "realistic" — the test itself triggered the exact failure it was supposed to demonstrate the absence of a guard for: 10001 chains × (100 warm-up batches × 1e4 inner iterations + 1000 samples) ≈ **10 billion MCMC iterations**. The test hung and had to be killed via `TaskStop` mid-run.
+
+## Root Cause
+
+**The bound gap**: `runChains()` is a multiplier layered on top of an already-bounded primitive. `MCMC._validateCombinedFootprint(dim, maxLag)` (`src/mc/_mcmc.js`, backed by `_MAX_DIM`/`_MAX_LAG` = 10000 and `_MAX_ACCUMULATOR_BYTES` — see `solutions/correctness/2026-07-13-1624-mcmc-arwindow-sibling-bound-gap.md` for the prior audit that established these) bounds the memory footprint of *one* chain. `runChains()` constructs `chains` independent instances of that already-bounded footprint, but nothing re-examined whether the existing per-instance bound still held once a new axis (`chains`) multiplied it — a "run N of X" wrapper around an already-validated X creates a *new* unbounded axis even when X itself is safe in isolation. The bound on X does not compose into a bound on N×X automatically; it has to be added explicitly at the wrapper.
+
+**The silent-truncation bug**: `chains` (a count) and `seeds` (a list whose `.length` implies a count) carry overlapping information, and only one of the two redundant sources of truth was validated. When two parameters can disagree, the code must pick an explicit policy — here, `.map` over `seeds` silently won by virtue of being the code path actually executed, discarding the caller's stated `chains` value without any signal.
+
+**The test-authoring mistake**: a red test proving "large N is rejected" reused the function's expensive default parameters instead of driving every other cost-bearing knob to its cheapest legal value. Since the validation guard didn't exist yet (that's the point of a red test), the test had no fast-fail path and instead executed the full expensive computation the guard was meant to prevent.
+
+## Fix
+
+1. Added `if (seeds !== undefined && seeds.length !== chains) throw Error('runChains: seeds.length must equal chains')` — a mismatch now fails loudly instead of silently truncating the run.
+2. Added `_MAX_CHAINS = 10000` (matching the existing `MCMC._MAX_DIM`/`_MAX_LAG` order of magnitude for consistency, not independently re-derived) and `if (chains > _MAX_CHAINS) throw Error(...)`, checked before any `RWM` instance is constructed.
+3. Deliberately left `warmUpBatches`/`sampleSize` **unbounded** — they pass through unchanged to `warmUp()`/`sample()`, which are themselves unbounded by design elsewhere in the public API (an intentional caller-controlled compute-time tradeoff, not a memory-crash risk). Bounding them only inside `runChains()` would have been an arbitrary restriction inconsistent with calling `RWM` directly. Only `chains` — the new multiplier this function introduces — needed a new bound.
+4. Rewrote the red test for `_MAX_CHAINS` to pass `warmUpBatches: 0, sampleSize: 0` alongside `chains: 10001`, so it exercises only the validation path (which throws before any chain is constructed). The test now completes in ~300ms instead of hanging, and would fail fast even in a hypothetical future regression where the bound check is accidentally removed.
+
+## Prevention Strategy
+
+- When wrapping an already-bounded primitive in a "run N of it" helper (fan-out, batch, multi-chain, multi-trial, ensemble, etc.), explicitly ask: *does this introduce a new unbounded multiplier axis, and does the wrapped primitive's existing bound already account for it?* It almost never does by default — validate the new axis independently rather than assuming the inner bound protects the outer loop. This generalizes the sibling-field-audit lesson from `solutions/correctness/2026-07-13-1624-mcmc-arwindow-sibling-bound-gap.md` (audit structurally parallel *fields*) to structurally parallel *layers* (audit structurally parallel *wrappers* around an already-bounded primitive).
+- When two parameters carry redundant information (a count, and a list whose `.length` implies that count), validate their agreement explicitly. Silent truncation of a requested quantity is a correctness bug even though no exception was thrown and the output looked superficially plausible — it is the same class of failure the return-value conventions in `CLAUDE.md` require a `throw` for ("structurally impossible input"), just arrived at via two parameters disagreeing rather than one parameter being invalid in isolation.
+- **Never write a red test for a resource-exhaustion/runaway-loop guard by relying on the function's own expensive default parameters to make the test "realistic."** Drive every *other* cost-bearing parameter to its cheapest legal value so the only thing under test is the validation/bound-check path itself. A correctly-placed bound check runs before any expensive work, so a well-constructed test proving the check exists should complete in milliseconds regardless of what value it's proving gets rejected. If a red test for "this should be rejected" takes more than an instant to fail, that itself is a signal the test is accidentally exercising the guarded behavior instead of the guard — treat a slow-to-fail rejection test as a bug in the test, not a quirk to wait out.
+
+## Related Solutions
+
+- `solutions/correctness/2026-07-13-1624-mcmc-arwindow-sibling-bound-gap.md` — the prior MCMC bound-check gap (`arWindow` missing the same `_MAX_*` treatment already applied to `dim`/`maxLag`); establishes the `_MAX_*` constant pattern and the sibling-field-audit discipline this solution extends to sibling-*wrapper* audits.
+- `solutions/correctness/2026-07-11-1230-mcmc-state-key-mismatch-silent-sigma-loss.md` — a different flavor of the same underlying lesson (two related pieces of state, `state()`'s written key and the constructor's read key, silently disagreeing with no error) — silent divergence between two things that should agree is a recurring failure shape in this module.
+
+## Key Insight
+
+A resource-exhaustion bound and the test that proves it exists must be independently cheap — zero out every other cost-bearing parameter in the test so the guard check is the *only* thing exercised, otherwise "testing that N is capped" can itself become the uncapped runaway you're trying to prevent.

--- a/src/mc/index.js
+++ b/src/mc/index.js
@@ -5,4 +5,5 @@
  * @memberof ran
  */
 export { default as gelmanRubin } from './gelman-rubin'
+export { default as runChains } from './run-chains'
 export { default as RWM } from './rwm'

--- a/src/mc/run-chains.js
+++ b/src/mc/run-chains.js
@@ -1,0 +1,76 @@
+import RWM from './rwm'
+import gelmanRubin from './gelman-rubin'
+
+// Same order-of-magnitude cap as MCMC._MAX_DIM/_MAX_LAG (src/mc/_mcmc.js) — chains multiplies
+// the per-instance accumulator footprint that bound already guards, one chain at a time.
+const _MAX_CHAINS = 10000
+
+/**
+ * Runs multiple independently-seeded [RWM]{@link ran.mc.RWM} chains from the same target density
+ * and computes the [Gelman-Rubin]{@link ran.mc.gelmanRubin} convergence diagnostic across them —
+ * the recommended workflow for gating MCMC convergence (decisions/0024-mcmc-warmup-convergence-strategy.md),
+ * since no signal computable from a single chain can distinguish "converged" from "stuck".
+ *
+ * @method runChains
+ * @memberof ran.mc
+ * @param {Function} logDensity The logarithm of the (unnormalized) target density.
+ * @param {Object=} config Sampler configuration, forwarded unchanged to each chain's constructor
+ * (see [MCMC]{@link ran.mc.MCMC} for supported properties).
+ * @param {Object=} options Run configuration. Supported properties:
+ * <ul>
+ *   <li>{chains}: Number of independent chains to run. Default is 2, minimum 2.</li>
+ *   <li>{warmUpBatches}: Number of warm-up batches per chain, forwarded to warmUp(). Default is 100.</li>
+ *   <li>{sampleSize}: Number of samples to collect per chain, forwarded to sample(). Default is 1000.</li>
+ *   <li>{seeds}: Explicit per-chain seed values. Defaults to [1, 2, ..., chains].</li>
+ *   <li>{maxLength}: Maximum number of diagnostic values, forwarded to gelmanRubin().</li>
+ * </ul>
+ * @returns {Object} Object with properties: samples (number[][][], one sample array per chain) and
+ * rhat (number[][], the gelmanRubin() diagnostic across the chains).
+ * @throws {Error} If options.chains is not an integer of at least two, or exceeds the maximum
+ * allowed chain count, or if options.seeds is provided and its length does not equal options.chains.
+ */
+export default function runChains (logDensity, config = {}, options = {}) {
+  const {
+    chains = 2,
+    warmUpBatches = 100,
+    sampleSize = 1000,
+    seeds,
+    maxLength
+  } = options
+
+  _validateChains(chains)
+  _validateSeeds(seeds, chains)
+
+  const resolvedSeeds = seeds || Array.from({ length: chains }, (_, i) => i + 1)
+
+  const samples = resolvedSeeds.map(seed => {
+    const sampler = new RWM(logDensity, config).seed(seed)
+    sampler.warmUp(null, warmUpBatches)
+    return sampler.sample(null, sampleSize)
+  })
+
+  return { samples, rhat: gelmanRubin(samples, maxLength) }
+}
+
+// Unlike warmUp()/sample()'s own maxBatches/size (unbounded by design — a caller-controlled
+// compute-time tradeoff, not a crash risk), chains multiplies the per-instance accumulator
+// footprint that MCMC._validateCombinedFootprint() already bounds per chain — an unbounded
+// chain count reintroduces the same unbounded-memory risk one instance at a time. Same
+// order-of-magnitude cap as MCMC._MAX_DIM/_MAX_LAG for consistency.
+// See solutions/testing/2026-07-14-1218-runchains-unbounded-chains-runaway-redtest.md
+function _validateChains (chains) {
+  if (!Number.isInteger(chains) || chains < 2) {
+    throw Error('runChains requires at least two chains')
+  }
+  if (chains > _MAX_CHAINS) {
+    throw Error(`runChains: chains must be at most ${_MAX_CHAINS}`)
+  }
+}
+
+// seeds.length silently diverging from chains would otherwise let RWM's .map() run fewer
+// chains than requested with no signal — see the solution doc linked above.
+function _validateSeeds (seeds, chains) {
+  if (seeds !== undefined && seeds.length !== chains) {
+    throw Error('runChains: seeds.length must equal chains')
+  }
+}

--- a/test/mc.js
+++ b/test/mc.js
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha'
 import MCMC from '../src/mc/_mcmc'
 import RWM from '../src/mc/rwm'
 import gelmanRubin from '../src/mc/gelman-rubin'
+import runChains from '../src/mc/run-chains'
 import { Normal } from '../src/dist'
 import { ksTest } from './test-utils'
 
@@ -556,6 +557,93 @@ describe('mc.gelmanRubin', () => {
 
       const result = gelmanRubin([chain1, chain2])
       assert.isBelow(result[0][result[0].length - 1], 1.1)
+    })
+  })
+})
+
+describe('mc.runChains', () => {
+  const logDensity = x => -0.5 * x[0] ** 2
+
+  describe('input validation', () => {
+    it('should throw when chains is fewer than two', () => {
+      assert.throws(() => runChains(logDensity, { dim: 1 }, { chains: 1 }), /at least two chains/)
+    })
+
+    it('should throw when chains is zero', () => {
+      assert.throws(() => runChains(logDensity, { dim: 1 }, { chains: 0 }), /at least two chains/)
+    })
+
+    it('should throw when chains is not an integer', () => {
+      assert.throws(() => runChains(logDensity, { dim: 1 }, { chains: 2.5 }), /at least two chains/)
+    })
+
+    it('should throw when seeds.length does not match chains', () => {
+      assert.throws(() => runChains(logDensity, { dim: 1 }, { chains: 5, seeds: [1, 2, 3] }), /seeds.length must equal.*chains/)
+    })
+
+    it('should throw when chains exceeds the maximum allowed', () => {
+      // warmUpBatches/sampleSize: 0 keeps this fast — the bound must be checked
+      // before any chain is constructed, not discovered by running out of time.
+      assert.throws(
+        () => runChains(logDensity, { dim: 1 }, { chains: 10001, warmUpBatches: 0, sampleSize: 0 }),
+        /chains must be at most/
+      )
+    })
+  })
+
+  describe('defaults', () => {
+    it('should default to two chains seeded 1 and 2 when chains/seeds are omitted', () => {
+      const { samples } = runChains(logDensity, { dim: 1 }, { warmUpBatches: 2, sampleSize: 20 })
+
+      const manual = [1, 2].map(seed => {
+        const rwm = new RWM(logDensity, { dim: 1 }).seed(seed)
+        rwm.warmUp(null, 2)
+        return rwm.sample(null, 20)
+      })
+
+      assert.deepEqual(samples, manual)
+    })
+  })
+
+  describe('output shape', () => {
+    it('should return samples for the requested chain count and sample size', () => {
+      const { samples } = runChains(logDensity, { dim: 1 }, { chains: 3, warmUpBatches: 2, sampleSize: 15 })
+      assert.strictEqual(samples.length, 3)
+      samples.forEach(chain => assert.strictEqual(chain.length, 15))
+    })
+
+    it('should return one rhat array per state dimension, each of length sampleSize - 1', () => {
+      const { rhat } = runChains(logDensity, { dim: 1 }, { chains: 2, warmUpBatches: 2, sampleSize: 15 })
+      assert.strictEqual(rhat.length, 1)
+      assert.strictEqual(rhat[0].length, 14)
+    })
+  })
+
+  describe('seeded reproducibility', () => {
+    it('should match manually constructed chains seeded with the same explicit seeds', () => {
+      const { samples } = runChains(logDensity, { dim: 1 }, { chains: 3, seeds: [10, 20, 30], warmUpBatches: 2, sampleSize: 15 })
+
+      const manual = [10, 20, 30].map(seed => {
+        const rwm = new RWM(logDensity, { dim: 1 }).seed(seed)
+        rwm.warmUp(null, 2)
+        return rwm.sample(null, 15)
+      })
+
+      assert.deepEqual(samples, manual)
+    })
+  })
+
+  describe('maxLength', () => {
+    it('should cap rhat length the same way gelmanRubin does', () => {
+      const { rhat } = runChains(logDensity, { dim: 1 }, { chains: 2, warmUpBatches: 2, sampleSize: 15, maxLength: 3 })
+      assert.strictEqual(rhat[0].length, 3)
+    })
+  })
+
+  describe('convergence', () => {
+    it('should converge to R-hat < 1.1 for a well-tuned unit-Gaussian target', () => {
+      const { rhat } = runChains(logDensity, { dim: 1 }, { chains: 2, warmUpBatches: 10, sampleSize: 500, seeds: [100, 200] })
+      assert.isBelow(rhat[0][rhat[0].length - 1], 1.1)
     })
   })
 })


### PR DESCRIPTION
## Summary

Implements `ran.mc.runChains(logDensity, config, options)`, the standalone multi-chain helper ADR-0024 (issue #921) recommended: constructs N independently-seeded `RWM` chains, runs `warmUp()`/`sample()` on each, and returns their samples plus the `gelmanRubin()` R-hat diagnostic across them — the correct workflow for gating MCMC convergence, since no signal computable from a single chain can distinguish "converged" from "stuck".

Closes #935

## Design decisions

- [ADR-0024: MCMC Warm-Up Stays Fixed-Length; Convergence Is a Post-Hoc, Multi-Chain Concern](decisions/0024-mcmc-warmup-convergence-strategy.md) — already merged (#934); this PR implements the `runChains()` helper it designates as the follow-up. No new ADR was needed for this PR itself (confirmed during review): `runChains()` is a pure orchestration function over already-public API (`RWM`'s constructor/`seed()`/`warmUp()`/`sample()`, `gelmanRubin()`), with no `MCMC`/`RWM` base-class change and no new cross-cutting convention — it doesn't clear CLAUDE.md's ADR bar.
- Signature/return-shape (`runChains(logDensity, config, options)` with `RWM` hardcoded, returning `{ samples, rhat }`, no `converged` boolean) was resolved via a design-propose/design-critique pass, both independently high-confidence. A generic `SamplerClass` parameter was explicitly rejected: it wouldn't even work for a future HMC sampler, which needs a different constructor signature (`gradLogDensity`, per ADR-0020) — premature genericity would have been actively wrong, not just speculative.

## Non-trivial changes

- **`src/mc/run-chains.js`** (new): new public API surface. Constructs `options.chains` (default 2) independently-seeded `RWM` instances (default seeds `[1, 2, ..., chains]`), runs `warmUp(null, options.warmUpBatches)` then `sample(null, options.sampleSize)` on each, and calls `gelmanRubin(samples, options.maxLength)`. Validates `chains >= 2`, `chains <= 10000` (a resource-exhaustion bound — see below), and that `options.seeds`, when explicitly supplied, has length matching `chains`.
- **`src/mc/index.js`**: exports `runChains` alongside the existing `gelmanRubin`/`RWM` exports.

## Notable fixes found during this session's mandatory review/triage stages

- **Bug (found via bug-triage)**: the initial implementation validated `chains >= 2` but not that `options.seeds.length` matched `chains` when explicitly supplied — `runChains(f, {}, { chains: 5, seeds: [1,2,3] })` would silently run only 3 chains with no error. Fixed with an explicit length-match guard.
- **Resource-exhaustion gap (found via the mandatory security review pass)**: `chains` had no upper bound — an unbounded chain count multiplies the already-bounded per-instance memory footprint (`MCMC._validateCombinedFootprint`) by an unbounded factor. Added `_MAX_CHAINS = 10000`, same order of magnitude as the existing `MCMC._MAX_DIM`/`_MAX_LAG` precedent. `warmUpBatches`/`sampleSize` were deliberately left unbounded, since they pass through unchanged to `warmUp()`/`sample()`'s own already-unbounded parameters (a compute-time tradeoff, not a memory-crash risk) — bounding them only here would be inconsistent with the rest of the public API.
- Both are documented in detail, including a testing-technique lesson (a red test for the missing bound initially used the function's expensive defaults and triggered ~10 billion real MCMC iterations before being killed and rewritten to validate cheaply) in `solutions/testing/2026-07-14-1218-runchains-unbounded-chains-runaway-redtest.md`.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious (the `_MAX_CHAINS` bound and the seeds/chains guard both link to the solution doc explaining the reasoning)
- [x] Tests verify observable behavior, not internal state (the initial "matches gelmanRubin's own output" test was flagged as circular during review and replaced with independent shape assertions)
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: new bullet under the existing `[Unreleased] > ### Added` heading.
- **`README.md`**: `runChains()` documented in the MC API section, alongside the existing `gelmanRubin()` example.
- **`test/mc.js`**: new `describe('mc.runChains', ...)` block — input validation, defaults, output shape, seeded reproducibility, `maxLength` passthrough, and a statistical convergence check (R-hat < 1.1, matching the existing tolerance precedent in the same file).

</details>

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 7790 passing)
- [x] `npm run typecheck` passes
- [x] Tests added for new behavior (full TDD — red tests confirmed failing before implementation)
- [ ] If a new distribution was added — N/A
- [ ] If a new distribution was added — N/A
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Production-code diff is under ~400 lines (tests excluded) — ~65 lines (`run-chains.js` + `index.js` export)

---
*Generated with [Claude Code](https://claude.ai/code)*


---
_Generated by [Claude Code](https://claude.ai/code/session_01CbrrKQX489St8RvyFMPErS)_