### PR TITLE
Extract shared seed()-reseed pattern from RWM/AdaptiveMetropolis/HMC

### DIFF
--- a/decisions/0026-mcmc-reseed-cached-log-density-hook.md
+++ b/decisions/0026-mcmc-reseed-cached-log-density-hook.md
@@ -1,0 +1,52 @@
+# ADR-0026: Shared `_reseedCachedLogDensity` Protected Method for Metropolis-Family Samplers
+
+**Date**: 2026-07-15
+**Status**: Accepted
+
+## Context
+
+`RWM.seed()` (`src/mc/rwm.js`), `AdaptiveMetropolis.seed()` (`src/mc/adaptive-metropolis.js`), and `HMC.seed()` (`src/mc/hmc.js`) independently implement a byte-for-byte identical four-line override: call `super.seed(value)`, reseed their own `Normal(0, 1)` proposal/momentum generator (`this._q`), and recompute their cached log-density (`this.lastLnp = this.lnp(this.x)`) because `super.seed()` may have redrawn `this.x`. The inline comment explaining why the recompute is needed is copy-pasted identically in all three files.
+
+ADR-0020 established `_iter`/`_adjust`/`_internal` as the only protected hooks in the `MCMC` subclass contract and noted that no fourth hook had been needed by any sampler family added so far. ADR-0022 stated that shared adaptation machinery should be extracted from `RWM`-family samplers "only when a second sampler family makes the common shape observable, not invented speculatively from a single subclass." That bar has since been cleared three times over: `RWM`, `AdaptiveMetropolis`, and `HMC` all independently arrived at the identical reseed-and-recompute logic. Issue #950 was filed specifically citing this precedent — extraction was deferred at #824 (HMC) review, but flagged once a second (now third) subclass exercised the identical pattern.
+
+`Gibbs` and `SliceSampler`-related code have neither a subclass-owned PRNG component nor a cached log-density, so they are unaffected. `ARS` has its own `seed()` override that only reseeds the base `this.r` and does not share this pattern.
+
+## Decision
+
+Add a protected instance method `_reseedCachedLogDensity(value)` to `MCMC` (`src/mc/_mcmc.js`):
+
+```js
+_reseedCachedLogDensity (value) {
+  this._q.seed(value)
+  this.lastLnp = this.lnp(this.x)
+}
+```
+
+Each of `RWM`, `AdaptiveMetropolis`, and `HMC` reduces its `seed()` override to:
+
+```js
+seed (value) {
+  super.seed(value)
+  this._reseedCachedLogDensity(value)
+  return this
+}
+```
+
+This is deliberately **not** a new entry in the `_iter`/`_adjust`/`_internal` contract from ADR-0020: it is not invoked automatically by any base-class control flow (unlike `_iter`, which `iterate()` calls, or `_adjust`, which `warmUp()` calls). It is a plain protected helper that a subclass's own `seed()` override calls explicitly, exactly as the issue's own suggested example (`_reseedCachedLogDensity`) named it. `MCMC.seed()` itself is unchanged. Subclasses without a `_q`/`lastLnp` pair (`Gibbs`, `SliceSampler`) simply never call it — there is no default no-op to maintain, and no behavior change for them.
+
+This was chosen over two alternatives considered:
+- **A standalone utility function** (e.g. `src/mc/_reseed-proposal.js` exporting `reseedProposal(sampler, value)`) — rejected because it introduces a duck-typing pattern (an external function reaching into `sampler._q`/`sampler.lastLnp`) with no precedent anywhere in `src/mc/` or `src/dist/`, where private helper files are self-contained algorithms or base classes, not object-mutating functions over parameters.
+- **A new intermediate `MetropolisMCMC` abstract class** between `MCMC` and the three subclasses, owning `_q`/`lastLnp` construction and `seed()` entirely — rejected because it was not one of the two mechanisms the issue named, is disproportionate to a `trivial`/`low` issue (a hierarchy change across three call sites to deduplicate roughly eight lines), and is complicated by `HMC`'s constructor carrying an extra `gradLogDensity` argument that the other two subclasses don't have, which a fully shared constructor cannot cleanly absorb.
+
+These three options were independently scored by a three-judge panel that split 1-1-1, each vote self-reporting "High confidence." See solutions/tooling/2026-07-16-0624-design-panel-confidence-vs-verified-premises.md for how the tie was broken (by re-verifying each vote's cited premise against the codebase rather than by vote count) and why trusting an issue's Scope section at face value would have missed `AdaptiveMetropolis` entirely.
+
+## Consequences
+
+**Easier:**
+- The reseed-and-recompute logic and its rationale comment exist in exactly one place; a future Metropolis-family sampler that owns a `_q`/`lastLnp` pair can reuse `_reseedCachedLogDensity` from its own `seed()` override instead of copy-pasting a fourth time.
+- No behavior change for any existing sampler; `test/mc.js`'s existing seed-reproducibility tests for `RWM`, `AdaptiveMetropolis`, and `HMC` continue to exercise the same effective logic unchanged.
+- `Gibbs`, `SliceSampler`, and `ARS` are entirely unaffected — the new method is opt-in per subclass, not a base-class control-flow change.
+
+**Harder:**
+- `MCMC` now has one protected method beyond the `_iter`/`_adjust`/`_internal` contract that is not part of that contract's automatic invocation. Future readers of `_mcmc.js` must recognize `_reseedCachedLogDensity` as an explicitly-called helper, not a fourth override-me-or-else hook like the other three.
+- If a future sampler owns a cached quantity that depends on `this.x` but is *not* named `lastLnp`, or a PRNG component not named `_q`, `_reseedCachedLogDensity` would need generalizing (e.g. parameterizing the field names) rather than being reused as-is.

--- a/decisions/0027-mcmc-reseed-cached-log-density-hook.md
+++ b/decisions/0027-mcmc-reseed-cached-log-density-hook.md
@@ -1,4 +1,4 @@
-# ADR-0026: Shared `_reseedCachedLogDensity` Protected Method for Metropolis-Family Samplers
+# ADR-0027: Shared `_reseedCachedLogDensity` Protected Method for Metropolis-Family Samplers
 
 **Date**: 2026-07-15
 **Status**: Accepted
@@ -38,7 +38,7 @@ This was chosen over two alternatives considered:
 - **A standalone utility function** (e.g. `src/mc/_reseed-proposal.js` exporting `reseedProposal(sampler, value)`) — rejected because it introduces a duck-typing pattern (an external function reaching into `sampler._q`/`sampler.lastLnp`) with no precedent anywhere in `src/mc/` or `src/dist/`, where private helper files are self-contained algorithms or base classes, not object-mutating functions over parameters.
 - **A new intermediate `MetropolisMCMC` abstract class** between `MCMC` and the three subclasses, owning `_q`/`lastLnp` construction and `seed()` entirely — rejected because it was not one of the two mechanisms the issue named, is disproportionate to a `trivial`/`low` issue (a hierarchy change across three call sites to deduplicate roughly eight lines), and is complicated by `HMC`'s constructor carrying an extra `gradLogDensity` argument that the other two subclasses don't have, which a fully shared constructor cannot cleanly absorb.
 
-These three options were independently scored by a three-judge panel that split 1-1-1, each vote self-reporting "High confidence." See solutions/tooling/2026-07-16-0624-design-panel-confidence-vs-verified-premises.md for how the tie was broken (by re-verifying each vote's cited premise against the codebase rather than by vote count) and why trusting an issue's Scope section at face value would have missed `AdaptiveMetropolis` entirely.
+These three options were independently scored by a three-judge panel that split 1-1-1, each vote self-reporting "High confidence." See `solutions/tooling/2026-07-16-0624-design-panel-confidence-vs-verified-premises.md` for how the tie was broken (by re-verifying each vote's cited premise against the codebase rather than by vote count) and why trusting an issue's Scope section at face value would have missed `AdaptiveMetropolis` entirely.
 
 ## Consequences
 

--- a/solutions/tooling/2026-07-16-0624-design-panel-confidence-vs-verified-premises.md
+++ b/solutions/tooling/2026-07-16-0624-design-panel-confidence-vs-verified-premises.md
@@ -33,7 +33,7 @@ Two independent gaps compounded into this outcome:
 - Migrated all three affected subclasses (`RWM`, `AdaptiveMetropolis`, `HMC`) — not just the two the issue named — after research surfaced the third occurrence by reading the source directly instead of trusting the issue body's file list.
 - Added a plain protected instance method `_reseedCachedLogDensity(value)` to `MCMC` (`src/mc/_mcmc.js`), explicitly called (never auto-invoked) from each subclass's own `seed()` override — matching one of the two mechanisms the issue itself had named, and the issue's own suggested method name.
 - Broke the 1-1-1 judge tie by re-verifying each vote's cited premise against the actual codebase/ADR text rather than by counting votes or trusting the self-reported confidence labels: counting how many times the ADR-0022 "second family" threshold had actually been crossed (three, not zero) discredited the "do-nothing" vote; checking the issue's literal Scope wording discredited the "intermediate class" vote. The surviving "plain protected method" vote was the only one whose cited premises held up under direct verification.
-- Documented the decision, and the two rejected alternatives with their specific flaws, in `decisions/0026-mcmc-reseed-cached-log-density-hook.md`.
+- Documented the decision, and the two rejected alternatives with their specific flaws, in `decisions/0027-mcmc-reseed-cached-log-density-hook.md`.
 
 ## Prevention Strategy
 

--- a/solutions/tooling/2026-07-16-0624-design-panel-confidence-vs-verified-premises.md
+++ b/solutions/tooling/2026-07-16-0624-design-panel-confidence-vs-verified-premises.md
@@ -1,0 +1,51 @@
+---
+date: 2026-07-16T06:24:50Z
+category: "tooling"
+problem: "Independent design-propose/critique/judge-panel agents each returned contradictory 'High confidence' recommendations for a trivial refactor"
+status: complete
+related_issue: "#950"
+related_plan: "thoughts/plans/2026-07-15-2115-seed-reseed-duplication-rwm-hmc.md"
+tags: [multi-agent, design-review, confidence-calibration, issue-scope-verification, adr, judge-panel]
+---
+
+# Solution: Design-panel "High confidence" votes don't correlate with verified premises
+
+**Date**: 2026-07-16T06:24:50Z
+**Category**: tooling
+**Related Issue**: #950
+
+## Problem
+
+Issue #950 asked to deduplicate an identical `seed()` override (reseed a subclass-owned `Normal(0,1)` proposal generator, then recompute a cached log-density) copy-pasted across `RWM.seed()` and `HMC.seed()`. The issue's own Scope section explicitly deferred the extraction-mechanism choice ("a protected base-class method... or a standalone shared utility... should be made when this issue is picked up") between exactly two named options.
+
+Resolving that one open decision required escalating through a design-propose agent, a design-critique agent, and — because they disagreed — a three-judge panel (simplicity/structure lens, convention lens, maintainability lens). The three judges split 1-1-1 across three *mutually exclusive* options (a new intermediate class, doing nothing, and a plain protected method), and **every one of the three votes was labeled "High confidence."** No amount of adding more independent agents converged on an answer; the orchestrating session had to manually adjudicate the tie by re-checking each vote's cited justification against the actual codebase.
+
+## Root Cause
+
+Two independent gaps compounded into this outcome:
+
+1. **The issue's stated Scope was incomplete, and no agent caught this until the codebase was read directly.** `AdaptiveMetropolis.seed()` (a third file, not `rwm.js`/`hmc.js`) had the byte-for-byte identical pattern, but the issue never named it — whoever filed it apparently checked the two files they remembered rather than grepping the whole `src/mc/` directory. Had the fix been scoped to exactly the two named files, it would have shipped a third, now-inconsistent copy of the same logic on the same day the issue closed. This was only caught because the `/research` phase read every file in `src/mc/`, not just the ones the issue body listed.
+
+2. **A judge's self-reported "High confidence" reflects internal argument coherence, not verified correctness of its premises.** The "do-nothing" judge (convention lens) cited ADR-0022's real rule — "extract shared logic only once a second sampler family demonstrates the pattern" — as grounds for High confidence that no refactor was warranted. But the rule's precondition (has a second family actually demonstrated the pattern?) was never checked against the codebase: the pattern had already occurred **three times** (RWM, AdaptiveMetropolis, HMC), which is the literal reason the issue existed. The judge quoted a real ADR correctly and still reached a false conclusion, because it treated the citation itself as sufficient evidence rather than checking the citation's premise. Symmetrically, the "intermediate class" judge (simplicity lens) was confidently wrong for the opposite reason: it treated "eliminates the most lines of duplication" as the deciding criterion without checking that the proposed mechanism fell entirely outside the two options the issue itself had scoped, and without accounting for `HMC`'s extra `gradLogDensity` constructor argument breaking the shared-constructor claim its own proposal depended on.
+
+## Fix
+
+- Migrated all three affected subclasses (`RWM`, `AdaptiveMetropolis`, `HMC`) — not just the two the issue named — after research surfaced the third occurrence by reading the source directly instead of trusting the issue body's file list.
+- Added a plain protected instance method `_reseedCachedLogDensity(value)` to `MCMC` (`src/mc/_mcmc.js`), explicitly called (never auto-invoked) from each subclass's own `seed()` override — matching one of the two mechanisms the issue itself had named, and the issue's own suggested method name.
+- Broke the 1-1-1 judge tie by re-verifying each vote's cited premise against the actual codebase/ADR text rather than by counting votes or trusting the self-reported confidence labels: counting how many times the ADR-0022 "second family" threshold had actually been crossed (three, not zero) discredited the "do-nothing" vote; checking the issue's literal Scope wording discredited the "intermediate class" vote. The surviving "plain protected method" vote was the only one whose cited premises held up under direct verification.
+- Documented the decision, and the two rejected alternatives with their specific flaws, in `decisions/0026-mcmc-reseed-cached-log-density-hook.md`.
+
+## Prevention Strategy
+
+- **Treat an issue's "Scope" section as a hypothesis, not a complete file list.** Before finalizing a fix's scope, grep/read the whole relevant module directory — not just the files the issue names — for the same pattern. A research phase that only reads the files an issue lists inherits any gaps in the issue author's own memory.
+- **When independent design agents (propose/critique/judge panels) disagree, do not resolve by vote count or by comparing self-reported confidence labels across agents.** Confidence labels are not calibrated against each other — three independent "High confidence" votes for three mutually exclusive answers is possible and, per this session, actually happened. Treat disagreement as a signal to re-verify, not to average or plurality-vote.
+- **Resolve ties by checking each vote's factual premise against the artifact it cites, not by re-reading the vote's prose for persuasiveness.** A citation of a real, correctly-quoted ADR or convention can still support a false conclusion if the citation's precondition was never checked. When a vote leans on "rule X says Y," verify Y's precondition against the current codebase state before accepting the vote.
+- **A proposed design option that falls outside an issue's explicitly named candidate mechanisms should be treated as scope creep by default**, not as equally admissible alongside the options the issue actually scoped — especially for `trivial`/`low`-priority issues where a heavier mechanism (new class, new file, new ADR-worthy hierarchy change) is disproportionate on its face.
+
+## Related Solutions
+
+- `solutions/tooling/2026-07-07-1601-agent-output-contract-caller-sync.md` — a different class of multi-agent reliability issue (output-format drift between agent versions and their callers), but shares the theme that agent-pipeline output must be independently verified rather than trusted at face value.
+
+## Key Insight
+
+When a design-propose/critique/judge-panel pipeline returns contradictory "High confidence" votes, resolve the tie by re-verifying each vote's factual premise against the codebase — not by counting votes or trusting self-reported confidence — because a judge's confidence measures how coherent its own argument feels to it, not whether the argument's premise is actually true.

--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -236,6 +236,26 @@ export default class MCMC {
   }
 
   /**
+   * Reseeds a subclass-owned proposal/momentum generator (`this._q`) and recomputes a
+   * subclass-owned cached log-density (`this.lastLnp`) against the current `this.x`. Explicitly
+   * called by a subclass's own `seed()` override — never invoked automatically by base-class
+   * control flow — so subclasses without a `_q`/`lastLnp` pair (e.g. Gibbs, SliceSampler) are
+   * unaffected.
+   *
+   * @method _reseedCachedLogDensity
+   * @memberof ran.mc.MCMC
+   * @param {number|string} value The seed value passed to the sampler's `seed()` method.
+   * @protected
+   * @ignore
+   */
+  // decisions/0026-mcmc-reseed-cached-log-density-hook.md — extracted reseed-and-recompute logic
+  // shared by RWM, AdaptiveMetropolis, and HMC into one explicitly-called protected method
+  _reseedCachedLogDensity (value) {
+    this._q.seed(value)
+    this.lastLnp = this.lnp(this.x)
+  }
+
+  /**
    * Performs a single iteration. Must be overridden.
    *
    * @method _iter

--- a/src/mc/_mcmc.js
+++ b/src/mc/_mcmc.js
@@ -248,7 +248,7 @@ export default class MCMC {
    * @protected
    * @ignore
    */
-  // decisions/0026-mcmc-reseed-cached-log-density-hook.md — extracted reseed-and-recompute logic
+  // decisions/0027-mcmc-reseed-cached-log-density-hook.md — extracted reseed-and-recompute logic
   // shared by RWM, AdaptiveMetropolis, and HMC into one explicitly-called protected method
   _reseedCachedLogDensity (value) {
     this._q.seed(value)

--- a/src/mc/adaptive-metropolis.js
+++ b/src/mc/adaptive-metropolis.js
@@ -54,10 +54,7 @@ export default class AdaptiveMetropolis extends MCMC {
    */
   seed (value) {
     super.seed(value)
-    this._q.seed(value)
-    // super.seed() may have redrawn this.x from the newly seeded generator, so lastLnp
-    // (computed against the pre-seed x at construction time) must be recomputed to match.
-    this.lastLnp = this.lnp(this.x)
+    this._reseedCachedLogDensity(value)
     return this
   }
 

--- a/src/mc/hmc.js
+++ b/src/mc/hmc.js
@@ -89,10 +89,7 @@ export default class HMC extends MCMC {
    */
   seed (value) {
     super.seed(value)
-    this._q.seed(value)
-    // super.seed() may have redrawn this.x from the newly seeded generator, so lastLnp
-    // (computed against the pre-seed x at construction time) must be recomputed to match.
-    this.lastLnp = this.lnp(this.x)
+    this._reseedCachedLogDensity(value)
     return this
   }
 

--- a/src/mc/rwm.js
+++ b/src/mc/rwm.js
@@ -57,10 +57,7 @@ export default class RWM extends MCMC {
    */
   seed (value) {
     super.seed(value)
-    this._q.seed(value)
-    // super.seed() may have redrawn this.x from the newly seeded generator, so lastLnp
-    // (computed against the pre-seed x at construction time) must be recomputed to match.
-    this.lastLnp = this.lnp(this.x)
+    this._reseedCachedLogDensity(value)
     return this
   }
 


### PR DESCRIPTION
## Summary

`RWM.seed()`, `AdaptiveMetropolis.seed()`, and `HMC.seed()` each independently implemented a byte-for-byte identical override (reseed their own `Normal(0,1)` proposal/momentum generator, then recompute a cached log-density since `super.seed()` may have redrawn `this.x`). This PR consolidates that logic into one new protected instance method, `MCMC._reseedCachedLogDensity(value)`, called explicitly by all three subclasses' `seed()` overrides.

Closes #950

## Design decisions

- [ADR-0027: Shared `_reseedCachedLogDensity` protected method for Metropolis-family samplers](decisions/0027-mcmc-reseed-cached-log-density-hook.md) — adds one protected, explicitly-called (not auto-invoked) helper method to `MCMC`; rejects a standalone duck-typed utility function (no precedent in `src/mc/`) and a new intermediate `MetropolisMCMC` class (exceeds the two mechanisms the issue named, complicated by HMC's extra `gradLogDensity` constructor argument).

## Non-trivial changes

- **`src/mc/_mcmc.js`**: Adds `_reseedCachedLogDensity(value)` as a new protected method on the `MCMC` base class — the first protected method added since ADR-0020 fixed the `_iter`/`_adjust`/`_internal` subclass contract. It is deliberately *not* a fourth entry in that contract: it's not auto-invoked by any base-class control flow (unlike `_iter`/`_adjust`), just a plain helper a subclass's own `seed()` calls explicitly. Reached via a design-propose → design-critique → three-judge-panel process that split 1-1-1 across three mutually exclusive options; see the ADR and `solutions/tooling/2026-07-16-0624-design-panel-confidence-vs-verified-premises.md` for how the tie was broken and why the pattern was found in `AdaptiveMetropolis` too, even though the issue's own Scope section named only `rwm.js`/`hmc.js`.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`src/mc/rwm.js`, `src/mc/adaptive-metropolis.js`, `src/mc/hmc.js`**: Each `seed()` override's inline reseed-and-recompute body replaced with a single call to `this._reseedCachedLogDensity(value)`. Mechanical, no behavior change.

</details>

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 7881 passing, coverage thresholds met)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior — N/A, pure refactor; existing `test/mc.js` seed-reproducibility tests for RWM/AdaptiveMetropolis/HMC cover this unchanged
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped, pure refactor with no user-visible behavior change
- [x] Production-code diff is under ~400 lines (tests excluded) — ~25 net lines across 4 files

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRr2BvC7mGR68uPFFdMjRt)_