### PR TITLE
Thread Gibbs's PRNG into conditionals for seed() reproducibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ran.mc.MCMC` warm-up thinning no longer inverts for slow-mixing chains: when a dimension's autocorrelation never decays to ≤ 0.05 within `maxLag`, `_thinningLag()` now falls back to the largest measured lag instead of reporting 0. Previously a chain that mixed slower than `maxLag` could resolve was treated as already-decorrelated, driving `samplingRate` down toward 1 and under-thinning `sample()` — the opposite of the intended "slowest-mixing dimension wins" rule (ADR-0020 §3).
 - `ran.mc.MCMC.warmUp(progress, maxBatches)` now runs exactly `maxBatches` batches (was `maxBatches + 1` due to a `batch <= maxBatches` loop bound) and reports `100` at completion instead of firing a redundant `0%` callback at the start.
 - `ran.mc.MCMC.sample(progress, size)` now reports each integer percentage of progress exactly once. Previously the `i % (iMax/100)` check used a fractional modulus whenever the total iteration count was not a multiple of 100, silently skipping most progress callbacks.
+- `ran.mc.Gibbs`'s conditionals now receive the sampler's own PRNG as a second argument (`conditionals[d](x, rng)`), so `seed()` can produce reproducible chains for conditionals that draw their randomness from `rng.next()` instead of an independently-seeded generator. Previously `Gibbs._iter()` never read `this.r`, so `gibbs.seed(42).sample(null, N)` silently failed to reproduce, violating the contract documented on `MCMC.seed()` (ADR-0026, #938).
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ npm run typecheck
 - `src/special/` — Special mathematical functions: gamma, log-gamma, incomplete gamma/beta, beta, log-beta, Bessel functions, error function, digamma, hypergeometric, Hurwitz zeta, Riemann zeta, Lambert W, Marcum Q, Owen T, Stirling numbers.
 - `src/core/` — PRNG (`xoshiro.js` — xoshiro128+), mathematical constants, seeding utilities. Exports `float` (uniform `[0,1)`), `int`, and `bool` generators.
 - `src/la/` — Linear algebra: `matrix.js` and `vector.js`.
-- `src/mc/` — Markov Chain Monte Carlo: `_mcmc.js` (base), `rwm.js` (random walk Metropolis), `gelman-rubin.js` (convergence diagnostic). (`SliceSampler` was removed in PR #615; re-add tracked in #822.)
+- `src/mc/` — Markov Chain Monte Carlo: `_mcmc.js` (base), `rwm.js` (random walk Metropolis), `gelman-rubin.js` (convergence diagnostic).
 - `src/location/`, `src/dispersion/`, `src/shape/`, `src/dependence/` — Statistical summary measures (mean, median, variance, skewness, Pearson, Spearman, Kendall, etc.).
 - `src/test/` — Statistical hypothesis tests (Bartlett, Levene, Brown-Forsythe, Mann-Whitney, HSIC).
 - `src/ts/` — Time series: online covariance.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Available samplers:
 |-------|-------------|
 | `ran.mc.RWM(logDensity, config, initialState)` | Random-walk Metropolis-Hastings sampler with Robbins-Monro step-size adaptation during warm-up |
 | `ran.mc.AdaptiveMetropolis(logDensity, config, initialState)` | Full-covariance adaptive Metropolis (Haario-Saksman-Tamminen 2001); adapts the joint proposal covariance from the chain's own history during warm-up, then freezes it for sampling |
-| `ran.mc.Gibbs(conditionals, config, initialState)` | Component-wise (systematic-scan) Gibbs sampler; draws each dimension directly from its full conditional, so every iteration is accepted (`ar()` is always 1.0) |
+| `ran.mc.Gibbs(conditionals, config, initialState)` | Component-wise (systematic-scan) Gibbs sampler; draws each dimension directly from its full conditional, so every iteration is accepted (`ar()` is always 1.0). Each conditional is called as `conditionals[d](x, rng)` — `seed()` only reproduces a conditional's draws if it consumes `rng.next()` for its own randomness instead of an independently-seeded generator |
 | `ran.mc.HMC(logDensity, gradLogDensity, config, initialState)` | Hamiltonian Monte Carlo sampler: proposes distant moves via a leapfrog integrator over `config.pathLength` steps of size `config.stepSize`, with Metropolis accept/reject on the augmented (position, momentum) system; step size is adapted during warm-up via Robbins-Monro dual averaging and jittered per iteration to avoid periodicity artifacts |
 | `ran.mc.SliceSampler(logDensity, config, initialState)` | Coordinate-wise slice sampler (Neal 2003) using stepping-out and shrinkage; no proposal tuning or gradient required, interval width `w` is adapted per dimension during warm-up, and `ar()` is always 1.0 |
 

--- a/decisions/0026-gibbs-seed-rng-threading.md
+++ b/decisions/0026-gibbs-seed-rng-threading.md
@@ -1,0 +1,36 @@
+# ADR-0026: Gibbs Conditionals Receive the Sampler's PRNG as a Second Argument
+
+**Date**: 2026-07-15
+**Status**: Accepted
+
+## Context
+
+`ran.mc.Gibbs` (added in #821, `src/mc/gibbs.js`) extends `MCMC` and inherits `seed(value)`, whose JSDoc on the base class (`src/mc/_mcmc.js:53-62`) promises "seed the PRNG for reproducible chains." `Gibbs._iter()` never reads `this.r` — every per-iteration draw comes from calling `this._conditionals[d](x1)`, an opaque, caller-supplied closure. Real conditionals typically construct or capture their own `Distribution` instance (e.g. `x => new Normal(rho * x[1], sigma).sample()`), which — per `src/core/xoshiro.js` — seeds itself from `Math.random()` unless the caller explicitly seeds it. `MCMC.seed()`/`Gibbs`'s inherited `seed()` has no way to reach into that closure, so `gibbs.seed(42).sample(null, N)` called twice does not produce identical output, silently violating the documented contract.
+
+This gap was already hit once at the test level: `solutions/testing/2026-07-15-2015-gibbs-conditionals-fresh-normal-seed-noop.md` documents a CI flake caused by exactly this issue and explicitly calls for a design-level follow-up rather than a further test-only workaround. Issue #938 is that follow-up, posing two directions: (A) extend the conditional contract so `Gibbs.seed()` can reach conditional-internal randomness, or (B) override `Gibbs.seed()` to throw, converting the silent violation into a documented hard error.
+
+`RWM.seed()` (`src/mc/rwm.js:58-65`) is the existing precedent for a subclass that owns additional randomness sources: it reseeds both `this.r` (via `super.seed()`) and its internally-owned `this._q` proposal generator with the same value. `AdaptiveMetropolis` and `HMC` follow the same override-and-reseed-internal-object pattern. `Gibbs` has no internal object analogous to `_q` — its randomness lives entirely inside caller-supplied closures — so the RWM pattern cannot be applied directly without first giving conditionals a way to draw from a sampler-owned, reseedable source.
+
+Three concrete options were evaluated:
+- **Thread `this.r` into conditionals** as `conditionals[d](x, rng)`. No `seed()` override needed — `Gibbs` already inherits `MCMC.seed()`, which reseeds `this.r`, the same object now passed through. Existing single-argument conditionals silently ignore the extra argument (additive, not breaking) and remain non-reproducible unless they adopt it.
+- **Throw from `seed()`**, documenting that reproducibility is the caller's responsibility. Smallest code footprint but does not provide any path to the reproducibility the issue asks for, and makes `Gibbs` the only `MCMC` subclass whose `seed()` does not work.
+- **Duck-typed `.seed()` protocol on conditionals** — `Gibbs.seed()` would call `.seed(value)` on any conditional exposing one. No precedent in the codebase for attaching methods to function objects; unnatural in the conditional-as-closure style already established by `Gibbs`'s existing tests and JSDoc, and produces a partial-reproducibility footgun when only some conditionals in an array are seedable.
+
+## Decision
+
+`Gibbs._iter()` calls each conditional with the current state **and** the sampler's own PRNG: `this._conditionals[d](x1, this.r)`. No `Gibbs.seed()` override is added — the inherited `MCMC.seed()` already reseeds `this.r`, which is the exact object now threaded into every conditional call, so seeding the sampler and seeding the conditionals' draws become the same operation for conditionals that use the second argument.
+
+Conditionals opt in to reproducibility by drawing all their randomness from the supplied `rng` (e.g. `rng.next()` for uniforms, or by constructing a `Distribution` once outside the conditional and reseeding it from `rng` at construction) instead of capturing an independently-seeded generator. Conditionals that ignore the second argument keep working exactly as before — JavaScript silently drops unused trailing arguments — but remain non-reproducible under `seed()`, exactly as they are today. This is a real, documented limitation: Option 1 makes reproducibility achievable, not automatic, because the base class cannot force an opaque closure to use a particular randomness source.
+
+This is not a breaking change under CLAUDE.md's definition (constructor/public-method rename or removal, intentional parameter convention change, or changed return shape) — the conditional signature widens additively, and no existing call site's behavior changes. No deprecation cycle applies.
+
+## Consequences
+
+**Easier:**
+- `gibbs.seed(42).sample(null, N)` is genuinely reproducible for any conditional that draws from the supplied `rng` — closing the specific gap issue #938 reports, using the same `this.r`/`seed()` machinery every other part of `MCMC` already relies on.
+- `Gibbs`'s public API stays uniform with every other `MCMC` subclass: `seed()` works (does not throw) on `RWM`, `AdaptiveMetropolis`, `HMC`, and `Gibbs` alike, so generic code that seeds an arbitrary sampler instance does not need a `Gibbs`-specific exception.
+- The change is a single line in `_iter()`; no new base-class hook, no new constructor parameter, no change to `MCMC` itself — consistent with ADR-0020's contract that new sampler families extend via their own `_iter`/`_adjust`/`_internal`, not via base-class changes.
+
+**Harder:**
+- The fix is opt-in, not automatic: a caller who writes the "natural" conditional style (`x => new Normal(mu(x), sigma).sample()`, capturing its own unseeded generator) still gets non-reproducible output after calling `.seed()`, with no error or warning. JSDoc and README must be explicit that reproducibility requires conditionals to consume the second `rng` argument, or the same silent-contract-violation shape resurfaces one level down.
+- Conditionals that want non-uniform draws (e.g. Normal) from the threaded `rng` must either implement their own inverse-CDF/Box-Muller transform against `rng.next()`, or construct a `Distribution` once (outside the hot path) and seed it from a value derived from `rng` — there is no built-in helper for "give me a reproducible Normal draw from this raw PRNG" inside a conditional today.

--- a/solutions/correctness/2026-07-16-0600-gibbs-seed-rng-threading.md
+++ b/solutions/correctness/2026-07-16-0600-gibbs-seed-rng-threading.md
@@ -1,0 +1,55 @@
+---
+date: 2026-07-16T06:00:18Z
+category: "correctness"
+problem: "ran.mc.Gibbs's inherited seed() silently failed to make sampling reproducible because Gibbs._iter() never read the sampler's own PRNG"
+status: complete
+related_issue: "#938"
+related_plan: "thoughts/plans/2026-07-15-2108-gibbs-seed-rng-threading.md"
+tags: [mcmc, gibbs, seed, reproducibility, prng, distribution-constructor, subclass-contract, opt-in]
+---
+
+# Solution: Gibbs Conditionals Receive the Sampler's PRNG So seed() Actually Reproduces
+
+**Date**: 2026-07-16T06:00:18Z
+**Category**: correctness
+**Related Issue**: #938
+
+## Problem
+
+`ran.mc.Gibbs` extends `MCMC` and inherits `seed(value)`, whose JSDoc promises "seed the PRNG for reproducible chains." In practice, `gibbs.seed(42).sample(null, N)` called twice produced different output each time — a silent violation of a documented public-API contract.
+
+This was not a fresh discovery: the exact same root cause had already surfaced once as a CI flake in an unrelated PR and was patched at the test level only (`solutions/testing/2026-07-15-2015-gibbs-conditionals-fresh-normal-seed-noop.md`), with that solution's own "Prevention Strategy" section explicitly flagging that the underlying library-level gap still needed a real fix rather than another test-side workaround. Issue #938 is that follow-up.
+
+## Root Cause
+
+`Gibbs._iter()` (`src/mc/gibbs.js`) never read `this.r` (the sampler's own PRNG, inherited from `MCMC`). Every per-iteration draw came from calling `this._conditionals[d](x1)` — an opaque, caller-supplied closure. The natural, idiomatic way to write a Gibbs conditional (`x => new Normal(rho * x[1], sigma).sample()`) constructs its own `Distribution` instance, and `Distribution`'s constructor seeds itself from `Math.random()` unless explicitly told otherwise (`src/core/xoshiro.js`). So `MCMC.seed()` (inherited unmodified by `Gibbs`) reseeded `this.r`, but `this.r` was structurally unreachable from inside the conditional closures — the sampler's PRNG and the conditionals' actual source of randomness were two disconnected systems, and nothing in the base class could bridge them.
+
+This is the same shape of bug as `RWM`'s pre-fix state (see ADR-0022 context): a subclass whose real randomness lives in an object the base class's `seed()` doesn't know about. `RWM` closed that gap by overriding `seed()` to explicitly reseed its internally-owned `this._q` proposal generator. `Gibbs` had no equivalent internal object — its randomness lived entirely inside caller-supplied, opaque closures — so the `RWM` pattern couldn't be applied directly without first giving conditionals a way to draw from a sampler-owned, reseedable source.
+
+## Fix
+
+`Gibbs._iter()` now calls `this._conditionals[d](x1, this.r)`, threading the sampler's own PRNG into each conditional call as an additive second argument. No `Gibbs.seed()` override was added — the inherited `MCMC.seed()` already reseeds `this.r`, and that's the same object now passed through, so seeding the sampler and seeding the conditionals' draws become the same operation for any conditional that opts in (e.g. via `rng.next()`).
+
+Three alternatives were evaluated in ADR-0026 (`decisions/0026-gibbs-seed-rng-threading.md`):
+1. **Thread `this.r` into conditionals** (chosen) — additive, no `seed()` override, follows the "randomness flows through `this.r`" pattern used elsewhere in `_iter()`-based samplers.
+2. **Throw from `seed()`** — smallest diff, but doesn't solve the problem at all, and makes `Gibbs` the only `MCMC` subclass whose `seed()` doesn't work.
+3. **Duck-typed `.seed()` protocol on conditional functions** — no precedent anywhere in the codebase for attaching methods to closures; rejected as unnatural and prone to partial-reproducibility footguns.
+
+This is explicitly an **opt-in, not automatic** fix: conditionals written in the pre-existing single-argument style continue to work unchanged (JavaScript silently drops unused trailing arguments) and remain exactly as non-reproducible as before. This asymmetry is intentional and documented in both the class JSDoc and ADR-0026 — it is a real, acknowledged limitation (the base class cannot force an opaque closure to consume a particular randomness source), not an oversight.
+
+Tests (`test/mc.js`, `describe('.seed()', ...)` under `mc.Gibbs`) verify the actual data path, not merely that `.seed()` was called: conditionals in the new test explicitly call `rng.next()`, and two identically-seeded `Gibbs` instances are asserted `deepEqual` on their full sample output across three seeds, with a divergence check across different seeds and a backward-compatibility check that old-style (rng-ignoring) conditionals still run without error.
+
+## Prevention Strategy
+
+When a base class (`MCMC`, `Distribution`, etc.) documents a `seed()`/reproducibility contract, check every subclass for hidden randomness sources that don't flow through the class's own PRNG field — particularly anywhere a subclass delegates sampling to a caller-supplied closure or constructs a nested `Distribution` instance internally. `RWM`, `AdaptiveMetropolis`, and `HMC` already follow the correct pattern (own an internal generator such as `this._q`, reseed it explicitly inside an overridden `seed()`); any new `MCMC` subclass should be checked against that pattern before merge. Any subclass whose randomness lives inside an opaque caller-supplied function needs an explicit design decision (thread the PRNG through, throw, or some other explicit contract) recorded in an ADR before shipping — not discovered later via a CI flake, as happened here.
+
+More generally: **a "seeded, deterministic" claim on a test is only as strong as the actual data path it exercises** (echoing the prior solution's key insight). When writing a reproducibility test for any sampler, verify the conditional/closure under test actually consumes the seeded generator — a test that merely calls `.seed(...)` somewhere is not proof the seed reaches every source of randomness the assertions depend on.
+
+## Related Solutions
+
+- [`solutions/testing/2026-07-15-2015-gibbs-conditionals-fresh-normal-seed-noop.md`](../testing/2026-07-15-2015-gibbs-conditionals-fresh-normal-seed-noop.md) — the prior incident this issue follows up on: a test-level-only workaround for the identical root cause, which explicitly called for the library-level fix this solution documents.
+- [`solutions/correctness/2026-07-11-1230-mcmc-state-key-mismatch-silent-sigma-loss.md`](2026-07-11-1230-mcmc-state-key-mismatch-silent-sigma-loss.md) — a different flavor of the same underlying lesson: a test that only checks the visible surface can pass while the guaranteed contract is silently broken underneath.
+
+## Key Insight
+
+A subclass's inherited `seed()` only reproduces randomness that actually flows through the class's own PRNG field — if a subclass delegates draws to caller-supplied closures or lets them construct their own `Distribution` instances, `seed()` silently does nothing for that randomness unless the PRNG is explicitly threaded through the delegation boundary, and even then only for closures that choose to consume it.

--- a/src/mc/gibbs.js
+++ b/src/mc/gibbs.js
@@ -10,9 +10,13 @@ import MCMC from './_mcmc'
  * @class Gibbs
  * @memberof ran.mc
  * @param {Function[]} conditionals Array of samplers, one per dimension. The d-th function is
- * called with the current full state (an array where index d is about to be replaced) and must
- * return a single draw from the full conditional distribution of dimension d given the rest of
- * the state.
+ * called as `conditionals[d](x, rng)` with the current full state (an array where index d is
+ * about to be replaced) and the sampler's own PRNG (exposing `rng.next(): number`, a uniform
+ * variate in [0, 1)), and must return a single draw from the full conditional distribution of
+ * dimension d given the rest of the state. `seed()` only reproduces a conditional's draws if the
+ * conditional actually consumes `rng` for its own randomness (e.g. `rng.next()`); a conditional
+ * that ignores `rng` and constructs its own independent generator remains non-reproducible
+ * regardless of `seed()` — see decisions/0026-gibbs-seed-rng-threading.md.
  * @param {Object=} config Sampler configuration (see MCMC base class for shared options). `dim`
  * defaults to `conditionals.length`; if provided explicitly it must match `conditionals.length`.
  * @param {Object=} initialState Initial state of the sampler (see MCMC base class).
@@ -22,6 +26,10 @@ import MCMC from './_mcmc'
  */
 // decisions/0020-mcmc-design.md — the _iter/_adjust/_internal contract was designed for exactly
 // this pattern: a full sweep that is always accepted, with no adaptive state to carry across.
+// decisions/0026-gibbs-seed-rng-threading.md — conditionals receive this.r as a second argument
+// so seed() can reach conditional-internal randomness for conditionals that opt in.
+// solutions/correctness/2026-07-16-0600-gibbs-seed-rng-threading.md — root cause and prevention
+// strategy for this seed()/conditional-randomness gap.
 export default class Gibbs extends MCMC {
   constructor (conditionals, config = {}, initialState = {}) {
     if (!Array.isArray(conditionals) || conditionals.length === 0) {
@@ -44,8 +52,10 @@ export default class Gibbs extends MCMC {
     const x1 = x.slice()
     for (let d = 0; d < this.dim; d++) {
       // Each conditional sees dimensions already updated earlier in this sweep, per the
-      // systematic-scan definition (Geman & Geman 1984) — not the pre-sweep state.
-      x1[d] = this._conditionals[d](x1)
+      // systematic-scan definition (Geman & Geman 1984) — not the pre-sweep state. this.r is
+      // passed through (decisions/0026-gibbs-seed-rng-threading.md) so seed() can reach
+      // conditional-internal randomness for conditionals that opt in to using it.
+      x1[d] = this._conditionals[d](x1, this.r)
     }
     return { x: x1, accepted: true }
   }

--- a/test/mc.js
+++ b/test/mc.js
@@ -743,6 +743,51 @@ describe('mc.Gibbs', () => {
       assert.doesNotThrow(() => gibbs2.iterate())
     })
   })
+
+  describe('.seed()', () => {
+    // Deliberately not a statistically meaningful conditional (distributional
+    // correctness is already covered by the KS test above) — this exists only
+    // to exercise rng.next() so the assertion tests the actual seeded data
+    // path, not merely that .seed() was called. See
+    // solutions/testing/2026-07-15-2015-gibbs-conditionals-fresh-normal-seed-noop.md
+    const rngConditionals = [
+      (x, rng) => rho * x[1] + sigma * rng.next(),
+      (x, rng) => rho * x[0] + sigma * rng.next()
+    ];
+
+    [0, 42, 12345].forEach(seed => {
+      it(`should produce bitwise-identical samples when seed ${seed} is applied twice`, () => {
+        const gibbs1 = new Gibbs(rngConditionals, { dim: 2 }, { x: [0, 0] }).seed(seed)
+        gibbs1.warmUp(null, 3)
+        const samples1 = gibbs1.sample(null, 50)
+
+        const gibbs2 = new Gibbs(rngConditionals, { dim: 2 }, { x: [0, 0] }).seed(seed)
+        gibbs2.warmUp(null, 3)
+        const samples2 = gibbs2.sample(null, 50)
+
+        assert.deepEqual(samples1, samples2)
+      })
+    })
+
+    it('should produce different samples for different seeds', () => {
+      const gibbs0 = new Gibbs(rngConditionals, { dim: 2 }, { x: [0, 0] }).seed(0)
+      gibbs0.warmUp(null, 3)
+      const samples0 = gibbs0.sample(null, 50)
+
+      const gibbs1 = new Gibbs(rngConditionals, { dim: 2 }, { x: [0, 0] }).seed(1)
+      gibbs1.warmUp(null, 3)
+      const samples1 = gibbs1.sample(null, 50)
+
+      assert.notDeepEqual(samples0, samples1)
+    })
+
+    it('should still produce finite, well-formed samples for conditionals that ignore the second (rng) argument', () => {
+      const gibbs = new Gibbs(conditionals, { dim: 2 }, { x: [0, 0] }).seed(42)
+      const samples = gibbs.sample(null, 10)
+      assert.strictEqual(samples.length, 10)
+      assert(samples.every(s => s.length === 2 && s.every(Number.isFinite)))
+    })
+  })
 })
 
 describe('mc.HMC', () => {


### PR DESCRIPTION
Closes #938

## Summary
- `ran.mc.Gibbs` inherited `MCMC.seed()`, whose JSDoc promises "seed the PRNG for reproducible chains," but `Gibbs._iter()` never read `this.r` — every draw came from caller-supplied `conditionals` closures, which typically own independent, unseeded randomness. `gibbs.seed(42).sample(null, N)` called twice silently produced different output.
- `Gibbs._iter()` now calls each conditional as `conditionals[d](x, rng)`, threading the sampler's own PRNG (`this.r`) through as a second argument. No `Gibbs.seed()` override is needed — the inherited `MCMC.seed()` already reseeds `this.r`, the same object now passed through, so reproducibility becomes achievable for conditionals that consume `rng.next()`.
- This is deliberately opt-in, not automatic: conditionals written in the pre-existing single-argument style keep working unchanged (JS silently drops unused trailing arguments) and remain exactly as non-reproducible as before — documented explicitly in JSDoc and the ADR rather than left as a second silent gap.

## Design decisions
- [ADR-0026: Gibbs Conditionals Receive the Sampler's PRNG as a Second Argument](decisions/0026-gibbs-seed-rng-threading.md) — evaluates three options (thread `this.r` into conditionals, override `seed()` to throw, duck-typed `.seed()` protocol on conditional functions) and picks PRNG-threading as the only one that provides a genuine path to reproducibility rather than converting the silent failure into a documented dead end.

## Non-trivial changes
- **`src/mc/gibbs.js`**: `_iter()` changed from `this._conditionals[d](x1)` to `this._conditionals[d](x1, this.r)` — the sampler's PRNG is now reachable from inside conditional closures. Class-level JSDoc rewritten to document the two-argument calling convention and the opt-in reproducibility contract.
- **`test/mc.js`**: new `describe('.seed()', ...)` block under `mc.Gibbs` — bitwise-identical-sample assertions across three seeds for conditionals that consume `rng.next()`, a divergence check across different seeds, and a backward-compatibility check that pre-existing rng-ignoring conditionals still produce finite, well-formed samples. Conditionals in the new tests deliberately call `rng.next()` directly (rather than merely accepting an unused second parameter) so the assertions exercise the real seeded data path — see the linked prior incident below for why that distinction matters.

## Comprehension checklist
- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`README.md`**: Gibbs row in the `## MC API` samplers table updated to document the `conditionals[d](x, rng)` signature and the opt-in reproducibility contract.
- **`CHANGELOG.md`**: adds a `### Fixed` entry under `[Unreleased]`.
- **`CLAUDE.md`**: removes a stale parenthetical claiming `SliceSampler` was removed and its re-add tracked in #822 — `SliceSampler` was in fact re-implemented, exported, and tested some time ago; the note was misleading contributors about current repo state (found via bug triage during this session, unrelated to #938's scope).
- **`solutions/correctness/2026-07-16-0600-gibbs-seed-rng-threading.md`**: solution write-up documenting root cause and prevention strategy — this is the second, library-level fix following up on a prior test-only workaround for the same underlying gap (`solutions/testing/2026-07-15-2015-gibbs-conditionals-fresh-normal-seed-noop.md`).

</details>

**Note**: issue #953 ("Gibbs conditionals silently defeat gibbs.seed() when they construct fresh Distribution instances") is a near-duplicate of #938, filed separately while a different PR was being babysat. This PR's fix substantively resolves #953's acceptance criteria too (it implements the "design fix" direction #953 poses as one of its two options) — flagging here rather than closing it directly, since that's outside this PR's explicit scope.

---
*Generated with [Claude Code](https://claude.ai/code)*


---
_Generated by [Claude Code](https://claude.ai/code/session_0186toSrx6oN7Zqr5SSvfrHi)_