### PR TITLE
Gibbs sampler test verifies correlation structure

### DIFF
--- a/test/mc.js
+++ b/test/mc.js
@@ -10,6 +10,7 @@ import SliceSampler from '../src/mc/slice'
 import gelmanRubin from '../src/mc/gelman-rubin'
 import runChains from '../src/mc/run-chains'
 import { Normal, Gamma, Beta } from '../src/dist'
+import pearson from '../src/dependence/pearson'
 import { ksTest, ess } from './test-utils'
 
 // Concrete subclass that replays a pre-built sequence, enabling deterministic
@@ -726,6 +727,12 @@ describe('mc.Gibbs', () => {
         const ref = new Normal(0, 1)
         assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
         assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+        // Both margins are standard Normal regardless of rho, so the KS tests above
+        // cannot detect a sign flip or a swapped source dimension in the conditionals;
+        // the joint correlation is the only statistic that distinguishes them.
+        // SE(r) ~= (1 - rho^2) / sqrt(n - 1) ~= 0.0168 for rho=0.5, n=2000, so 0.1 is ~6 SE.
+        const r = pearson(samples.map(s => s[0]), samples.map(s => s[1]))
+        assert.approximately(r, rho, 0.1)
       })
     })
   })


### PR DESCRIPTION
## Summary

Closes #937

The `mc.Gibbs` distributional test targeted a correlated bivariate Normal (`rho = 0.5`) but only ran KS tests on each marginal against `Normal(0, 1)`. Both marginals are standard normal regardless of `rho`'s value or sign, so the test couldn't catch a broken correlation structure — e.g. a sign flip (`-rho` instead of `rho`) or a conditional reading the wrong source dimension. This PR adds an assertion on the sample Pearson correlation between the two dimensions, using the existing `ran.dependence.pearson` function.

## Non-trivial changes

_No non-trivial changes — this is a test-only, mechanical addition._

- **`test/mc.js`**: Added `assert.approximately(r, rho, 0.1)` to the `.sample() distributional test` for `mc.Gibbs`, where `r` is the sample Pearson correlation of the two chain dimensions. Tolerance of `0.1` is derived from the analytic standard error of the sample correlation, `SE(r) ≈ (1 - rho²) / sqrt(n - 1) ≈ 0.0168` for `rho=0.5, n=2000`, giving roughly a 6-SE margin. Verified (and reverted) that sign-flipping the conditionals' `rho` term makes all three seeded sub-tests fail as expected, confirming the assertion has real discriminating power.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green, 7881 passing)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [x] `CHANGELOG.md` updated under `## [Unreleased]` — N/A, test-only change per CLAUDE.md changelog rule
- [x] Production-code diff is under ~400 lines (tests excluded) — no production code changed

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wrf7SCspNXkMq5ojJAowje)_