### PR TITLE
Standardize MCMC KS-test seed-sweep policy

### DIFF
--- a/solutions/testing/2026-07-17-1615-mcmc-ks-test-seed-sweep-file-wide-policy.md
+++ b/solutions/testing/2026-07-17-1615-mcmc-ks-test-seed-sweep-file-wide-policy.md
@@ -1,0 +1,45 @@
+---
+date: 2026-07-17T16:15:03Z
+category: "testing"
+problem: "test/mc.js had two independent fixes for unseeded/single-seed KS-test flakiness (ARS, Gibbs) that were never generalized into a file-wide policy, leaving 11 more KS-test blocks -- one of them fully unseeded -- on undocumented single pinned seeds"
+status: complete
+related_issue: "#1000"
+related_plan: "thoughts/plans/2026-07-17-1242-mcmc-ks-test-seed-pinning-policy.md"
+tags: [ks-test, seeded-tests, flaky-tests, statistical-tests, false-positive-rate, mc, ci-stability, file-wide-policy, seed-hunting]
+---
+
+# Solution: A per-sampler flakiness fix is a file-wide policy, not a one-off patch
+
+**Date**: 2026-07-17T16:15:03Z
+**Category**: testing
+**Related Issue**: #1000
+
+## Problem
+
+`test/mc.js` contains distributional KS-test blocks for 9 MCMC samplers (RWM, AdaptiveMetropolis, HMC, Gibbs, MALA, NUTS, ARS, SliceSampler, ParallelTempering). Two prior sessions independently diagnosed and fixed the same underlying defect for a single sampler each: ARS's KS test flaked in CI at exactly its own significance-level false-positive rate (issue #820), and Gibbs's `.seed()` call turned out not to reach its actual randomness source (issue #824). Both fixes converted their sampler's tests from a single seed to a fixed three-seed sweep (`[0, 42, 12345]` for ARS, `[0, 7, 42]` for Gibbs) and documented the rationale in a solution doc.
+
+Neither fix was generalized into a file-wide audit. Eleven more KS-test blocks across RWM (main + joint-proposals), AdaptiveMetropolis (main + joint-proposals), HMC (three separate blocks), MALA, NUTS, and SliceSampler (two blocks) were left on single pinned seeds with no comment explaining why that seed was chosen or that alternative seeds might legitimately fail — the exact "seed-hunting" risk issue #1000 was filed to close. One of those blocks, AdaptiveMetropolis's main distributional test, had no `.seed()` call at all: it was drawing from `Math.random()`-seeded entropy on every CI run, carrying the full undocumented ~1% flake rate the ARS solution doc had already diagnosed and fixed elsewhere in the same file.
+
+## Root Cause
+
+`ksTest()`'s critical value (`test/test-utils.js`, `D <= 1.628/√n`) is the standard two-sided asymptotic KS constant for α ≈ 0.01 — not the 5% issue #1000's body used as an illustrative estimate. Every unseeded or single-shot call to it carries an inherent ~1% chance of failing a run that exercises entirely correct code, purely from the sampled draw landing on the wrong side of the threshold. That defect was fixed twice, once per affected sampler, without ever asking "does this same anti-pattern exist anywhere else in this file?" — so it persisted, undocumented, in 11 more blocks (plus one genuinely unseeded block) until a dedicated file-wide pass closed it.
+
+## Fix
+
+All 11 remaining single-seed or unseeded `ksTest()` blocks in `test/mc.js` were converted to the `[0, 42, 12345]` sweep already used by ARS and ParallelTempering, via a new module-level `const SEEDS = [0, 42, 12345]` and the same `SEEDS.forEach(seed => it(...))` structural pattern already proven correct in the file. AdaptiveMetropolis's main distributional test was seeded for the first time. A file-level WHY comment (`test/mc.js:19-29`) now states the α≈0.01 derivation and the seed-sweep rationale once, instead of leaving it implicit or repeated inconsistently per block, and cross-references the two prior solution docs. Gibbs's `[0, 7, 42]` variant, and ARS/ParallelTempering's existing sweeps, were deliberately left untouched — they already satisfied the target policy, and the design decision (confirmed with the user after a low-confidence design-critique pass) was that "consistently applied" means every `ksTest()` call site uses *a* documented multi-seed sweep, not that every site must share identical seed values.
+
+Per the plan's gating discipline (borrowed from `solutions/testing/2026-05-19-1132-gof-test-swap-effective-alpha-empirical-calibration.md`'s prevention strategy), any seed failure during conversion would have been treated as a candidate real bug rather than silently re-seeded. Empirically none of the 33 resulting test cases (11 blocks × 3 seeds) needed a substitution — every one passed on the canonical seed set on the first attempt. No `src/mc/*` production code was touched, matching the issue's explicit scope boundary.
+
+## Prevention Strategy
+
+When a statistical-test flakiness fix (unseeded or single-seed KS/chi-squared/Anderson-Darling test → fixed-seed sweep) is applied to one component in a shared test file, immediately grep the rest of that file for the same anti-pattern (a bare `.seed(N)` or no seed call adjacent to the same test-helper call) instead of stopping at the component that triggered the investigation. A targeted fix that isn't generalized into a file-wide policy just leaves siblings with the identical latent defect until a future contributor happens to notice — as happened here across two separate prior fixes before this pass closed the gap. Any new distributional test added to `test/mc.js` going forward must use the `SEEDS` sweep (or a documented sampler-specific variant) from the moment it is written, not as a later cleanup pass.
+
+## Related Solutions
+
+- `solutions/testing/2026-07-15-1044-ars-unseeded-ks-test-flake-fixed-seeds.md` — established the `[0, 42, 12345]` convention and diagnosed the root cause for ARS; this solution generalizes that fix file-wide.
+- `solutions/testing/2026-07-15-2015-gibbs-conditionals-fresh-normal-seed-noop.md` — applied the same multi-seed-sweep convention to Gibbs, with its own `[0, 7, 42]` variant left intentionally unchanged by this pass.
+- `solutions/testing/2026-05-19-1132-gof-test-swap-effective-alpha-empirical-calibration.md` — source of the empirical-verification-before-merging discipline applied here (treat a newly-failing seed as a candidate bug, not noise).
+
+## Key Insight
+
+When a statistical-test flakiness fix (unseeded/single-seed KS test → fixed-seed sweep) is applied to one sampler in a shared test file, audit every other call site of the same test helper in that file immediately — the fix is a file-wide policy, not a per-component patch, and leaving siblings undocumented just defers the same bug to a future issue.

--- a/test/mc.js
+++ b/test/mc.js
@@ -16,6 +16,19 @@ import { Normal, Gamma, Beta } from '../src/dist'
 import pearson from '../src/dependence/pearson'
 import { ksTest, ess } from './test-utils'
 
+// ksTest's critical value (test/test-utils.js) is the standard two-sided KS asymptotic
+// constant at alpha=0.01 (D <= 1.628/sqrt(n)) -- every unseeded call has an inherent ~1%
+// false-positive rate per CI run. Every distributional/margin-recovery KS assertion in this
+// file therefore sweeps a fixed, pre-verified seed set -- [0, 42, 12345] (or, for Gibbs,
+// [0, 7, 42] -- see that block's own comment for why) -- instead of relying on a single seed,
+// so a real regression must break at least one of three independent trajectories reproducibly
+// instead of the whole block carrying a permanent flake rate or, worse, having its seed
+// hand-picked because it happened to pass. See
+// solutions/testing/2026-07-15-1044-ars-unseeded-ks-test-flake-fixed-seeds.md,
+// solutions/testing/2026-07-15-2015-gibbs-conditionals-fresh-normal-seed-noop.md, and
+// solutions/testing/2026-07-17-1615-mcmc-ks-test-seed-sweep-file-wide-policy.md
+const SEEDS = [0, 42, 12345]
+
 // Concrete subclass that replays a pre-built sequence, enabling deterministic
 // accumulator testing without involving the PRNG.
 class TestMCMC extends MCMC {
@@ -449,13 +462,15 @@ describe('mc.RWM', () => {
       assert.strictEqual(x.filter((v, j) => v !== prev[j]).length, 3)
     })
 
-    it('should recover both margins of an independent 2D standard Normal target', () => {
-      const rwm = new RWM(x => -0.5 * (x[0] * x[0] + x[1] * x[1]), { dim: 2 }).seed(7)
-      rwm.warmUp(null, 10)
-      const samples = rwm.sample(null, 2000)
-      const ref = new Normal(0, 1)
-      assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
-      assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should recover both margins of an independent 2D standard Normal target (KS test, seed ${seed})`, () => {
+        const rwm = new RWM(x => -0.5 * (x[0] * x[0] + x[1] * x[1]), { dim: 2 }).seed(seed)
+        rwm.warmUp(null, 10)
+        const samples = rwm.sample(null, 2000)
+        const ref = new Normal(0, 1)
+        assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
+        assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+      })
     })
   })
 
@@ -497,13 +512,15 @@ describe('mc.RWM', () => {
   })
 
   describe('.sample() distributional test', () => {
-    it('should produce samples matching Normal(0,1) target (KS test)', () => {
-      const rwm = new RWM(x => -0.5 * x[0] * x[0], { dim: 1 }).seed(42)
-      rwm.warmUp(null, 10)
-      const samples = rwm.sample(null, 2000)
-      const values = samples.map(s => s[0])
-      const ref = new Normal(0, 1)
-      assert(ksTest(values, x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should produce samples matching Normal(0,1) target (KS test, seed ${seed})`, () => {
+        const rwm = new RWM(x => -0.5 * x[0] * x[0], { dim: 1 }).seed(seed)
+        rwm.warmUp(null, 10)
+        const samples = rwm.sample(null, 2000)
+        const values = samples.map(s => s[0])
+        const ref = new Normal(0, 1)
+        assert(ksTest(values, x => ref.cdf(x)))
+      })
     })
   })
 
@@ -607,13 +624,15 @@ describe('mc.AdaptiveMetropolis', () => {
       assert.strictEqual(x.filter((v, j) => v !== prev[j]).length, 3)
     })
 
-    it('should recover both margins of an independent 2D standard Normal target', () => {
-      const am = new AdaptiveMetropolis(x => -0.5 * (x[0] * x[0] + x[1] * x[1]), { dim: 2 }).seed(7)
-      am.warmUp(null, 10)
-      const samples = am.sample(null, 2000)
-      const ref = new Normal(0, 1)
-      assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
-      assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should recover both margins of an independent 2D standard Normal target (KS test, seed ${seed})`, () => {
+        const am = new AdaptiveMetropolis(x => -0.5 * (x[0] * x[0] + x[1] * x[1]), { dim: 2 }).seed(seed)
+        am.warmUp(null, 10)
+        const samples = am.sample(null, 2000)
+        const ref = new Normal(0, 1)
+        assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
+        assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+      })
     })
   })
 
@@ -652,13 +671,15 @@ describe('mc.AdaptiveMetropolis', () => {
   })
 
   describe('.sample() distributional test', () => {
-    it('should produce samples matching Normal(0,1) target (KS test)', () => {
-      const am = new AdaptiveMetropolis(x => -0.5 * x[0] * x[0], { dim: 1 })
-      am.warmUp(null, 10)
-      const samples = am.sample(null, 2000)
-      const values = samples.map(s => s[0])
-      const ref = new Normal(0, 1)
-      assert(ksTest(values, x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should produce samples matching Normal(0,1) target (KS test, seed ${seed})`, () => {
+        const am = new AdaptiveMetropolis(x => -0.5 * x[0] * x[0], { dim: 1 }).seed(seed)
+        am.warmUp(null, 10)
+        const samples = am.sample(null, 2000)
+        const values = samples.map(s => s[0])
+        const ref = new Normal(0, 1)
+        assert(ksTest(values, x => ref.cdf(x)))
+      })
     })
   })
 
@@ -1128,15 +1149,17 @@ describe('mc.HMC', () => {
         assert(meanUnadaptedRatio > 10, `mean unadapted per-dimension ESS ratio (${meanUnadaptedRatio}) over seeds ${seeds} should be markedly unbalanced`)
       })
 
-      it('should still recover the correct per-dimension margins under metric adaptation (KS test)', () => {
-        // Guards against an M/M^-1 inversion bug that could improve ESS while silently biasing
-        // the sampled distribution -- neither test above inspects the distribution itself.
-        const hmc = new HMC(lnp, grad, { dim: 3 }, { x: [0, 0, 0] }).seed(1)
-        hmc.warmUp(null, 20)
-        const samples = hmc.sample(null, 2000)
-        sigma.forEach((s, i) => {
-          const ref = new Normal(0, s)
-          assert(ksTest(samples.map(x => x[i]), x => ref.cdf(x)), `margin ${i} (sigma=${s}) failed KS test`)
+      SEEDS.forEach(seed => {
+        it(`should still recover the correct per-dimension margins under metric adaptation (KS test, seed ${seed})`, () => {
+          // Guards against an M/M^-1 inversion bug that could improve ESS while silently biasing
+          // the sampled distribution -- neither test above inspects the distribution itself.
+          const hmc = new HMC(lnp, grad, { dim: 3 }, { x: [0, 0, 0] }).seed(seed)
+          hmc.warmUp(null, 20)
+          const samples = hmc.sample(null, 2000)
+          sigma.forEach((s, i) => {
+            const ref = new Normal(0, s)
+            assert(ksTest(samples.map(x => x[i]), x => ref.cdf(x)), `margin ${i} (sigma=${s}) failed KS test`)
+          })
         })
       })
     })
@@ -1153,16 +1176,18 @@ describe('mc.HMC', () => {
         assert.deepEqual(hmc2.state().internal, state.internal)
       })
 
-      it('should still recover the correct margins of a correlated target under metric adaptation (KS test)', () => {
-        // Same rationale as the diagonal metric's KS test above, applied to the dense metric's
-        // sampling path (_sampleMomentum's back-substitution and _applyInverseMetric's L*D*L^T*p
-        // product) -- both margins are standard Normal regardless of rho (see logDensity2D above).
-        const hmc = new HMC(logDensity2D, gradLogDensity2D, { dim: 2, metric: 'dense' }).seed(3)
-        hmc.warmUp(null, 10)
-        const samples = hmc.sample(null, 2000)
-        const ref = new Normal(0, 1)
-        assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
-        assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+      SEEDS.forEach(seed => {
+        it(`should still recover the correct margins of a correlated target under metric adaptation (KS test, seed ${seed})`, () => {
+          // Same rationale as the diagonal metric's KS test above, applied to the dense metric's
+          // sampling path (_sampleMomentum's back-substitution and _applyInverseMetric's L*D*L^T*p
+          // product) -- both margins are standard Normal regardless of rho (see logDensity2D above).
+          const hmc = new HMC(logDensity2D, gradLogDensity2D, { dim: 2, metric: 'dense' }).seed(seed)
+          hmc.warmUp(null, 10)
+          const samples = hmc.sample(null, 2000)
+          const ref = new Normal(0, 1)
+          assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
+          assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+        })
       })
 
       it('should achieve higher effective sample size than the diagonal metric on a strongly correlated target', () => {
@@ -1219,13 +1244,15 @@ describe('mc.HMC', () => {
   })
 
   describe('.sample() distributional test', () => {
-    it('should recover both margins of a correlated bivariate Normal target (KS test)', () => {
-      const hmc = new HMC(logDensity2D, gradLogDensity2D, { dim: 2 }).seed(3)
-      hmc.warmUp(null, 10)
-      const samples = hmc.sample(null, 2000)
-      const ref = new Normal(0, 1)
-      assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
-      assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should recover both margins of a correlated bivariate Normal target (KS test, seed ${seed})`, () => {
+        const hmc = new HMC(logDensity2D, gradLogDensity2D, { dim: 2 }).seed(seed)
+        hmc.warmUp(null, 10)
+        const samples = hmc.sample(null, 2000)
+        const ref = new Normal(0, 1)
+        assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
+        assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+      })
     })
   })
 
@@ -1352,13 +1379,15 @@ describe('mc.MALA', () => {
   })
 
   describe('.sample() distributional test', () => {
-    it('should recover both margins of a correlated bivariate Normal target (KS test)', () => {
-      const mala = new MALA(logDensity2D, gradLogDensity2D, { dim: 2 }).seed(3)
-      mala.warmUp(null, 10)
-      const samples = mala.sample(null, 2000)
-      const ref = new Normal(0, 1)
-      assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
-      assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should recover both margins of a correlated bivariate Normal target (KS test, seed ${seed})`, () => {
+        const mala = new MALA(logDensity2D, gradLogDensity2D, { dim: 2 }).seed(seed)
+        mala.warmUp(null, 10)
+        const samples = mala.sample(null, 2000)
+        const ref = new Normal(0, 1)
+        assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
+        assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+      })
     })
   })
 
@@ -1591,13 +1620,15 @@ describe('mc.NUTS', () => {
   })
 
   describe('.sample() distributional test', () => {
-    it('should recover both margins of a correlated bivariate Normal target (KS test)', () => {
-      const nuts = new NUTS(logDensity2D, gradLogDensity2D, { dim: 2 }).seed(3)
-      nuts.warmUp(null, 10)
-      const samples = nuts.sample(null, 2000)
-      const ref = new Normal(0, 1)
-      assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
-      assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should recover both margins of a correlated bivariate Normal target (KS test, seed ${seed})`, () => {
+        const nuts = new NUTS(logDensity2D, gradLogDensity2D, { dim: 2 }).seed(seed)
+        nuts.warmUp(null, 10)
+        const samples = nuts.sample(null, 2000)
+        const ref = new Normal(0, 1)
+        assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
+        assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+      })
     })
   })
 
@@ -1985,24 +2016,28 @@ describe('mc.SliceSampler', () => {
   })
 
   describe('.sample() distributional test', () => {
-    it('should produce samples matching Normal(0,1) target (KS test)', () => {
-      const slice = new SliceSampler(x => -0.5 * x[0] * x[0], { dim: 1 }).seed(5)
-      slice.warmUp(null, 10)
-      const samples = slice.sample(null, 2000)
-      const values = samples.map(s => s[0])
-      const ref = new Normal(0, 1)
-      assert(ksTest(values, x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should produce samples matching Normal(0,1) target (KS test, seed ${seed})`, () => {
+        const slice = new SliceSampler(x => -0.5 * x[0] * x[0], { dim: 1 }).seed(seed)
+        slice.warmUp(null, 10)
+        const samples = slice.sample(null, 2000)
+        const values = samples.map(s => s[0])
+        const ref = new Normal(0, 1)
+        assert(ksTest(values, x => ref.cdf(x)))
+      })
     })
 
-    it('should recover both margins of a correlated bivariate Normal target (KS test)', () => {
-      const rho = 0.5
-      const lnp = x => -0.5 / (1 - rho * rho) * (x[0] * x[0] - 2 * rho * x[0] * x[1] + x[1] * x[1])
-      const slice = new SliceSampler(lnp, { dim: 2 }, { x: [0, 0] }).seed(7)
-      slice.warmUp(null, 10)
-      const samples = slice.sample(null, 2000)
-      const ref = new Normal(0, 1)
-      assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
-      assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+    SEEDS.forEach(seed => {
+      it(`should recover both margins of a correlated bivariate Normal target (KS test, seed ${seed})`, () => {
+        const rho = 0.5
+        const lnp = x => -0.5 / (1 - rho * rho) * (x[0] * x[0] - 2 * rho * x[0] * x[1] + x[1] * x[1])
+        const slice = new SliceSampler(lnp, { dim: 2 }, { x: [0, 0] }).seed(seed)
+        slice.warmUp(null, 10)
+        const samples = slice.sample(null, 2000)
+        const ref = new Normal(0, 1)
+        assert(ksTest(samples.map(s => s[0]), x => ref.cdf(x)))
+        assert(ksTest(samples.map(s => s[1]), x => ref.cdf(x)))
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #1000

`test/mc.js`'s distributional KS-test blocks mixed two seeding conventions: a documented multi-seed sweep (`[0, 42, 12345]` for ARS/ParallelTempering, `[0, 7, 42]` for Gibbs) and an undocumented single pinned seed for the rest — the exact "seed-hunting" risk the issue describes, since a single seed chosen because it happens to pass exercises only one lucky trajectory going forward. This PR converts every remaining single-seed or unseeded `ksTest()` call site (RWM main + joint-proposals, AdaptiveMetropolis main + joint-proposals, HMC ×3, MALA, NUTS, SliceSampler ×2 — 11 blocks total) to the same `[0, 42, 12345]` sweep via a new shared `SEEDS` constant, and adds a file-level WHY comment documenting the convention and the actual KS significance level (`D <= 1.628/√n` is α ≈ 0.01, not the 5% the issue text used as an estimate).

- AdaptiveMetropolis's main distributional test previously had **no** `.seed()` call at all — it drew from `Math.random()`-seeded entropy every CI run, carrying an undocumented ~1% flake rate. It's now deterministically seeded for the first time.
- Gibbs, ARS, and ParallelTempering already complied with the target policy and were left untouched.
- All 33 resulting test cases (11 blocks × 3 seeds) were empirically verified to pass with the canonical seed set — no seed substitutions were needed.
- No production code (`src/mc/*`) was touched, per the issue's explicit scope.
- The decision and rationale are captured in `solutions/testing/2026-07-17-1615-mcmc-ks-test-seed-sweep-file-wide-policy.md`.

## Non-trivial changes

_No non-trivial changes — this PR is purely test-only (no production API, formula, or behavior changes)._ Two items worth a reviewer's attention despite being test-only:

- **`test/mc.js`**: AdaptiveMetropolis's `.sample() distributional test` (previously unseeded) now asserts against `[0, 42, 12345]` — this makes a previously flaky, non-reproducible test deterministic, which is the intended fix, not a regression.
- **`test/mc.js`**: Total KS-test `it()` blocks in the file grow from ~16 to ~54 (net +22), since 11 single-seed blocks each became 3 seeded blocks. This is a deliberate tradeoff (broad-scope option, confirmed during planning) to make the "applied consistently" acceptance criterion unambiguous rather than leaving exceptions to argue about later — it does increase suite runtime for the (already the slowest) MCMC distributional tests.

## Code Health

`test/mc.js` scores 8.54 (Yellow) via CodeScene, flagging two pre-existing smells: (1) "Number of Functions in a Single Module" (224 functions — the file holds all 9 MCMC samplers' test suites) and (2) code duplication among unrelated state-round-trip/R-hat tests (lines 492-501, 640-649, 1354-1366, 1583-1597, 2332-2344, 2346-2357). Neither smell overlaps any line this PR touches (all edits are at lines 19-29, 464, 514, 626, 673, 1151, 1178, 1246, 1381, 1622, 2018, 2029) and fixing either would mean an unrelated, much larger refactor of the file (splitting it per-sampler, deduplicating existing round-trip tests) — out of scope for a seeding-policy issue that explicitly excludes production-code and broad refactors.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 8006 passing)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, no new distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped, pure test-only change per `CLAUDE.md`'s changelog rule
- [x] Production-code diff is under ~400 lines (tests excluded) — 0 lines of production code changed

<details>
<summary>Trivial changes</summary>

- **`test/mc.js`**: Mechanical `.seed(N)` → `SEEDS.forEach(seed => it(...))` conversion, preserving every original assertion verbatim.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01727QH1q5AR8aELydzWgyd2)_