### PR TITLE
Remove duplicate GoF check from UnitTests.sample

### DIFF
--- a/test/dist.js
+++ b/test/dist.js
@@ -181,9 +181,6 @@ const UnitTests = {
       name: c.name || 'random parameters',
       generate: () => new dist[tc.name](...c.params())
     }))
-    // per-distribution override for GoF assertion only; support-range check always uses SAMPLE_SIZE
-    // See solutions/testing/2026-05-22-1820-per-distribution-gof-sample-size-override.md
-    const n = tc.sampleSize
 
     cases.forEach(c => {
       describe(c.name, () => {
@@ -200,14 +197,6 @@ const UnitTests = {
             assert(d <= supp[1].value, `Above upper bound: ${d} > ${supp[1].value}`)
           })
         })
-
-        it('sample values should be distributed correctly', () => {
-          for (const s of (tc.testSeeds ?? [0, 42, 12345])) {
-            const generator = c.generate()
-            generator.seed(s)
-            assert(generator.test(generator.sample(n ?? SAMPLE_SIZE)).passed, `seed ${s}`)
-          }
-        })
       })
     })
   },
@@ -222,6 +211,9 @@ const UnitTests = {
         return new dist[tc.name](...p)
       }
     }))
+    // per-distribution override for GoF assertion only; support-range check in .sample() always uses SAMPLE_SIZE
+    // See solutions/testing/2026-05-22-1820-per-distribution-gof-sample-size-override.md
+    const n = tc.sampleSize
 
     // Go through text cases.
     cases.forEach(c => {
@@ -230,7 +222,7 @@ const UnitTests = {
           for (const s of (tc.testSeeds ?? [0, 42, 12345])) {
             const generator = c.gen()
             generator.seed(s)
-            assert(generator.test(generator.sample(SAMPLE_SIZE)).passed, `seed ${s}`)
+            assert(generator.test(generator.sample(n ?? SAMPLE_SIZE)).passed, `seed ${s}`)
           }
         })
 


### PR DESCRIPTION
## Summary

Removes the duplicate goodness-of-fit (GoF) check that ran identically in both `UnitTests.sample()` and `UnitTests.test()` for every distribution in `test/dist.js`. The GoF assertion (`generator.test(generator.sample(n ?? SAMPLE_SIZE)).passed` over seeds `[0, 42, 12345]`) now runs once, in `UnitTests.test()`'s "should pass for own test" block. The distinct, cheap "sample should be within the range of the support" check in `UnitTests.sample()` (always `SAMPLE_SIZE`) is untouched.

Closes #1022

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

The one behavioral wrinkle worth flagging for reviewers: `UnitTests.test()`'s surviving GoF check previously hardcoded `SAMPLE_SIZE`, silently ignoring the per-distribution `tc.sampleSize` override (only the now-removed duplicate in `UnitTests.sample()` respected it). This PR moves `const n = tc.sampleSize` into `UnitTests.test()` and switches the assertion to `n ?? SAMPLE_SIZE`, so the override (used by Exponential, Normal, and Uniform per `solutions/testing/2026-05-22-1820-per-distribution-gof-sample-size-override.md`) is now honored where the check actually lives. This satisfies acceptance criterion 3 in #1022.

## Code Health note

`test/dist.js` scores 9.09 (CodeScene), flagged for "Number of Functions in a Single Module" (203 functions, Brain Class risk). This is pre-existing structural debt across the whole 1400+ line test-suite file, not introduced or worsened by this change — this diff net-removes one function (`it()` block). Splitting `test/dist.js` is a major cross-file refactor explicitly out of scope for #1022 ("Refactoring test structure beyond the consolidation itself").

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green) — 7,779 passing, coverage thresholds met
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped, pure test-only refactor
- [x] Production-code diff is under ~400 lines (tests excluded) — 16 lines, test-only

---
*Generated with [Claude Code](https://claude.ai/code)*


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrMqZfVLYfyt3ijHBKt9RX)_