### PR TITLE
Options-object constructor added to ParallelTempering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- `ran.mc.ParallelTempering`'s positional constructor form `new ParallelTempering(logDensity, options)` is deprecated in favor of the options-object form `new ParallelTempering({ logDensity, ...options })`, bringing it in line with every other `ran.mc` sampler and coordinator (RWM, AdaptiveMetropolis, Slice, HMC, MALA, NUTS, Gibbs per ADR-0030; ARS per ADR-0031) and removing the last positional-constructor wart in `ran.mc`. The positional form still constructs and samples correctly but emits a one-time `console.warn` on first use; it will be removed in v1.32.0 (#1034).
+
 ### Removed
 
 - `ran.mc.RWM`'s, `ran.mc.AdaptiveMetropolis`'s, `ran.mc.Slice`'s, `ran.mc.HMC`'s, and `ran.mc.Gibbs`'s deprecated positional constructor arguments (e.g. `new RWM(logDensity, config, initialState)`) are removed; only the options-object form (`new RWM({ logDensity, config, initialState })`) remains. `ran.mc.runChains()`'s deprecated legacy call form, `runChains(logDensity, config, options)`, is likewise removed; only the generalized `runChains(Sampler, samplerOptions, runOptions)` form remains. This closes out the deprecation cycle introduced in #962–#967 (ADR-0030, ADR-0031, ADR-0033). **Note on the deprecation cycle:** CLAUDE.md's normal deprecation-cycle rule requires a released minor version containing the warning to ship and hold for a full release before the removal lands; here the #962–#967 `### Deprecated` entry never left the `[Unreleased]` section of this changelog (v1.30.0 predates it), so the removal is landing without that hold, at explicit maintainer request overriding the standard process (#968). No published version of `ranjs` ever carried the positional forms as deprecated-but-working, so no downstream user is exposed to a behavior change without warning — the positional forms and their `console.warn` deprecation notices are simply gone, as if they had never been introduced.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Available samplers:
 | `ran.mc.MALA({ logDensity, gradLogDensity, config, initialState })` | Metropolis-Adjusted Langevin Algorithm: proposes a single gradient-informed Langevin step per iteration (`x' = x + (stepSize² / 2) · ∇log p(x) + stepSize · z`), with a Metropolis-Hastings correction for the proposal's asymmetry; step size is adapted during warm-up via batch Robbins-Monro toward the MALA-optimal 0.574 acceptance rate |
 | `ran.mc.NUTS({ logDensity, gradLogDensity, config, initialState })` | No-U-Turn Sampler (Hoffman & Gelman 2014): extends `HMC` with a doubling-tree trajectory that automatically stops at a U-turn, eliminating the need to hand-tune `pathLength`; the transition is selected via slice sampling over the tree, and step size is adapted during warm-up via the same Robbins-Monro dual averaging as `HMC` |
 | `ran.mc.Slice({ logDensity, config, initialState })` | Coordinate-wise slice sampler (Neal 2003) using stepping-out and shrinkage; no proposal tuning or gradient required, interval width `w` is adapted per dimension during warm-up, and `ar()` is always 1.0 |
-| `ran.mc.ParallelTempering(logDensity, options)` | Parallel Tempering / Replica Exchange MCMC (Geyer 1991) for multimodal targets; not a subclass of `MCMC`, it coordinates an array of independent replica samplers (default `RWM`) at descending inverse temperatures, periodically swapping adjacent replicas' positions so the cold (β = 1) replica inherits the hot replicas' mode-crossing moves |
+| `ran.mc.ParallelTempering({ logDensity, ...options })` | Parallel Tempering / Replica Exchange MCMC (Geyer 1991) for multimodal targets; not a subclass of `MCMC`, it coordinates an array of independent replica samplers (default `RWM`) at descending inverse temperatures, periodically swapping adjacent replicas' positions so the cold (β = 1) replica inherits the hot replicas' mode-crossing moves |
 
 ### Choosing a sampler
 
@@ -295,8 +295,8 @@ const { samples, rhat } = ran.mc.runChains(ran.mc.RWM, { logDensity, config: { d
 For multimodal targets that a single chain cannot mix across, `ran.mc.ParallelTempering` runs several replicas at a geometric ladder of inverse temperatures and swaps their positions so the cold replica benefits from the hot replicas' freer exploration:
 
 ```javascript
-const pt = new ran.mc.ParallelTempering(logDensity, { nReplicas: 4, tempMax: 100 })
-// or: { temperatures: [1, 0.5, 0.25, 0.1] } for an explicit ladder
+const pt = new ran.mc.ParallelTempering({ logDensity, nReplicas: 4, tempMax: 100 })
+// or: { logDensity, temperatures: [1, 0.5, 0.25, 0.1] } for an explicit ladder
 
 pt.warmUp(null, 20)          // warms up every replica independently, no swaps
 const samples = pt.sample(null, 2000) // lockstep sampling with swap proposals; returns the cold replica's draws

--- a/src/mc/parallel-tempering.js
+++ b/src/mc/parallel-tempering.js
@@ -6,6 +6,11 @@ import Xoshiro128p from '../core/xoshiro'
 // one replica at a time.
 const _MAX_REPLICAS = 10000
 
+// Module-level so the deprecated positional-constructor warning fires exactly once per process,
+// no matter how many positional instances are built — a per-instance flag would re-warn every time.
+// decisions/0030-mcmc-options-object-constructor.md — options-object constructor convention.
+let warnedPositionalDeprecation = false
+
 /**
  * Class implementing [Parallel Tempering]{@link https://doi.org/10.1090/conm/026} (Replica Exchange MCMC,
  * Geyer 1991) to sample multimodal targets. Runs N independent [MCMC]{@link ran.mc.MCMC} replicas at inverse
@@ -25,9 +30,9 @@ const _MAX_REPLICAS = 10000
  *
  * @class ParallelTempering
  * @memberof ran.mc
- * @param {Function} logDensity The logarithm of the (unnormalized) target density.
- * @param {Object=} options Configuration. Supported properties:
+ * @param {Object} options Coordinator options, as a single object. Supported properties:
  * <ul>
+ *   <li>{logDensity}: The logarithm of the (unnormalized) target density (required).</li>
  *   <li>{temperatures}: Explicit, strictly descending array of inverse temperatures starting at 1.
  *   At least two are required. Takes precedence over nReplicas/tempMax if provided.</li>
  *   <li>{nReplicas}: Number of replicas for an auto-generated geometric ladder. At least 2, at most 10000.</li>
@@ -36,6 +41,10 @@ const _MAX_REPLICAS = 10000
  *   <li>{sampler}: Factory `(scaledLogDensity, config) => MCMC` building one replica. Defaults to RWM.</li>
  *   <li>{config}: Configuration object forwarded unchanged to every replica's constructor.</li>
  * </ul>
+ * The deprecated positional form `new ParallelTempering(logDensity, options)` is still accepted, but
+ * emits a one-time deprecation warning on first use and will be removed in v1.32.0.
+ * @param {Object=} legacyOptions Deprecated positional-form options object, read only when the
+ * deprecated `new ParallelTempering(logDensity, options)` form is used. Do not use in new code.
  * @constructor
  * @throws {Error} If logDensity is not a function.
  * @throws {Error} If neither temperatures nor nReplicas and tempMax are provided, or if they are invalid.
@@ -43,14 +52,15 @@ const _MAX_REPLICAS = 10000
 // decisions/0028-parallel-tempering-standalone-coordinator.md — not an MCMC subclass; swaps positions
 // only, via direct field mutation, keeping adaptation state pinned to its temperature slot
 export default class ParallelTempering {
-  constructor (logDensity, options = {}) {
+  constructor (options, legacyOptions) {
+    const { logDensity, options: opts } = ParallelTempering._normalizeConstructorArgs(options, legacyOptions)
     if (typeof logDensity !== 'function') {
       throw Error('ParallelTempering: logDensity must be a function')
     }
-    this.temperatures = ParallelTempering._resolveLadder(options)
+    this.temperatures = ParallelTempering._resolveLadder(opts)
     this._logDensity = logDensity
-    this._sampler = options.sampler || ((lnp, config) => new RWM({ logDensity: lnp, config }))
-    this._config = options.config || {}
+    this._sampler = opts.sampler || ((lnp, config) => new RWM({ logDensity: lnp, config }))
+    this._config = opts.config || {}
     this._replicas = this.temperatures.map(beta => this._sampler(x => beta * this._logDensity(x), this._config))
     this._swapAttempts = new Array(this.temperatures.length - 1).fill(0)
     this._swapAccepts = new Array(this.temperatures.length - 1).fill(0)
@@ -189,6 +199,27 @@ export default class ParallelTempering {
   }
 
   // ─── PRIVATE STATIC ───
+
+  // Accepts the preferred options-object form `new ParallelTempering({ logDensity, ...options })` and
+  // the deprecated positional form `new ParallelTempering(logDensity, options)`. The two forms are
+  // told apart by the first argument's type: a function is the positional logDensity, anything else is
+  // the options object carrying logDensity as a property.
+  static _normalizeConstructorArgs (first, legacyOptions) {
+    if (typeof first === 'function') {
+      ParallelTempering._warnPositionalDeprecation()
+      return { logDensity: first, options: legacyOptions || {} }
+    }
+    const options = first || {}
+    return { logDensity: options.logDensity, options }
+  }
+
+  static _warnPositionalDeprecation () {
+    if (warnedPositionalDeprecation) {
+      return
+    }
+    warnedPositionalDeprecation = true
+    console.warn('[ranjs] ParallelTempering(logDensity, options) positional constructor is deprecated and will be removed in v1.32.0; use ParallelTempering({ logDensity, ...options }).')
+  }
 
   static _resolveLadder (options) {
     if (options.temperatures !== undefined) {

--- a/test/mc/parallel-tempering.js
+++ b/test/mc/parallel-tempering.js
@@ -9,61 +9,63 @@ describe('mc.ParallelTempering', () => {
 
   describe('constructor', () => {
     it('should throw when logDensity is not a function', () => {
-      assert.throws(() => new ParallelTempering(null, { temperatures: [1, 0.5] }), /logDensity must be a function/)
+      assert.throws(() => new ParallelTempering({ logDensity: null, temperatures: [1, 0.5] }), /logDensity must be a function/)
+      assert.throws(() => new ParallelTempering({ temperatures: [1, 0.5] }), /logDensity must be a function/)
+      assert.throws(() => new ParallelTempering(), /logDensity must be a function/)
     })
 
     it('should throw when neither temperatures nor nReplicas/tempMax are provided', () => {
-      assert.throws(() => new ParallelTempering(logDensity, {}), /temperatures.*nReplicas.*tempMax|Either/)
+      assert.throws(() => new ParallelTempering({ logDensity }), /temperatures.*nReplicas.*tempMax|Either/)
     })
 
     it('should throw when temperatures is not an array', () => {
-      assert.throws(() => new ParallelTempering(logDensity, { temperatures: 'nope' }), /temperatures must be an array/)
+      assert.throws(() => new ParallelTempering({ logDensity, temperatures: 'nope' }), /temperatures must be an array/)
     })
 
     it('should throw when temperatures has fewer than two entries', () => {
-      assert.throws(() => new ParallelTempering(logDensity, { temperatures: [1] }), /temperatures must be an array of at least two/)
+      assert.throws(() => new ParallelTempering({ logDensity, temperatures: [1] }), /temperatures must be an array of at least two/)
     })
 
     it('should throw when temperatures does not start at 1', () => {
-      assert.throws(() => new ParallelTempering(logDensity, { temperatures: [0.9, 0.5] }), /temperatures\[0\] must equal 1/)
+      assert.throws(() => new ParallelTempering({ logDensity, temperatures: [0.9, 0.5] }), /temperatures\[0\] must equal 1/)
     })
 
     it('should throw when temperatures is not strictly descending', () => {
-      assert.throws(() => new ParallelTempering(logDensity, { temperatures: [1, 1, 0.5] }), /temperatures must be strictly descending/)
-      assert.throws(() => new ParallelTempering(logDensity, { temperatures: [1, 0.5, 0.6] }), /temperatures must be strictly descending/)
+      assert.throws(() => new ParallelTempering({ logDensity, temperatures: [1, 1, 0.5] }), /temperatures must be strictly descending/)
+      assert.throws(() => new ParallelTempering({ logDensity, temperatures: [1, 0.5, 0.6] }), /temperatures must be strictly descending/)
     })
 
     it('should throw when temperatures contains a non-positive or non-finite value', () => {
-      assert.throws(() => new ParallelTempering(logDensity, { temperatures: [1, 0] }), /temperatures must contain only positive finite/)
-      assert.throws(() => new ParallelTempering(logDensity, { temperatures: [1, NaN] }), /temperatures must contain only positive finite/)
-      assert.throws(() => new ParallelTempering(logDensity, { temperatures: [1, -Infinity] }), /temperatures must contain only positive finite/)
+      assert.throws(() => new ParallelTempering({ logDensity, temperatures: [1, 0] }), /temperatures must contain only positive finite/)
+      assert.throws(() => new ParallelTempering({ logDensity, temperatures: [1, NaN] }), /temperatures must contain only positive finite/)
+      assert.throws(() => new ParallelTempering({ logDensity, temperatures: [1, -Infinity] }), /temperatures must contain only positive finite/)
     })
 
     it('should not throw for a valid temperatures array', () => {
-      assert.doesNotThrow(() => new ParallelTempering(logDensity, { temperatures: [1, 0.5, 0.25] }))
+      assert.doesNotThrow(() => new ParallelTempering({ logDensity, temperatures: [1, 0.5, 0.25] }))
     })
 
     it('should throw when nReplicas is not an integer of at least two', () => {
-      assert.throws(() => new ParallelTempering(logDensity, { nReplicas: 1, tempMax: 10 }), /nReplicas must be an integer/)
-      assert.throws(() => new ParallelTempering(logDensity, { nReplicas: 2.5, tempMax: 10 }), /nReplicas must be an integer/)
+      assert.throws(() => new ParallelTempering({ logDensity, nReplicas: 1, tempMax: 10 }), /nReplicas must be an integer/)
+      assert.throws(() => new ParallelTempering({ logDensity, nReplicas: 2.5, tempMax: 10 }), /nReplicas must be an integer/)
     })
 
     it('should throw when nReplicas exceeds the maximum allowed', () => {
-      assert.throws(() => new ParallelTempering(logDensity, { nReplicas: 10001, tempMax: 10 }), /nReplicas must be at most/)
+      assert.throws(() => new ParallelTempering({ logDensity, nReplicas: 10001, tempMax: 10 }), /nReplicas must be at most/)
     })
 
     it('should throw when tempMax is not a finite number greater than 1', () => {
-      assert.throws(() => new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 1 }), /tempMax must be a finite number greater than 1/)
-      assert.throws(() => new ParallelTempering(logDensity, { nReplicas: 3, tempMax: Infinity }), /tempMax must be a finite number greater than 1/)
-      assert.throws(() => new ParallelTempering(logDensity, { nReplicas: 3, tempMax: NaN }), /tempMax must be a finite number greater than 1/)
+      assert.throws(() => new ParallelTempering({ logDensity, nReplicas: 3, tempMax: 1 }), /tempMax must be a finite number greater than 1/)
+      assert.throws(() => new ParallelTempering({ logDensity, nReplicas: 3, tempMax: Infinity }), /tempMax must be a finite number greater than 1/)
+      assert.throws(() => new ParallelTempering({ logDensity, nReplicas: 3, tempMax: NaN }), /tempMax must be a finite number greater than 1/)
     })
 
     it('should not throw for valid nReplicas and tempMax', () => {
-      assert.doesNotThrow(() => new ParallelTempering(logDensity, { nReplicas: 4, tempMax: 100 }))
+      assert.doesNotThrow(() => new ParallelTempering({ logDensity, nReplicas: 4, tempMax: 100 }))
     })
 
     it('should auto-generate a strictly descending geometric ladder from nReplicas and tempMax', () => {
-      const pt = new ParallelTempering(logDensity, { nReplicas: 4, tempMax: 100 })
+      const pt = new ParallelTempering({ logDensity, nReplicas: 4, tempMax: 100 })
       // beta_i = tempMax^(-i/(nReplicas-1)) for i = 0..3 -> [1, 100^(-1/3), 100^(-2/3), 0.01].
       // Interior values checked against 10^(-2/3) and 10^(-4/3) (100^(-1/3) === 10^(-2/3) algebraically),
       // a different exponent/base decomposition than the source's Math.pow(tempMax, -i/(n-1)) call,
@@ -81,21 +83,51 @@ describe('mc.ParallelTempering', () => {
     })
 
     it('should expose the caller-supplied temperatures array unchanged', () => {
-      const pt = new ParallelTempering(logDensity, { temperatures: [1, 0.6, 0.3] })
+      const pt = new ParallelTempering({ logDensity, temperatures: [1, 0.6, 0.3] })
       assert.deepEqual(pt.temperatures, [1, 0.6, 0.3])
+    })
+  })
+
+  describe('positional constructor (deprecated)', () => {
+    // The "warns exactly once" assertion below depends on the source module's `warnedPositionalDeprecation`
+    // flag still being unset when this test runs. That holds only because this is the SOLE positional-form
+    // construction in this file/process — a second positional `new ParallelTempering(fn, ...)` added earlier
+    // in this file would pre-trip the flag and make `warnings.length` come back 0, failing here for a reason
+    // unrelated to the deprecation logic. Keep positional construction confined to this block.
+    it('should still construct and sample, warning exactly once regardless of how many positional instances are built', () => {
+      const warnings = []
+      const originalWarn = console.warn
+      // Capture instead of silencing so a regression that stops warning (or over-warns) is caught,
+      // and so the deprecation notice never leaks into the test runner's output.
+      console.warn = msg => warnings.push(msg)
+      try {
+        const pt = new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 10 }).seed(1)
+        pt.warmUp(null, 3)
+        const samples = pt.sample(null, 50)
+        assert.strictEqual(samples.length, 50)
+        assert(samples.every(s => s.length === 1 && Number.isFinite(s[0])))
+        // A second positional instance must NOT emit another warning (module-level once-only flag).
+        assert(new ParallelTempering(logDensity, { temperatures: [1, 0.5] }) instanceof ParallelTempering)
+        // Positional form with the options argument omitted still routes through the deprecated path.
+        assert.throws(() => new ParallelTempering(logDensity), /either temperatures or nReplicas and tempMax/)
+      } finally {
+        console.warn = originalWarn
+      }
+      assert.strictEqual(warnings.length, 1)
+      assert.match(warnings[0], /ParallelTempering\(logDensity, options\) positional constructor is deprecated and will be removed in v1\.32\.0/)
     })
   })
 
   describe('.state', () => {
     it('should not be resumable — state() is not implemented', () => {
-      const pt = new ParallelTempering(logDensity, { temperatures: [1, 0.5] })
+      const pt = new ParallelTempering({ logDensity, temperatures: [1, 0.5] })
       assert.notStrictEqual(typeof pt.state, 'function')
     })
   })
 
   describe('swap mechanics', () => {
     it('should exchange positions and recompute each replica\'s cached scaled log-density on an accepted swap', () => {
-      const pt = new ParallelTempering(logDensity, { temperatures: [1, 0.5] })
+      const pt = new ParallelTempering({ logDensity, temperatures: [1, 0.5] })
       // Positions chosen so (beta_0 - beta_1) * (lnp(x1) - lnp(x0)) = 0.5 * (0 - (-12.5)) = 6.25 >= 0
       // (the hotter replica currently holds the higher-density position), making the acceptance
       // probability exp(6.25) > 1 -- the swap is accepted for ANY draw in [0,1), so the test is
@@ -113,7 +145,7 @@ describe('mc.ParallelTempering', () => {
     })
 
     it('should count an attempted-but-rejected swap without exchanging positions', () => {
-      const pt = new ParallelTempering(logDensity, { temperatures: [1, 0.5] })
+      const pt = new ParallelTempering({ logDensity, temperatures: [1, 0.5] })
       // Reversed positions: (beta_0 - beta_1) * (lnp(x1) - lnp(x0)) = 0.5 * (-12.5 - 0) = -6.25,
       // acceptance probability exp(-6.25) ~= 0.00193. Stubbing r.next() to return a value
       // comfortably above that threshold makes rejection deterministic instead of depending on
@@ -135,7 +167,7 @@ describe('mc.ParallelTempering', () => {
 
   describe('.warmUp() and .sample()', () => {
     it('should return size samples of the correct dimensionality from the cold replica', () => {
-      const pt = new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 10 }).seed(1)
+      const pt = new ParallelTempering({ logDensity, nReplicas: 3, tempMax: 10 }).seed(1)
       pt.warmUp(null, 3)
       const samples = pt.sample(null, 50)
       assert.strictEqual(samples.length, 50)
@@ -143,7 +175,7 @@ describe('mc.ParallelTempering', () => {
     })
 
     it('should report warmUp() progress once per replica, ending at 100', () => {
-      const pt = new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 10 })
+      const pt = new ParallelTempering({ logDensity, nReplicas: 3, tempMax: 10 })
       const pcts = []
       pt.warmUp(p => pcts.push(p), 2)
       assert.strictEqual(pcts.length, 3)
@@ -151,7 +183,7 @@ describe('mc.ParallelTempering', () => {
     })
 
     it('should report each integer percent of sample() progress once, in increasing order', () => {
-      const pt = new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 10 }).seed(1)
+      const pt = new ParallelTempering({ logDensity, nReplicas: 3, tempMax: 10 }).seed(1)
       pt.warmUp(null, 3)
       const pcts = []
       pt.sample(p => pcts.push(p), 50)
@@ -163,7 +195,7 @@ describe('mc.ParallelTempering', () => {
 
   describe('.swapRate()', () => {
     it('should return one entry per adjacent pair, each in [0, 1], with at least one non-zero for a well-spaced ladder', () => {
-      const pt = new ParallelTempering(logDensity, { nReplicas: 4, tempMax: 20 }).seed(2)
+      const pt = new ParallelTempering({ logDensity, nReplicas: 4, tempMax: 20 }).seed(2)
       pt.warmUp(null, 5)
       pt.sample(null, 500)
       const rates = pt.swapRate()
@@ -175,11 +207,11 @@ describe('mc.ParallelTempering', () => {
 
   describe('.seed()', () => {
     it('should produce bitwise-identical samples when the same seed is applied twice', () => {
-      const pt1 = new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 10 }).seed(42)
+      const pt1 = new ParallelTempering({ logDensity, nReplicas: 3, tempMax: 10 }).seed(42)
       pt1.warmUp(null, 3)
       const samples1 = pt1.sample(null, 50)
 
-      const pt2 = new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 10 }).seed(42)
+      const pt2 = new ParallelTempering({ logDensity, nReplicas: 3, tempMax: 10 }).seed(42)
       pt2.warmUp(null, 3)
       const samples2 = pt2.sample(null, 50)
 
@@ -187,11 +219,11 @@ describe('mc.ParallelTempering', () => {
     })
 
     it('should produce different samples for different seeds', () => {
-      const pt1 = new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 10 }).seed(1)
+      const pt1 = new ParallelTempering({ logDensity, nReplicas: 3, tempMax: 10 }).seed(1)
       pt1.warmUp(null, 3)
       const samples1 = pt1.sample(null, 50)
 
-      const pt2 = new ParallelTempering(logDensity, { nReplicas: 3, tempMax: 10 }).seed(2)
+      const pt2 = new ParallelTempering({ logDensity, nReplicas: 3, tempMax: 10 }).seed(2)
       pt2.warmUp(null, 3)
       const samples2 = pt2.sample(null, 50)
 
@@ -219,7 +251,7 @@ describe('mc.ParallelTempering', () => {
         // occupancy at a matched sample size, pushing the KS statistic above its critical value for
         // some seeds. warmUp: 15 / size: 4000 (vs. the 10/2000 used by unimodal samplers elsewhere in
         // the test suite) gives the swap relay enough rounds to equilibrate before and during sampling.
-        const pt = new ParallelTempering(bimodalLogDensity, { nReplicas: 4, tempMax: 100 }).seed(seed)
+        const pt = new ParallelTempering({ logDensity: bimodalLogDensity, nReplicas: 4, tempMax: 100 }).seed(seed)
         pt.warmUp(null, 15)
         const samples = pt.sample(null, 4000)
         const values = samples.map(s => s[0])


### PR DESCRIPTION
## Summary

Migrates `ran.mc.ParallelTempering` to an options-object constructor — `new ParallelTempering({ logDensity, ...options })` — bringing it in line with every other `ran.mc` sampler and coordinator (RWM, AdaptiveMetropolis, Slice, HMC, MALA, NUTS, Gibbs per ADR-0030; ARS per ADR-0031) and removing the last positional-constructor wart in `ran.mc`. The positional form `new ParallelTempering(logDensity, options)` still constructs and samples correctly but emits a one-time `console.warn` on first use (module-level `warnedPositionalDeprecation` flag) and is scheduled for removal in v1.32.0. `ParallelTempering` remains a standalone coordinator, not an `MCMC` subclass (ADR-0028) — only the call convention is aligned.

Closes #1034

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 7786 passing, coverage thresholds met)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior (existing tests migrated to the options-object form; new deprecated-positional block verifies construct/sample + warn-exactly-once)
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [x] `CHANGELOG.md` updated under `## [Unreleased]` (new `### Deprecated` bullet naming v1.32.0)
- [x] Production-code diff is under ~400 lines (tests excluded) — 37 lines in `src/mc/parallel-tempering.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9tBAFbnz3p3PzCHYQd42L

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9tBAFbnz3p3PzCHYQd42L)_