### PR TITLE
Reduce per-iteration array allocations in AdaptiveMetropolis

### DIFF
--- a/src/mc/adaptive-metropolis.js
+++ b/src/mc/adaptive-metropolis.js
@@ -35,6 +35,11 @@ export default class AdaptiveMetropolis extends MCMC {
     this._covN = 0
     this._covMean = new Array(this.dim).fill(0)
     this._covS = Array.from({ length: this.dim }, () => new Array(this.dim).fill(0))
+    // Reusable scratch buffers to avoid per-iteration array allocations in _iter/_updateCovariance.
+    this._zBuffer = new Array(this.dim).fill(0)
+    this._z = new Vector(this._zBuffer)
+    this._delta = new Array(this.dim).fill(0)
+    this._delta2 = new Array(this.dim).fill(0)
     // Seeded from an isotropic guess (matching RWM's all-ones default) since the covariance
     // accumulator has no observations yet to base a better proposal on (see _adjust).
     this._A = this.internal.proposal
@@ -62,8 +67,10 @@ export default class AdaptiveMetropolis extends MCMC {
   }
 
   _iter (x) {
-    const z = new Vector(Array.from({ length: this.dim }, () => this._q.sample()))
-    const jump = this._A.apply(z).v()
+    for (let i = 0; i < this.dim; i++) {
+      this._zBuffer[i] = this._q.sample()
+    }
+    const jump = this._A.apply(this._z).v()
     const x1 = x.map((d, i) => d + jump[i])
     const newLnp = this.lnp(x1)
     const accepted = this.r.next() < Math.exp(newLnp - this.lastLnp)
@@ -96,11 +103,17 @@ export default class AdaptiveMetropolis extends MCMC {
   _updateCovariance (x) {
     this._covN++
     const n = this._covN
-    const delta = x.map((v, i) => v - this._covMean[i])
+    const delta = this._delta
+    const delta2 = this._delta2
+    for (let i = 0; i < this.dim; i++) {
+      delta[i] = x[i] - this._covMean[i]
+    }
     for (let i = 0; i < this.dim; i++) {
       this._covMean[i] += delta[i] / n
     }
-    const delta2 = x.map((v, i) => v - this._covMean[i])
+    for (let i = 0; i < this.dim; i++) {
+      delta2[i] = x[i] - this._covMean[i]
+    }
     for (let i = 0; i < this.dim; i++) {
       for (let j = 0; j < this.dim; j++) {
         this._covS[i][j] += delta[i] * delta2[j]

--- a/src/mc/adaptive-metropolis.js
+++ b/src/mc/adaptive-metropolis.js
@@ -36,8 +36,10 @@ export default class AdaptiveMetropolis extends MCMC {
     this._covMean = new Array(this.dim).fill(0)
     this._covS = Array.from({ length: this.dim }, () => new Array(this.dim).fill(0))
     // Reusable scratch buffers to avoid per-iteration array allocations in _iter/_updateCovariance.
+    // Only plain arrays are cached as fields here, never a Vector instance: a cached Vector field's
+    // type is inferred from its own JSDoc (ran.la.Vector), which breaks npm run typecheck the same
+    // way a cached Matrix field does — see solutions/tooling/2026-07-15-1330-adaptive-metropolis-ran-la-matrix-dts-leak.md
     this._zBuffer = new Array(this.dim).fill(0)
-    this._z = new Vector(this._zBuffer)
     this._delta = new Array(this.dim).fill(0)
     this._delta2 = new Array(this.dim).fill(0)
     // Seeded from an isotropic guess (matching RWM's all-ones default) since the covariance
@@ -70,7 +72,10 @@ export default class AdaptiveMetropolis extends MCMC {
     for (let i = 0; i < this.dim; i++) {
       this._zBuffer[i] = this._q.sample()
     }
-    const jump = this._A.apply(this._z).v()
+    // z wraps the reused _zBuffer; kept as a local rather than a cached field (see the
+    // constructor's typecheck note above), but no new array is allocated per iteration.
+    const z = new Vector(this._zBuffer)
+    const jump = this._A.apply(z).v()
     const x1 = x.map((d, i) => d + jump[i])
     const newLnp = this.lnp(x1)
     const accepted = this.r.next() < Math.exp(newLnp - this.lastLnp)


### PR DESCRIPTION
## Summary

`AdaptiveMetropolis._iter()` and `_updateCovariance()` allocated a fresh array on every MCMC iteration (`Array.from(...)` for the standard-normal draw vector, two `.map()` calls for the Welford `delta`/`delta2` update). Warm-up can run millions of iterations, so this refactors both hot paths to fill reusable, pre-allocated scratch buffers (`_zBuffer`, `_delta`, `_delta2`) instead, with plain `for` loops replacing `.map()`. No behavior change is intended or expected.

Closes #943

## Non-trivial changes

- **`src/mc/adaptive-metropolis.js`**: The standard-normal draw vector's underlying array (`_zBuffer`) is now allocated once in the constructor and reused every iteration; the `Vector` *wrapper* around it is still constructed fresh each call inside `_iter()` rather than cached as a field. This is deliberate: an earlier version of this change cached the `Vector` instance as `this._z`, and `npm run typecheck` failed because `tsc`'s declaration generation infers a cached instance's field type from its own JSDoc (`ran.la.Vector`), which isn't part of the public export graph — the exact same class of bug already documented for `Matrix` in `solutions/tooling/2026-07-15-1330-adaptive-metropolis-ran-la-matrix-dts-leak.md`. Keeping `z` as a local variable avoids the leak while still eliminating the actual expensive allocation (the backing array + the `Array.from` callback invocation per element).

## Design decisions

No ADR was added — per `CLAUDE.md`, this is an internal implementation-technique choice (buffer reuse inside private methods), not a change to public API, base-class conventions, or module exports. The `Vector`-field-leak precedent is already captured in the linked solution note; this PR adds a code comment cross-referencing it for the next person who reaches for the same "cache it as a field" shortcut.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 7881 passing, no test modifications, per issue's acceptance criteria)
- [x] `npm run typecheck` passes
- [ ] Tests added or updated for changed behavior — N/A: pure internal refactor, no behavior change; issue explicitly required existing tests to pass unmodified, and they already cover bitwise-deterministic seeded sampling which is maximally sensitive to a buffer-reuse/aliasing bug
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [x] `CHANGELOG.md` updated under `## [Unreleased]` — skipped: pure refactor, no user-visible change
- [x] Production-code diff is under ~400 lines (tests excluded) — ~24 lines changed in one file

## Comprehension checklist

- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives (local `Vector`, not a cached field)
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state (existing suite unchanged)
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDaVGhCTkGtGABuKxx7t3D)_