### PR TITLE
Seed RWM distributional KS test

### DIFF
--- a/test/mc.js
+++ b/test/mc.js
@@ -498,7 +498,7 @@ describe('mc.RWM', () => {
 
   describe('.sample() distributional test', () => {
     it('should produce samples matching Normal(0,1) target (KS test)', () => {
-      const rwm = new RWM(x => -0.5 * x[0] * x[0], { dim: 1 })
+      const rwm = new RWM(x => -0.5 * x[0] * x[0], { dim: 1 }).seed(42)
       rwm.warmUp(null, 10)
       const samples = rwm.sample(null, 2000)
       const values = samples.map(s => s[0])


### PR DESCRIPTION
Closes #994

## Summary
- `mc.RWM`'s `.sample() distributional test` (`should produce samples matching Normal(0,1) target (KS test)`) constructed its `RWM` instance without calling `.seed()`, so the KS statistic varied run-to-run and occasionally landed past the alpha=5% critical value, intermittently failing CI (observed on the Node 18 matrix job in PR #992).
- Fixed by chaining `.seed(42)` onto the `RWM` construction, mirroring the fixed-seed pattern already used in this file's `.seed()` block and the prior ARS/Gibbs unseeded-KS-flake fixes. `RWM.seed()` correctly reseeds the sampler's internal proposal generator (`this._q`) via the base `MCMC._reseedCachedLogDensity` hook, unlike the earlier Gibbs bug where `seed()` never reached caller-supplied conditionals — so a plain seed call is genuinely sufficient here.
- Seed 42 was verified locally: deterministic and reproducible across repeated runs, with KS statistic D=0.0096 comfortably under the critical value of ~0.0304 at alpha=5% (n=2000).

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical (test-only, 1 line)._

## Code Health note
`test/mc.js` scores 8.54/10.0 (pre-existing "Number of Functions in a Single Module" and "Code Duplication" smells spanning many unrelated describe blocks across all MCMC samplers). This is a god-file-scale issue unrelated to the 1-line change in this PR and out of scope for a hotfix — not addressed here.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/mc.js`**: Added `.seed(42)` to the `RWM` distributional KS test's sampler construction.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4ZwsY4dzWvSZn2Sf1xUrK)_