### PR TITLE
Verify HMC dense-metric adaptation via options-object form

### DIFF
--- a/test/mc.js
+++ b/test/mc.js
@@ -1561,6 +1561,29 @@ describe('mc.HMC', () => {
 
         assert(meanRatio > 1.1, `dense/diagonal mean ESS ratio (${meanRatio}) over seeds ${seeds} should exceed 1.1`)
       })
+
+      it('should produce identical ESS-balance behavior whether the dense-metric sampler is constructed via the options-object or positional form', () => {
+        // The generic assertGradientConstructorFormsMatch check above only compares a single
+        // post-construction iterate() call, not the metric-adaptation pipeline (covariance
+        // accumulation across warm-up batches, periodic LDL refresh) that the ESS-balance test
+        // above exercises -- so parity is reconfirmed here after a full warm-up + sampling run.
+        const rho = 0.99
+        const c = 1 - rho * rho
+        const lnp = x => -0.5 * (x[0] * x[0] - 2 * rho * x[0] * x[1] + x[1] * x[1]) / c
+        const grad = x => [-(x[0] - rho * x[1]) / c, -(x[1] - rho * x[0]) / c]
+
+        const positional = new HMC(lnp, grad, { dim: 2, metric: 'dense' }).seed(7)
+        const options = new HMC({ logDensity: lnp, gradLogDensity: grad, config: { dim: 2, metric: 'dense' } }).seed(7)
+
+        const rawIterations = 6000;
+        [positional, options].forEach(hmc => {
+          hmc.warmUp(null, 20)
+          hmc.sample(null, 0)
+          for (let i = 0; i < rawIterations; i++) hmc.iterate()
+        })
+
+        assert.deepStrictEqual(essPerDimension(options, rawIterations), essPerDimension(positional, rawIterations))
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

Verifies that HMC's Euclidean metric adaptation (`config.metric`, from #826) composes cleanly with the options-object constructor form (from #966). Investigation confirmed `src/mc/hmc.js` already threads `config.metric` identically through both constructor forms via `HMC._resolveGradientSamplerArgs` — no production bug exists. The gap was purely in test coverage: the existing generic parity helper (`assertGradientConstructorFormsMatch`) only compares a single post-construction `iterate()` call, not the full metric-adaptation pipeline (warm-up covariance accumulation, periodic dense-metric LDL refresh). This PR adds a test that exercises that full pipeline under both constructor forms.

Closes #971

## Non-trivial changes

_No non-trivial changes — this PR is purely a test addition. No production code was modified._

- **`test/mc.js`**: Added a test in `mc.HMC > mass matrix adaptation > dense metric (opt-in)` that constructs two HMC dense-metric samplers targeting a strongly correlated (ρ=0.99) bivariate normal — one via the positional constructor form, one via the options-object form — seeds both identically, runs an identical warm-up + 6000-iteration sequence on each, and asserts `essPerDimension()` returns bit-identical results. This confirms ESS-balance behavior is unaffected by which constructor form was used, per the issue's acceptance criteria.

## Code Health

`test/mc.js` scores 8.54/10 via CodeScene, flagged for "Number of Functions in a Single Module" (288 functions — the file aggregates tests for every MC sampler: RWM, AdaptiveMetropolis, Gibbs, HMC, MALA, NUTS, Slice, Gelman-Rubin) and pre-existing duplication across unrelated state-round-trip tests. Both smells predate this change and are not introduced by the new test (lines 1565–1586 are not among the flagged duplication instances). Splitting this file is a major cross-file refactor out of scope for this verification-only PR.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, no new distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped, test-only change
- [x] Production-code diff is under ~400 lines (tests excluded) — zero production-code lines changed

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01T15qZNYohtehcxYBhJhoNs)_