### PR TITLE
Add constructor JSDoc to MCMC samplers for typed params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ran.mc.MCMC.warmUp(progress, maxBatches)` now runs exactly `maxBatches` batches (was `maxBatches + 1` due to a `batch <= maxBatches` loop bound) and reports `100` at completion instead of firing a redundant `0%` callback at the start.
 - `ran.mc.MCMC.sample(progress, size)` now reports each integer percentage of progress exactly once. Previously the `i % (iMax/100)` check used a fractional modulus whenever the total iteration count was not a multiple of 100, silently skipping most progress callbacks.
 - `ran.mc.Gibbs`'s conditionals now receive the sampler's own PRNG as a second argument (`conditionals[d](x, rng)`), so `seed()` can produce reproducible chains for conditionals that draw their randomness from `rng.next()` instead of an independently-seeded generator. Previously `Gibbs._iter()` never read `this.r`, so `gibbs.seed(42).sample(null, N)` silently failed to reproduce, violating the contract documented on `MCMC.seed()` (ADR-0026, #938).
+- `ran.mc.RWM`, `ran.mc.AdaptiveMetropolis`, and `ran.mc.Gibbs` constructors now have a dedicated JSDoc `@param` block directly on `constructor()`, so `tsc`'s generated `.d.ts` resolves the true parameter types (`Function`/`Function[]`) instead of `any`; `Gibbs` previously had no constructor signature in the generated declaration at all (#944).
 
 ### Added
 

--- a/src/mc/adaptive-metropolis.js
+++ b/src/mc/adaptive-metropolis.js
@@ -26,6 +26,11 @@ const EPS = 1e-6
  */
 // decisions/0022-rwm-joint-adaptive-metropolis.md — anticipates full-covariance AM as a separate sampler
 export default class AdaptiveMetropolis extends MCMC {
+  /**
+   * @param {Function} logDensity The logarithm of the (unnormalized) target density.
+   * @param {Object=} config AdaptiveMetropolis configuration (see MCMC base class for shared options).
+   * @param {Object=} initialState Initial state of the sampler (see MCMC base class).
+   */
   constructor (logDensity, config, initialState) {
     super(logDensity, config, initialState)
     this.lastLnp = this.lnp(this.x)

--- a/src/mc/gibbs.js
+++ b/src/mc/gibbs.js
@@ -31,6 +31,21 @@ import MCMC from './_mcmc'
 // solutions/correctness/2026-07-16-0600-gibbs-seed-rng-threading.md — root cause and prevention
 // strategy for this seed()/conditional-randomness gap.
 export default class Gibbs extends MCMC {
+  /**
+   * @param {Function[]} conditionals Array of samplers, one per dimension. The d-th function is
+   * called as `conditionals[d](x, rng)` with the current full state (an array where index d is
+   * about to be replaced) and the sampler's own PRNG (exposing `rng.next(): number`, a uniform
+   * variate in [0, 1)), and must return a single draw from the full conditional distribution of
+   * dimension d given the rest of the state. `seed()` only reproduces a conditional's draws if the
+   * conditional actually consumes `rng` for its own randomness (e.g. `rng.next()`); a conditional
+   * that ignores `rng` and constructs its own independent generator remains non-reproducible
+   * regardless of `seed()` — see decisions/0026-gibbs-seed-rng-threading.md.
+   * @param {Object=} config Sampler configuration (see MCMC base class for shared options). `dim`
+   * defaults to `conditionals.length`; if provided explicitly it must match `conditionals.length`.
+   * @param {Object=} initialState Initial state of the sampler (see MCMC base class).
+   * @throws {Error} If conditionals is not a non-empty array, or config.dim is provided but does not
+   * match conditionals.length.
+   */
   constructor (conditionals, config = {}, initialState = {}) {
     if (!Array.isArray(conditionals) || conditionals.length === 0) {
       throw Error('Gibbs: conditionals must be a non-empty array')

--- a/src/mc/rwm.js
+++ b/src/mc/rwm.js
@@ -30,6 +30,11 @@ const BATCH = 100
  */
 // decisions/0022-rwm-joint-adaptive-metropolis.md — joint diagonal adaptive Metropolis in both phases
 export default class RWM extends MCMC {
+  /**
+   * @param {Function} logDensity The logarithm of the (unnormalized) target density.
+   * @param {Object=} config RWM configuration (see MCMC base class for shared options).
+   * @param {Object=} initialState Initial state of the sampler (see MCMC base class).
+   */
   constructor (logDensity, config, initialState) {
     super(logDensity, config, initialState)
     this.lastLnp = this.lnp(this.x)

--- a/types-test.ts
+++ b/types-test.ts
@@ -74,6 +74,18 @@ const _spear: number | undefined = ran.dependence.spearman([1, 2], [3, 4])
 const _kend: number | undefined = ran.dependence.kendall([1, 2], [3, 4])
 const _cov: number | undefined = ran.dependence.covariance([1, 2], [3, 4])
 
+// mc namespace — constructor params typed via dedicated constructor JSDoc (issue #944)
+const logDensity: (x: number[]) => number = (x) => -0.5 * x[0] * x[0]
+const _rwm = new ran.mc.RWM(logDensity, { dim: 1 })
+const _am = new ran.mc.AdaptiveMetropolis(logDensity, { dim: 1 })
+const _gibbs = new ran.mc.Gibbs([(x: number[]) => x[0]], { dim: 1 })
+// @ts-expect-error - logDensity must be a Function, not a number; guards against the constructor JSDoc block being reverted and tsc widening back to `any`
+new ran.mc.RWM(42, { dim: 1 })
+// @ts-expect-error - logDensity must be a Function, not a number; guards against the constructor JSDoc block being reverted and tsc widening back to `any`
+new ran.mc.AdaptiveMetropolis(42, { dim: 1 })
+// @ts-expect-error - conditionals must be a Function[], not a number[]; guards against the constructor JSDoc block being reverted and tsc widening back to `any`
+new ran.mc.Gibbs([1, 2], { dim: 2 })
+
 // test namespace — all 5 functions
 const _bart = ran.test.bartlett([[1, 2, 3], [4, 5, 6]])
 const _bstat: number = _bart.stat
@@ -92,3 +104,4 @@ void _choice1; void _choice2; void _ch2; void _ch3; void _shuffled; void _coinSi
 void _gm; void _hm; void _med; void _var; void _sd; void _iqr
 void _skew; void _kurt; void _q50; void _pear; void _spear; void _kend; void _cov
 void _bstat; void _bpass; void _bf; void _lev; void _mw; void _hsic
+void _rwm; void _am; void _gibbs


### PR DESCRIPTION
Closes #944

## Summary
- Added dedicated constructor-level JSDoc `@param` blocks to `RWM`, `AdaptiveMetropolis`, and `Gibbs` (`src/mc/*.js`) so `tsc`'s declaration generator resolves typed constructor parameters (`Function`/`Function[]`) instead of `any` — `Gibbs` previously had **no constructor signature at all** in the generated `.d.ts`.
- Added `types-test.ts` regression coverage, including `@ts-expect-error` negative cases, so a future removal of these JSDoc blocks would be caught by `npm run typecheck` (verified by temporarily reverting the fix locally and confirming typecheck fails as expected).
- Added a `CHANGELOG.md` entry under `## [Unreleased] / ### Fixed`.

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical (JSDoc/type-declaration only, no runtime behavior change)._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- `src/mc/rwm.js`, `src/mc/adaptive-metropolis.js`, `src/mc/gibbs.js`: constructor-level JSDoc `@param` blocks added (duplicating the existing class-level documentation — required because `tsc` only reads `@param` tags from the constructor method's own JSDoc block, per CLAUDE.md's TypeScript Declarations convention).
- `types-test.ts`: positive usage lines and `@ts-expect-error` negative cases exercising the three MCMC constructors.
- `CHANGELOG.md`: `### Fixed` bullet added.

</details>

## Checklist
- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (7881 passing)
- [x] `npm run typecheck` passes
- [x] `npm run build && npm run typecheck` confirms generated `dist/mc/*.d.ts` now shows typed constructor params (`logDensity: Function`, `conditionals: Function[]`)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Production-code diff is well under ~400 lines

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgKMwHaguPWETdK3LY4nNi)_