### PR TITLE
Error thrown on rejection() MAX_ITER exhaustion

### DIFF
--- a/src/algorithms/rejection.js
+++ b/src/algorithms/rejection.js
@@ -10,7 +10,7 @@ import { MAX_ITER } from '../core/constants'
  * @param {Function} accept The function that returns the acceptance threshold.
  * @param {Function=} transform Optional transformation to apply once the sample is accepted (for transformed
  * distributions).
- * @return {(number|undefined)} The sampled random variate.
+ * @return {number} The sampled random variate.
  * @ignore
  */
 export default function (r, g, accept, transform) {
@@ -20,4 +20,5 @@ export default function (r, g, accept, transform) {
       return typeof transform !== 'undefined' ? transform(x) : x
     }
   }
+  throw Error('rejection: exceeded MAX_ITER trials without accepting a sample')
 }

--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha'
 import { repeat } from './test-utils'
 import { lambertW0 } from '../src/special/lambert-w'
 import * as algorithms from '../src/algorithms'
+import rejection from '../src/algorithms/rejection'
+import Xoshiro128p from '../src/core/xoshiro'
 
 const PRECISION = 1e-10
 
@@ -292,6 +294,26 @@ describe('algorithms', () => {
       // equals the first, diff=0 triggers the DELTA guard, and the fallback returns S ≈ 1.
       const result = algorithms.wynnEpsilon(k => (k === 0 ? 1 : 1e-20))
       assert(Math.abs(result - 1) < 1e-9)
+    })
+  })
+
+  describe('rejection()', () => {
+    it('should throw when MAX_ITER trials are exhausted without accepting a candidate', () => {
+      const r = new Xoshiro128p()
+      r.seed(1)
+      assert.throws(() => rejection(r, () => 0, () => 0), /exceeded MAX_ITER/)
+    })
+
+    it('should return the accepted sample without a transform', () => {
+      const r = new Xoshiro128p()
+      r.seed(1)
+      assert.equal(rejection(r, () => 5, () => 1), 5)
+    })
+
+    it('should apply the transform to the accepted sample', () => {
+      const r = new Xoshiro128p()
+      r.seed(1)
+      assert.equal(rejection(r, () => 5, () => 1, x => x * 2), 10)
     })
   })
 })


### PR DESCRIPTION
## Summary

`ran.algorithms.rejection` silently returned `undefined` when its trial loop exhausted `MAX_ITER` (100) attempts without accepting a candidate, instead of surfacing a diagnosable error — violating the project's Return Value and Error Conventions (`decisions/0015-return-value-and-error-conventions.md`), which forbid `undefined` as a failure sentinel. The loop now throws `Error('rejection: exceeded MAX_ITER trials without accepting a sample')` on exhaustion; the normal accepting path is unchanged.

Closes #940

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 7876 passing)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, not a distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, not a distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped: `rejection.js` is not exported via `src/algorithms/index.js` and has zero callers anywhere in the codebase (ARS and `_gamma.js` both use their own inline accept/reject loops), so this fix is not user-visible per CLAUDE.md's changelog rule
- [x] Production-code diff is under ~400 lines (tests excluded) — 4 lines changed in `src/algorithms/rejection.js`

## Non-trivial changes

_No non-trivial changes — this is a single-function bug fix in an internal, currently-uncalled algorithm helper._

## Comprehension checklist

- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious (none needed — the throw message is self-explanatory)
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/algorithms/rejection.js`**: JSDoc `@return` tag narrowed from `{(number|undefined)}` to `{number}` to match the new contract.
- **`test/algorithms.js`**: Added a `describe('rejection()', ...)` block with three tests (MAX_ITER exhaustion throws, accepted sample without transform, accepted sample with transform) — imports `rejection` directly since it isn't re-exported from `src/algorithms/index.js`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVkX8477dRFD2kXH9X82Ln)_