### PR TITLE
Reduce array allocations in HMC leapfrog integrator

### DIFF
--- a/src/mc/hmc.js
+++ b/src/mc/hmc.js
@@ -420,15 +420,22 @@ export default class HMC extends MCMC {
   // one applies the adapted metric's M^-1 to the position update -- combining the dense metric
   // with NUTS is explicitly out of scope (issue #826).
   _leapfrog (x, r, eps) {
-    let xCur = x.slice()
-    let rCur = r.slice()
+    const xCur = x.slice()
+    const rCur = r.slice()
+    const n = xCur.length
     for (let l = 0; l < this._pathLength; l++) {
       const grad0 = this._gradLnp(xCur)
-      rCur = rCur.map((ri, i) => ri + 0.5 * eps * grad0[i])
+      for (let i = 0; i < n; i++) {
+        rCur[i] += 0.5 * eps * grad0[i]
+      }
       const mInvR = this._applyInverseMetric(rCur)
-      xCur = xCur.map((xi, i) => xi + eps * mInvR[i])
+      for (let i = 0; i < n; i++) {
+        xCur[i] += eps * mInvR[i]
+      }
       const grad1 = this._gradLnp(xCur)
-      rCur = rCur.map((ri, i) => ri + 0.5 * eps * grad1[i])
+      for (let i = 0; i < n; i++) {
+        rCur[i] += 0.5 * eps * grad1[i]
+      }
     }
     return { x: xCur, r: rCur }
   }


### PR DESCRIPTION
## Summary

`HMC._leapfrog()` used three `.map()` calls per leapfrog step to update the position/momentum arrays, allocating a new array each time — with the default `pathLength: 10` that's 30 allocations per `_iter()` call, adding up to real GC pressure over long `warmUp()`/`sample()` runs. This replaces the `.map()` calls with in-place `for` loops mutating pre-allocated `xCur`/`rCur` arrays (still freshly `.slice()`-copied once from the caller-owned `x`/`r` at the top of the function, so caller arrays are never mutated).

Closes #948

## Non-trivial changes

_No non-trivial changes — this is a purely mechanical performance refactor with no behavioral change._ The arithmetic sequencing (half-step momentum → full-step position via the metric-transformed momentum → half-step momentum) is preserved exactly; all 40 existing `mc.HMC` tests (including bitwise-reproducibility seed tests and KS-distributional tests) pass identically before and after.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green, coverage thresholds met)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior — N/A, pure performance refactor with no behavior change; existing `mc.HMC` suite covers it
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [x] `CHANGELOG.md` updated under `## [Unreleased]` (skip for pure refactors/docs/tests) — skipped, pure internal refactor
- [x] Production-code diff is under ~400 lines (tests excluded) — 17 lines, one file

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNfot3WA7LXbhWAUVRXZU9)_