### PR TITLE
Harden docs build parser against unbracketed {@link} constructs

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -42,32 +42,53 @@ function getSortedEntries (entries, priority) {
     )
 }
 
+// Distribution classes carry @param/@throws on the constructor's own JSDoc (the
+// post-#306 layout: class block has no @param so tsc can pick the constructor
+// signature). documentation.js v14 surfaces that block as entry.constructorComment.
+// Fall back to it when the class entry itself has no params/throws, otherwise the
+// rendered cards show "Name()" with no Parameters table.
+function resolveEntrySource (entry) {
+  const ctor = entry.constructorComment
+  return {
+    params: entry.params.length > 0 ? entry.params : (ctor ? ctor.params : []),
+    throws: entry.throws.length > 0 ? entry.throws : (ctor ? ctor.throws : [])
+  }
+}
+
+function resolveLocation (entry) {
+  const ctx = entry.context || {}
+  return {
+    file: ctx.file ? path.relative(REPO_ROOT, ctx.file).split(path.sep).join('/') : null,
+    line: ctx.loc && ctx.loc.start ? ctx.loc.start.line : null
+  }
+}
+
+function sourceLink (location) {
+  return location.file && location.line != null
+    ? `https://github.com/synesenom/ran/blob/v${VERSION}/${location.file}#L${location.line}`
+    : null
+}
+
+function renderSignature (entry, params) {
+  const args = params.map((d, i) => `${d.optional ? '[' : ''}${i > 0 ? ', ' : ''}${d.name}`).join('')
+  const closers = params.filter(d => d.optional).map(() => ']').join('')
+  return `${entry.memberof}.${entry.name}(${args}${closers})`
+}
+
+function renderReturns (entry, location) {
+  const ret = entry.returns[0]
+  return ret && {
+    desc: DescParser(ret, location),
+    type: TypeParser(ret.type)
+  }
+}
+
 function parseEntry (entry) {
   const name = entry.name
-  // Distribution classes carry @param/@throws on the constructor's own
-  // JSDoc (the post-#306 layout: class block has no @param so tsc can
-  // pick the constructor signature). documentation.js v14 surfaces that
-  // block as entry.constructorComment. Fall back to it when the class
-  // entry itself has no params/throws, otherwise the rendered cards
-  // show "Name()" with no Parameters table.
-  const ctor = entry.constructorComment
-  const sourceParams = entry.params.length > 0
-    ? entry.params
-    : (ctor ? ctor.params : [])
-  const sourceThrows = entry.throws.length > 0
-    ? entry.throws
-    : (ctor ? ctor.throws : [])
-
-  const ctx = entry.context || {}
-  const relFile = ctx.file ? path.relative(REPO_ROOT, ctx.file).split(path.sep).join('/') : null
-  const line = ctx.loc && ctx.loc.start ? ctx.loc.start.line : null
-  const source = relFile && line != null
-    ? `https://github.com/synesenom/ran/blob/v${VERSION}/${relFile}#L${line}`
-    : null
+  const { params: sourceParams, throws: sourceThrows } = resolveEntrySource(entry)
+  const location = resolveLocation(entry)
   // entry.params, entry.returns[0] and entry.deprecated don't carry their own context, so
   // every DescParser call is given the enclosing entry's location for error reporting (#980).
-  const location = { file: relFile, line }
-
   const params = sourceParams.map(p => ParamParser(p, location))
   const throws = sourceThrows.map(ThrowsParser)
 
@@ -75,18 +96,11 @@ function parseEntry (entry) {
     name,
     index: `${entry.memberof}.${name}`.slice(4).replace('.', '-'),
     path: entry.memberof,
-    signature: `${entry.memberof}.${name}(${params.map((d, i) => `${d.optional ? '[' : ''}${i > 0 ? ', ' : ''}${d.name}`)
-      .join('')}${params.filter(d => d.optional).map(() => ']').join('')})`,
+    signature: renderSignature(entry, params),
     desc: DescParser(entry, location),
-    source,
+    source: sourceLink(location),
     params: params.length > 0 ? params : undefined,
-    returns: (() => {
-      const ret = entry.returns[0]
-      return ret && {
-        desc: DescParser(ret, location),
-        type: TypeParser(ret.type)
-      }
-    })(),
+    returns: renderReturns(entry, location),
     throws: throws.length > 0 ? throws : undefined,
     examples: entry.examples.length > 0
       ? hljs.highlight(entry.examples[0].description, { language: 'javascript' }).value

--- a/docs/index.js
+++ b/docs/index.js
@@ -57,8 +57,6 @@ function parseEntry (entry) {
   const sourceThrows = entry.throws.length > 0
     ? entry.throws
     : (ctor ? ctor.throws : [])
-  const params = sourceParams.map(ParamParser)
-  const throws = sourceThrows.map(ThrowsParser)
 
   const ctx = entry.context || {}
   const relFile = ctx.file ? path.relative(REPO_ROOT, ctx.file).split(path.sep).join('/') : null
@@ -66,6 +64,12 @@ function parseEntry (entry) {
   const source = relFile && line != null
     ? `https://github.com/synesenom/ran/blob/v${VERSION}/${relFile}#L${line}`
     : null
+  // entry.params, entry.returns[0] and entry.deprecated don't carry their own context, so
+  // every DescParser call is given the enclosing entry's location for error reporting (#980).
+  const location = { file: relFile, line }
+
+  const params = sourceParams.map(p => ParamParser(p, location))
+  const throws = sourceThrows.map(ThrowsParser)
 
   return {
     name,
@@ -73,13 +77,13 @@ function parseEntry (entry) {
     path: entry.memberof,
     signature: `${entry.memberof}.${name}(${params.map((d, i) => `${d.optional ? '[' : ''}${i > 0 ? ', ' : ''}${d.name}`)
       .join('')}${params.filter(d => d.optional).map(() => ']').join('')})`,
-    desc: DescParser(entry),
+    desc: DescParser(entry, location),
     source,
     params: params.length > 0 ? params : undefined,
     returns: (() => {
       const ret = entry.returns[0]
       return ret && {
-        desc: DescParser(ret),
+        desc: DescParser(ret, location),
         type: TypeParser(ret.type)
       }
     })(),
@@ -88,7 +92,7 @@ function parseEntry (entry) {
       ? hljs.highlight(entry.examples[0].description, { language: 'javascript' }).value
       : undefined,
     sees: entry.sees.length > 0 ? entry.sees.map(SeesParser) : undefined,
-    deprecated: entry.deprecated ? DescParser({ description: entry.deprecated }) : undefined
+    deprecated: entry.deprecated ? DescParser({ description: entry.deprecated }, location) : undefined
   }
 }
 

--- a/docs/src/desc-parser.js
+++ b/docs/src/desc-parser.js
@@ -9,9 +9,21 @@
 // AST as adjacent [text, link] pairs) are stitched back into a single
 // <a> per pair via assembleLinks.
 
-function extractLinkText (node) {
+function extractLinkText (node, location) {
   const re = /\[(.*?)\]/
-  return re.exec(node.value)[1]
+  const match = re.exec(node.value)
+  if (!match) {
+    // documentation.js only strips `[text]` off the preceding node for
+    // `[text]{@link Symbol}`; a bare `{@link Symbol}` (or a `` `code` ``
+    // span sitting directly in front of the link) leaves no brackets to
+    // find, so failing loudly here beats a null-dereference deep in the
+    // AST walk (see #980).
+    const where = location && location.file
+      ? ` at ${location.file}${location.line != null ? `:${location.line}` : ''}`
+      : ''
+    throw new Error(`Error processing docs/src/desc-parser.js: Bare {@link} not supported${where}`)
+  }
+  return match[1]
 }
 
 function removeLinkText (node, text) {
@@ -23,10 +35,10 @@ function extractLinkURL (node) {
   return node.url.replace('}', '')
 }
 
-const assembleLinks = children => {
+const assembleLinks = (children, location) => {
   for (let i = 0; i < children.length; i++) {
     if (children[i + 1] && children[i + 1].type === 'link') {
-      const linkText = extractLinkText(children[i])
+      const linkText = extractLinkText(children[i], location)
       const context = removeLinkText(children[i], linkText)
       const linkUrl = extractLinkURL(children[i + 1])
       children[i].value = `${context} <a href='${linkUrl}' target='_blank'>${linkText}</a>`
@@ -39,14 +51,14 @@ const assembleLinks = children => {
 
 const simplify = str => str.replace(/\s+/g, ' ')
 
-const renderNode = node => {
+const renderNode = (node, location) => {
   if (Array.isArray(node.children)) {
-    return assembleLinks(node.children).map(renderNode).join('')
+    return assembleLinks(node.children, location).map(child => renderNode(child, location)).join('')
   }
   return node.value || ''
 }
 
-module.exports = obj => {
+module.exports = (obj, location) => {
   const root = obj.description
   if (!root || !Array.isArray(root.children)) {
     return ''
@@ -58,12 +70,12 @@ module.exports = obj => {
   // breathing room in the rendered card.
   const paragraphs = root.children
     .filter(c => c.type === 'paragraph')
-    .map(p => `<p>${simplify(renderNode(p)).trim()}</p>`)
+    .map(p => `<p>${simplify(renderNode(p, location)).trim()}</p>`)
 
   // Fallback for descriptions with no paragraph nodes (rare — e.g. a
   // single bare text root): render the whole subtree inline.
   if (paragraphs.length === 0) {
-    return simplify(renderNode(root)).trim()
+    return simplify(renderNode(root, location)).trim()
   }
   return paragraphs.join('')
 }

--- a/docs/src/param-parser.js
+++ b/docs/src/param-parser.js
@@ -1,13 +1,13 @@
 const DescParser = require('./desc-parser')
 const TypeParser = require('./type-parser')
 
-module.exports = param => {
+module.exports = (param, location) => {
 
   const isOptional = type => type.type === 'OptionalType' || typeof param.default !== 'undefined'
 
   return {
     name: param.name,
-    desc: DescParser(param),
+    desc: DescParser(param, location),
     optional: isOptional(param.type),
     default: param.default && param.default.replace('=>', ' => '),
     type: TypeParser(param.type)

--- a/test/docs-desc-parser.js
+++ b/test/docs-desc-parser.js
@@ -1,0 +1,63 @@
+import { assert } from 'chai'
+import { describe, it } from 'mocha'
+import DescParser from '../docs/src/desc-parser'
+
+// Minimal mdast fragments shaped like documentation.js's description AST —
+// only the fields desc-parser.js actually reads (type, value, url, children).
+const text = value => ({ type: 'text', value })
+const inlineCode = value => ({ type: 'inlineCode', value })
+const jsdocLink = url => ({ type: 'link', url, jsdoc: true, children: [text(url)] })
+const paragraph = children => ({ type: 'paragraph', children })
+const entry = (...paragraphs) => ({ description: { type: 'root', children: paragraphs } })
+
+describe('docs/desc-parser', () => {
+  it('renders a bracketed {@link} as an anchor tag', () => {
+    const html = DescParser(entry(paragraph([
+      text('Unlike [RWM]'),
+      jsdocLink('ran.mc.RWM')
+    ])))
+    assert.strictEqual(html, "<p>Unlike <a href='ran.mc.RWM' target='_blank'>RWM</a></p>")
+  })
+
+  it('throws a localized error instead of crashing on a bare {@link}', () => {
+    assert.throws(
+      () => DescParser(entry(paragraph([
+        text('Unlike'),
+        jsdocLink('ran.mc.RWM')
+      ])), { file: 'src/mc/adaptive-metropolis.js', line: 14 }),
+      /^Error processing docs\/src\/desc-parser\.js: Bare \{@link\} not supported at src\/mc\/adaptive-metropolis\.js:14$/
+    )
+  })
+
+  it('throws instead of crashing when inline code sits directly in front of a bare {@link}', () => {
+    // Reproduces the src/mc/parallel-tempering.js#980 root cause: a `` `code` ``
+    // span immediately followed by {@link Symbol} with no [text] wrapper.
+    assert.throws(
+      () => DescParser(entry(paragraph([
+        inlineCode('MCMC'),
+        jsdocLink('ran.mc.MCMC')
+      ])), { file: 'src/mc/parallel-tempering.js', line: 14 }),
+      /Bare \{@link\} not supported at src\/mc\/parallel-tempering\.js:14$/
+    )
+  })
+
+  it('omits the line number when the location has a file but no line', () => {
+    assert.throws(
+      () => DescParser(entry(paragraph([
+        text('Unlike'),
+        jsdocLink('ran.mc.RWM')
+      ])), { file: 'src/mc/foo.js', line: null }),
+      /Bare \{@link\} not supported at src\/mc\/foo\.js$/
+    )
+  })
+
+  it('omits the location clause when no location is given', () => {
+    assert.throws(
+      () => DescParser(entry(paragraph([
+        text('Unlike'),
+        jsdocLink('ran.mc.RWM')
+      ]))),
+      /Bare \{@link\} not supported$/
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Hardens the docs build's JSDoc `{@link}` parser (`docs/src/desc-parser.js`) so a bare, unbracketed `{@link Symbol}` construct (optionally preceded by an inline-code span) throws a clear, localized `Error` instead of crashing with an unlocalized `TypeError: Cannot read properties of null (reading '1')` deep in the AST walk. `docs/index.js` now precomputes each entry's `{file, line}` location once and threads it through every `DescParser`/`ParamParser` call site so the thrown error can cite exactly where the offending JSDoc comment lives.

Closes #980

## Non-trivial changes

- **`docs/src/desc-parser.js`**: `extractLinkText()` used to do `re.exec(node.value)[1]`, which threw an opaque `TypeError` the moment a paragraph child preceding a `{@link}` link node had no `[text]` wrapper (verified against real AST output from `documentation.build()` for both a plain-bare `{@link ran.mc.RWM}` and an inline-code-then-bare-link case matching the original `src/mc/parallel-tempering.js` crash). It now detects the failed match and throws `Error processing docs/src/desc-parser.js: Bare {@link} not supported at <file>:<line>` instead. I deliberately left the pre-existing loop-index bug in `assembleLinks()` untouched — fixing it would surface a second bare `{@link ran.mc.RWM}` in `src/mc/adaptive-metropolis.js:14` that the loop's off-by-one currently never inspects, which would violate issue #980's explicit "no crash regression on `adaptive-metropolis.js`" acceptance criterion. Filed that loop bug separately as #997.
- **`docs/index.js`**: `parseEntry()` scored 9.47 on CodeScene (Complex Method, cc=19) once the location-threading edit touched it, so per this repo's Code Health rule I extracted `resolveEntrySource`, `resolveLocation`, `sourceLink`, `renderSignature`, and `renderReturns` as named helpers. This is a pure structural refactor (verified via `npm run docs` producing identical rendered output and the full test suite staying green) but accounts for most of this PR's line count.

**Diff-size note**: issue #980 asked for a production-code diff under 50 lines; the location-threading fix itself is ~45 lines across `desc-parser.js`/`index.js`/`param-parser.js`, but the mandatory Code Health refactor of `parseEntry` (see above) pushed the total to ~116 lines. Still comfortably inside this repo's general ~400-line PR cap.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 7984 passing, coverage thresholds met)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior (`test/docs-desc-parser.js`, 5 cases covering the crash fix, location formatting, and the bracketed-link non-regression path)
- [ ] N/A — no new distribution added
- [ ] `CHANGELOG.md` — not updated; this is internal docs-build tooling with no published-package or user-visible runtime effect, which CLAUDE.md's changelog rule exempts (analogous to a refactor/doc-only change)
- [x] Production-code diff is under ~400 lines (tests excluded) — see diff-size note above for the gap vs. issue #980's own tighter 50-line ask

<details>
<summary>Trivial changes</summary>

- **`docs/index.js` / `docs/src/param-parser.js`**: mechanical propagation of the new `location` parameter through `parseEntry` → `ParamParser` → `DescParser`, no logic change.
- **`test/docs-desc-parser.js`**: new test file with hand-built minimal mdast-shaped fixtures.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzgVYE5DSCx4kBBtb4MGB4)_