### PR TITLE
Rework /release to run via GitHub MCP + dispatch workflow

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -65,7 +65,7 @@ Full pipelines that chain multiple skills together.
 | Skill | Pipeline | When to use |
 |-------|----------|-------------|
 | [`/build`](skills/build/SKILL.md) | research → plan → implement → validate → review → ship (commit, compound, push, PR) | Full pipeline from issue to PR |
-| [`/release`](skills/release/SKILL.md) | preflight → version bump → changelog → PR → merge → tag → milestone rotation | Cut a versioned npm release end-to-end |
+| [`/release`](skills/release/SKILL.md) | preflight → version bump → changelog → PR → merge (all via GitHub MCP) → trigger `release.yml` (tag, npm publish, GitHub release, milestone rotation) | Cut a versioned npm release end-to-end |
 
 ### Leaf Skills
 
@@ -252,7 +252,7 @@ Launched **in parallel** by [`/suggest`](skills/suggest/SKILL.md). Each scout sc
 
 /validate ───→ discovery-thoughts
 
-/release ────→ (no agents; uses git + gh CLI directly)
+/release ────→ (no agents; GitHub MCP for PR/merge, then triggers .github/workflows/release.yml for tag/publish/release/milestone)
 
 /fix ────────→ ops-triage
               → ops-issue (per definite bug)

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -28,9 +28,11 @@ omitted, the version is computed by bumping the minor part of the current
 - GitHub MCP tools available (`mcp__github__*`).
 - `NPM_TOKEN` secret configured in repo Settings → Secrets → Actions (npm
   publish permission).
-- The `v*` tag-protection rule must let **`github-actions[bot]` bypass** it
-  (Settings → Rules → Tag protection → Bypass list), so the workflow's built-in
-  `GITHUB_TOKEN` can create the release tag. This is a one-time setup.
+- `RELEASE_TOKEN` secret configured — a fine-grained PAT owned by a repo admin
+  (repo: this one, Contents: read+write). `github-actions[bot]` cannot be added
+  to the `v*` tag-protection ruleset's bypass list, so the workflow uses this
+  PAT (which authenticates as an admin, who is in the bypass list) solely to
+  push the release tag. One-time setup.
 - `main` must be the default branch and there must be no in-flight release PR
   or existing `v{VERSION}` tag.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,8 +1,17 @@
 # Release Skill
 
 You are cutting a versioned release of ranjs: bumping the version, updating
-the changelog, creating and merging a release PR, pushing the git tag that
-triggers npm publish, and rotating the GitHub milestone.
+the changelog, creating and merging a release PR, and handing off to the
+GitHub Actions release workflow which tags, publishes to npm, cuts the GitHub
+release, and rotates the milestone.
+
+This skill runs **entirely through GitHub MCP tools** — it needs neither the
+`gh` CLI nor a local git tag push. Everything the skill cannot do from an
+MCP-only environment (create the `v*` tag, `npm publish`, cut the GitHub
+release, rotate the milestone) is done server-side by
+`.github/workflows/release.yml`, which the skill triggers via
+`mcp__github__actions_run_trigger`. See
+`decisions/0037-mcp-orchestrated-release.md`.
 
 ## Invocation
 
@@ -10,322 +19,190 @@ triggers npm publish, and rotating the GitHub milestone.
 /release [version]
 ```
 
-Optional `version` argument — the exact semver to release, e.g. `1.25.0`. If
+Optional `version` argument — the exact semver to release, e.g. `1.31.0`. If
 omitted, the version is computed by bumping the minor part of the current
-`package.json` version (`1.24.6` → `1.25.0`).
+`package.json` version (`1.30.0` → `1.31.0`).
 
 ## Pre-conditions
 
-- `gh` CLI must be installed and authenticated (`gh auth status`)
-- Must be on `main` with a clean working tree
-- Network access to GitHub and npm must be available
+- GitHub MCP tools available (`mcp__github__*`).
+- `NPM_TOKEN` secret configured in repo Settings → Secrets → Actions (npm
+  publish permission).
+- The `v*` tag-protection rule must let **`github-actions[bot]` bypass** it
+  (Settings → Rules → Tag protection → Bypass list), so the workflow's built-in
+  `GITHUB_TOKEN` can create the release tag. This is a one-time setup.
+- `main` must be the default branch and there must be no in-flight release PR
+  or existing `v{VERSION}` tag.
+
+Throughout, use these MCP tools with `owner` = the repo owner and `repo` = the
+repo name (derive from the remote, e.g. `synesenom`/`ran`).
 
 ## Workflow
 
 ### 1. Pre-flight
 
-```bash
-gh auth status
-git status --short        # must be empty
-git branch --show-current # must be 'main'
-git pull origin main
-```
+- `mcp__github__list_pull_requests` (state `open`) — abort if a
+  `Release v*` PR is already open.
+- `mcp__github__get_tag` for `v{VERSION}` once VERSION is known — abort if it
+  already exists.
+- `mcp__github__list_commits` on `main` — note the latest commit; the release
+  PR bases off it.
 
-Abort with a clear error message if any check fails.
+Abort with a clear message if any check fails.
 
 ---
 
 ### 2. Determine version
 
-```bash
-CURRENT=$(node -p "require('./package.json').version")
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-```
+Read the current version from `package.json` (via `mcp__github__get_file_contents`
+on `main`, or the local checkout if present).
 
-**If a `version` argument was provided**, use it as `VERSION` directly.
+**If a `version` argument was provided**, use it as `VERSION`.
 
 **Otherwise, default to a minor bump**: `X.Y.Z` → `X.(Y+1).0`.
 
 Under the numpy/scipy-style versioning policy, **breaking changes ship in
-minor releases** (behind a deprecation cycle), so the `breaking` label does
+minor releases** (behind a deprecation cycle), so a `breaking` label does
 **not** trigger a major bump. A major bump (`X.Y.Z` → `(X+1).0.0`) is reserved
 for a rare, sweeping overhaul and is only ever done by passing an explicit
-`version` argument — never inferred automatically from issue labels.
+`version` argument.
 
-Surface any `breaking`-labelled issues closed since the last tag so the
-operator is aware of behavior changes in this minor release (informational
-only — it does not change the bump type):
+Optionally surface `breaking`-labelled issues closed since the last release via
+`mcp__github__search_issues` so the operator is aware of behavior changes
+(informational only — it does not change the bump type).
 
-```bash
-if [ -n "$LAST_TAG" ]; then
-  LAST_TAG_DATE=$(git log -1 --format=%cI "$LAST_TAG")
-  BREAKING_CLOSED=$(gh issue list \
-    --state closed \
-    --label breaking \
-    --json number,closedAt,title \
-    --jq ".[] | select(.closedAt > \"$LAST_TAG_DATE\") | \"#\(.number) \(.title)\"")
-fi
-```
+Compute `NEXT_VERSION` = `X.(Y+1).0` (the milestone the workflow will create).
 
-Compute `NEXT_VERSION` (the milestone to create after this release):
-- Any release `X.Y.0` → next is `X.(Y+1).0`
-
-Print `VERSION`, the bump type, any `breaking`-labelled issues in the release,
-and `NEXT_VERSION` so the operator can confirm before continuing.
+Print `VERSION`, the bump type, any `breaking` issues, and `NEXT_VERSION`.
 
 ---
 
 ### 3. Show what's in the release
 
-```bash
-if [ -n "$LAST_TAG" ]; then
-  CHANGES=$(git log "${LAST_TAG}..HEAD" --oneline --no-merges)
-else
-  CHANGES=$(git log --oneline --no-merges)
-fi
-echo "$CHANGES"
-```
-
-Display the commit list. If it is empty, warn and ask the operator whether to
-continue.
+Use `mcp__github__list_commits` on `main` since the last release to display the
+commit list. If it is empty, warn and ask the operator whether to continue.
 
 ---
 
 ### 4. Create release branch
 
-```bash
-git checkout -b "release/v${VERSION}"
-```
+`mcp__github__create_branch` — create `release/v{VERSION}` from `main`.
 
 ---
 
 ### 5. Update version files
 
-**`package.json` + `package-lock.json`** — update both atomically:
+On the `release/v{VERSION}` branch, edit and stage (do not commit yet — bundle
+with step 6 into one commit):
 
-```bash
-npm version "${VERSION}" --no-git-tag-version
-```
-
-**`CHANGELOG.md`** — replace the `## [Unreleased]` heading with the versioned
-heading and prepend a fresh empty `[Unreleased]` section above it:
-
-```
-## [Unreleased]
-
-## [1.25.0] - 2026-05-18
-```
-
-Use today's date in `YYYY-MM-DD` format. Do not alter any other content in
-the file.
+- **`package.json`** — set `"version"` to `VERSION`.
+- **`package-lock.json`** — set both the top-level `"version"` and the
+  `packages[""].version` to `VERSION` (keep them in sync so `npm ci` on the
+  runner does not fail).
 
 ---
 
 ### 6. Consolidate CHANGELOG
 
-Read the new `## [VERSION]` section (everything between its heading and the
-next `## [` heading) and rewrite it in-place:
+**This is the step that stays in the skill's judgement** — the workflow only
+reads the finished section. Rewrite `CHANGELOG.md`:
 
-1. **Order subsections** to the canonical Keep-a-Changelog sequence:
-   `Added` → `Changed` → `Deprecated` → `Removed` → `Fixed` → `Security`.
-   Drop any subsection that has no bullets.
+1. Replace the `## [Unreleased]` heading with `## [VERSION] - YYYY-MM-DD`
+   (today's date) and prepend a fresh empty `## [Unreleased]` section above it.
 
-2. **Merge grouped bullets.** If multiple bullets describe the same logical
-   change applied to several items (e.g. "_fitInit MOM overrides added for
-   distributions A, B, C" appearing as separate bullets), collapse them into a
-   single bullet that names all items. The goal is one bullet per logical
-   change, not one bullet per file or distribution.
+2. **Order subsections** in the new `## [VERSION]` section to the canonical
+   Keep-a-Changelog sequence: `Added` → `Changed` → `Deprecated` → `Removed`
+   → `Fixed` → `Security`. Drop any subsection with no bullets. Merge any
+   duplicate subsections (e.g. two `### Added` blocks) into one.
 
-3. **Keep every distinct change.** Do not silently drop a bullet that does not
-   fit an obvious group — prefer a slightly longer list over a lossy summary.
+3. **Merge grouped bullets.** Collapse multiple bullets describing the same
+   logical change applied to several items into a single bullet that names all
+   items. One bullet per logical change, not per file.
 
-4. **Do not touch** any section below the new versioned heading (prior
-   releases stay exactly as they are).
+4. **Keep every distinct change.** Prefer a slightly longer list over a lossy
+   summary. **Do not touch** anything below the new versioned heading.
 
-After editing, verify the file parses correctly (no duplicate headings, no
-orphaned bullets outside a subsection).
+Verify the file parses correctly (no duplicate headings, no orphaned bullets).
 
 ---
 
-### 7. Commit and push
+### 7. Commit release branch
 
-```bash
-git add package.json package-lock.json CHANGELOG.md
-git commit -m "Release v${VERSION}"
-git push -u origin "release/v${VERSION}"
-```
+Commit the step 5 + step 6 edits as a single commit `Release v{VERSION}` on
+`release/v{VERSION}` using `mcp__github__push_files` (all files in one commit).
 
 ---
 
 ### 8. Create PR
 
-```bash
-PR_URL=$(gh pr create \
-  --title "Release v${VERSION}" \
-  --base main \
-  --body "$(cat <<EOF
-## Release v${VERSION}
+`mcp__github__create_pull_request`:
+- title: `Release v{VERSION}`
+- base: `main`, head: `release/v{VERSION}`
+- body: the commit list from step 3 plus a note
+  `*Automated release PR — do not add commits to this branch.*`
 
-### Changes since ${LAST_TAG:-initial commit}
-
-${CHANGES}
-
----
-*Automated release PR — do not add commits to this branch.*
-
-https://claude.ai/code/session_01NNVzrusD7ynZgfa1ZEP2wC
-EOF
-)")
-echo "PR: ${PR_URL}"
-```
+Record the PR number and URL.
 
 ---
 
 ### 9. Merge PR
 
-```bash
-gh pr merge --merge --auto
-```
+Wait for the PR's required checks to pass, then merge:
 
-Poll until merged (5-minute timeout, 5-second interval):
+- Poll `mcp__github__pull_request_read` (and `mcp__github__get_check_run` if
+  needed) until the PR is mergeable and checks are green (5-minute timeout,
+  ~15-second interval).
+- `mcp__github__merge_pull_request` with method `merge`.
 
-```bash
-for i in $(seq 1 60); do
-  STATE=$(gh pr view --json state -q '.state')
-  [ "$STATE" = "MERGED" ] && break
-  if [ "$i" -eq 60 ]; then
-    echo "ERROR: Timed out waiting for PR to merge. Merge it manually, then"
-    echo "       run: git checkout main && git pull && git tag v${VERSION} && git push origin v${VERSION}"
-    exit 1
-  fi
-  sleep 5
-done
-```
+If the merge is blocked or times out, stop and report — do not force it.
 
 ---
 
-### 10. Tag the release
+### 10. Trigger the release workflow
 
-```bash
-git checkout main
-git pull origin main
-git tag "v${VERSION}"
-git push origin "v${VERSION}"
-```
+Once the PR is merged (the bumped `package.json` and consolidated `CHANGELOG.md`
+are now on `main`), trigger the workflow:
 
-This push triggers `.github/workflows/release.yml` (lint → typecheck → tests →
-`npm publish --provenance`).
+- `mcp__github__actions_run_trigger` — `workflow_id` `release.yml`, `ref`
+  `main`, `inputs: { version: "VERSION" }`.
 
----
+The workflow then, on the runner, does everything MCP cannot:
 
-### 11. Update GitHub release notes
+- creates and pushes the `v{VERSION}` tag,
+- runs lint/typecheck/tests and `npm publish --provenance`,
+- cuts the GitHub release with the consolidated `## [VERSION]` notes from
+  `CHANGELOG.md`,
+- rotates the milestone (creates `v{NEXT_VERSION}`, moves open issues, closes
+  `v{VERSION}`).
 
-CI creates the GitHub release as part of `release.yml`. Poll until it appears,
-then replace its body with the consolidated `## [VERSION]` section from
-`CHANGELOG.md` so the release page shows the canonical `### Added`,
-`### Changed`, `### Fixed`, `### Removed` sections.
-
-```bash
-# Poll until CI creates the GitHub release (15-minute timeout, 15-second interval)
-RELEASE_READY=0
-for i in $(seq 1 60); do
-  if gh release view "v${VERSION}" > /dev/null 2>&1; then
-    RELEASE_READY=1
-    break
-  fi
-  echo "Waiting for GitHub release v${VERSION}... ($((i * 15))s elapsed)"
-  sleep 15
-done
-
-if [ "$RELEASE_READY" -eq 0 ]; then
-  echo "Warning: GitHub release v${VERSION} not found after 15 minutes."
-  echo "         Edit manually: https://github.com/${REPO}/releases/tag/v${VERSION}"
-else
-  # Extract the versioned section body (skip the heading line itself)
-  RELEASE_NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
-  gh release edit "v${VERSION}" --notes "$RELEASE_NOTES"
-  echo "GitHub release v${VERSION} notes updated."
-fi
-```
-
-This step is best-effort — a timeout warns and continues rather than aborting
-the release.
+Poll `mcp__github__actions_list` / `mcp__github__actions_get` for the run and
+report its conclusion. If the run fails on the tag step, the most likely cause
+is the `github-actions[bot]` tag-protection bypass not being configured (see
+Pre-conditions).
 
 ---
 
-### 12. Milestone rotation
-
-```bash
-REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
-
-CURRENT_MS=$(gh api "repos/${REPO}/milestones" \
-  --jq ".[] | select(.title == \"v${VERSION}\") | .number")
-
-if [ -z "$CURRENT_MS" ]; then
-  echo "Warning: milestone v${VERSION} not found — skipping milestone rotation."
-else
-  # Create the next milestone before moving issues so the target exists
-  if gh api "repos/${REPO}/milestones" --jq '.[].title' | grep -qx "v${NEXT_VERSION}"; then
-    echo "Milestone v${NEXT_VERSION} already exists — skipping create."
-  else
-    gh api "repos/${REPO}/milestones" \
-      -X POST \
-      -f title="v${NEXT_VERSION}" \
-      -f description="Next release — bug fixes, new distributions, and non-breaking changes"
-  fi
-
-  # Move all open issues from the released milestone to the next one
-  OPEN_ISSUES=$(gh issue list \
-    --milestone "v${VERSION}" \
-    --state open \
-    --limit 200 \
-    --json number \
-    --jq '.[].number')
-
-  MOVED=0
-  for NUM in $OPEN_ISSUES; do
-    gh issue edit "$NUM" --milestone "v${NEXT_VERSION}"
-    MOVED=$((MOVED + 1))
-  done
-
-  # Close the released milestone
-  gh api "repos/${REPO}/milestones/${CURRENT_MS}" \
-    -X PATCH \
-    -f state=closed
-
-  echo "Milestone v${VERSION}: closed (${MOVED} open issues moved to v${NEXT_VERSION})"
-  echo "Milestone v${NEXT_VERSION}: ready"
-fi
-```
-
-Note: only the milestone whose title matches `v${VERSION}` is closed and
-rotated. Any future major-overhaul milestone, if one is ever created, is left
-untouched by this skill.
-
----
-
-### 13. Report
+### 11. Report
 
 End with a concise summary:
 
 ```
 Released:  v{VERSION}
-Tag:       v{VERSION} → triggers npm publish via CI
-PR:        {PR_URL}
-
-Milestone v{VERSION}:      closed  ({N} open issues moved)
-Milestone v{NEXT_VERSION}: created
+PR:        {PR_URL} (merged)
+Workflow:  {RUN_URL} → tag, npm publish, GitHub release, milestone rotation
+Milestone: v{VERSION} closed, v{NEXT_VERSION} created (by the workflow)
 ```
 
 ## Rules
 
-- **Abort if pre-flight fails** — never release from a dirty tree or a
-  non-main branch
-- **Never skip the tag push** — without it, `release.yml` never fires and
-  nothing is published to npm
-- **Milestone rotation is best-effort** — if the milestone is missing, warn
-  and continue; do not abort the release
-- **Only touch the released milestone** — leave any future major-overhaul
-  milestone untouched when releasing a minor version
+- **All GitHub state changes go through MCP** — never assume `gh` or a local
+  tag push is available.
+- **Never skip the workflow trigger** — without step 10 nothing is tagged or
+  published to npm. The merged PR alone publishes nothing.
+- **Consolidate the changelog in the skill, not the workflow** — the semantic
+  merge of grouped bullets is judgement the workflow cannot do; it only reads
+  the finished `## [VERSION]` section.
+- **Milestone rotation is best-effort** — the workflow warns and continues if
+  the milestone is missing.
 - **No interactive prompts mid-pipeline** — if anything is ambiguous, abort
-  early with a clear message rather than pausing mid-release
+  early with a clear message rather than pausing mid-release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,66 @@
 name: Release
 
-# Requires an NPM_TOKEN secret in GitHub repository settings (Settings > Secrets)
-# with npm publish permission. Tag protection rules should restrict v* tag
-# creation to maintainers only (Settings > Rules > Tag protection).
+# Two entry points, one publish path:
+#   - workflow_dispatch (primary): the /release skill merges the version-bump PR
+#     via GitHub MCP, then triggers this workflow with the target version. The
+#     runner creates the v* tag, publishes to npm, cuts the GitHub release, and
+#     rotates the milestone — everything the MCP-only skill cannot do itself.
+#   - push tags 'v*' (fallback): a maintainer with a local git checkout can still
+#     push a tag directly and get the same publish path.
+#
+# Requires an NPM_TOKEN secret (npm publish permission). The v* tag-protection
+# rule must let github-actions[bot] bypass it so the workflow_dispatch path can
+# create the tag with the built-in GITHUB_TOKEN (Settings > Rules > Tag
+# protection > Bypass list). A tag pushed by GITHUB_TOKEN does not re-trigger the
+# 'push: tags' event (GitHub loop prevention), so the dispatch path publishes
+# inline in this same run rather than depending on the tag trigger.
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 1.31.0 (must already be committed to main)'
+        required: true
   push:
     tags: ['v*']
 
 # id-token: write is required for npm provenance attestation generation.
+# issues: write is required for milestone rotation.
 permissions:
   contents: write
   id-token: write
+  issues: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            V="${{ inputs.version }}"
+          else
+            V="${GITHUB_REF_NAME#v}"
+          fi
+          if ! echo "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'$V' is not a valid semver version."
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Verify package.json matches input (dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$PKG" != "${{ steps.ver.outputs.version }}" ]; then
+            echo "::error::package.json version ($PKG) does not match requested ${{ steps.ver.outputs.version }}. Merge the release PR first."
+            exit 1
+          fi
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -32,12 +76,77 @@ jobs:
       - run: npm run jsdoclint
       - run: npm run check-decl && ./node_modules/.bin/tsc -p tsconfig.build.json && npm run typecheck
       - run: npm test
+
       - run: npm whoami
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes
+
+      # Tag only on dispatch — on the push-tags fallback the tag already exists.
+      # Publish is gated by tests above and runs first, so a failed publish never
+      # leaves a v* tag pointing at an unpublished version.
+      - name: Create and push tag (dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.ver.outputs.version }}"
+          git push origin "v${{ steps.ver.outputs.version }}"
+
+      # Notes come from the already-consolidated ## [version] CHANGELOG section
+      # (the skill does the semantic consolidation before merging), not
+      # --generate-notes. Idempotent: skip if the release already exists so a
+      # re-run never fails on the last step.
+      - name: Create GitHub release with consolidated notes
         env:
           GH_TOKEN: ${{ github.token }}
+        run: |
+          V="v${{ steps.ver.outputs.version }}"
+          NOTES=$(awk -v hdr="## [${{ steps.ver.outputs.version }}]" '
+            index($0, hdr) == 1 { f = 1; next }
+            f && /^## \[/ { exit }
+            f { print }
+          ' CHANGELOG.md)
+          if gh release view "$V" >/dev/null 2>&1; then
+            echo "Release $V already exists — leaving its notes unchanged."
+          else
+            gh release create "$V" --title "$V" --notes "$NOTES"
+          fi
+
+      # Best-effort: warn and continue if the milestone is missing.
+      - name: Milestone rotation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          V="${{ steps.ver.outputs.version }}"
+          MAJOR=$(echo "$V" | cut -d. -f1)
+          MINOR=$(echo "$V" | cut -d. -f2)
+          NEXT="${MAJOR}.$((MINOR + 1)).0"
+          REPO="${{ github.repository }}"
+
+          CURRENT_MS=$(gh api "repos/${REPO}/milestones" \
+            --jq ".[] | select(.title == \"v${V}\") | .number")
+          if [ -z "$CURRENT_MS" ]; then
+            echo "Milestone v${V} not found — skipping milestone rotation."
+            exit 0
+          fi
+
+          if gh api "repos/${REPO}/milestones" --jq '.[].title' | grep -qx "v${NEXT}"; then
+            echo "Milestone v${NEXT} already exists — skipping create."
+          else
+            gh api "repos/${REPO}/milestones" -X POST \
+              -f title="v${NEXT}" \
+              -f description="Next release — bug fixes, new distributions, and non-breaking changes"
+          fi
+
+          MOVED=0
+          for NUM in $(gh issue list --milestone "v${V}" --state open --limit 200 \
+            --json number --jq '.[].number'); do
+            gh issue edit "$NUM" --milestone "v${NEXT}"
+            MOVED=$((MOVED + 1))
+          done
+
+          gh api "repos/${REPO}/milestones/${CURRENT_MS}" -X PATCH -f state=closed
+          echo "Milestone v${V}: closed (${MOVED} open issues moved to v${NEXT})"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,26 @@
 name: Release
 
-# Two entry points, one publish path:
-#   - workflow_dispatch (primary): the /release skill merges the version-bump PR
-#     via GitHub MCP, then triggers this workflow with the target version. The
-#     runner creates the v* tag, publishes to npm, cuts the GitHub release, and
-#     rotates the milestone — everything the MCP-only skill cannot do itself.
-#   - push tags 'v*' (fallback): a maintainer with a local git checkout can still
-#     push a tag directly and get the same publish path.
+# Dispatch-driven release. The /release skill merges the version-bump PR via
+# GitHub MCP, then triggers this workflow with the target version. The runner
+# creates the v* tag, publishes to npm, cuts the GitHub release, and rotates the
+# milestone — everything the MCP-only skill cannot do itself.
 #
-# Requires an NPM_TOKEN secret (npm publish permission). The v* tag-protection
-# rule must let github-actions[bot] bypass it so the workflow_dispatch path can
-# create the tag with the built-in GITHUB_TOKEN (Settings > Rules > Tag
-# protection > Bypass list). A tag pushed by GITHUB_TOKEN does not re-trigger the
-# 'push: tags' event (GitHub loop prevention), so the dispatch path publishes
-# inline in this same run rather than depending on the tag trigger.
+# Why a PAT: github-actions[bot] cannot be added to the v* tag-protection
+# ruleset's bypass list, so the built-in GITHUB_TOKEN cannot create the tag. A
+# RELEASE_TOKEN secret (a fine-grained PAT owned by a repo admin, Contents:
+# read+write) authenticates as that admin — who IS in the bypass list — and is
+# used ONLY for the tag push. Everything else uses GITHUB_TOKEN. The workflow is
+# dispatch-only: with a PAT, a 'push: tags' trigger would re-fire on the tag
+# push and double-publish, so there is no tag trigger.
+#
+# Requires: NPM_TOKEN (npm publish) and RELEASE_TOKEN (admin PAT) secrets in
+# Settings > Secrets > Actions.
 on:
   workflow_dispatch:
     inputs:
       version:
         description: 'Version to release, e.g. 1.31.0 (must already be committed to main)'
         required: true
-  push:
-    tags: ['v*']
 
 # id-token: write is required for npm provenance attestation generation.
 # issues: write is required for milestone rotation.
@@ -34,26 +33,24 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # RELEASE_TOKEN so the later tag push authenticates as an admin and
+      # bypasses the v* tag-protection ruleset.
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
       - name: Resolve version
         id: ver
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            V="${{ inputs.version }}"
-          else
-            V="${GITHUB_REF_NAME#v}"
-          fi
+          V="${{ inputs.version }}"
           if ! echo "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::'$V' is not a valid semver version."
             exit 1
           fi
           echo "version=$V" >> "$GITHUB_OUTPUT"
 
-      - name: Verify package.json matches input (dispatch only)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Verify package.json matches input
         run: |
           PKG=$(node -p "require('./package.json').version")
           if [ "$PKG" != "${{ steps.ver.outputs.version }}" ]; then
@@ -84,11 +81,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Tag only on dispatch — on the push-tags fallback the tag already exists.
-      # Publish is gated by tests above and runs first, so a failed publish never
-      # leaves a v* tag pointing at an unpublished version.
-      - name: Create and push tag (dispatch only)
-        if: github.event_name == 'workflow_dispatch'
+      # Tag after a successful publish (publish is gated by the tests above), so
+      # a failed publish never leaves a v* tag pointing at an unpublished
+      # version. Pushed via the RELEASE_TOKEN remote configured by checkout.
+      - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/decisions/0037-mcp-orchestrated-release.md
+++ b/decisions/0037-mcp-orchestrated-release.md
@@ -1,0 +1,55 @@
+# ADR-0037: MCP-orchestrated release with workflow finalization
+
+**Date**: 2026-07-20
+**Status**: Accepted
+
+## Context
+
+The `/release` skill was written around the `gh` CLI and a local git tag push:
+it required a maintainer on a machine with `gh` authenticated, a clean `main`
+checkout, and permission to push a `v*` tag. That excludes the environments the
+skill is increasingly run from — Claude Code on the web and other MCP-only
+sessions — which have no `gh` CLI and are restricted from pushing protected
+tags. In those environments the release simply could not be cut.
+
+The GitHub MCP tools available in those sessions can create branches, commit
+files, open PRs, and merge PRs, but they have **no** tool to create a git tag,
+create/edit a GitHub release, or create/close a milestone. The one publish
+trigger — pushing the `v*` tag — was therefore unreachable.
+
+## Decision
+
+Split the release across two actors, matched to what each can do:
+
+- **The `/release` skill, via GitHub MCP**, does everything that is reachable
+  through MCP: version decision, the semantic **changelog consolidation** (which
+  requires judgement no script can replicate), the version-bump commit, the
+  release PR, and the merge to `main`.
+- **`.github/workflows/release.yml`** does everything MCP cannot, on a runner
+  where `gh`/`npm` exist: create and push the `v*` tag, `npm publish
+  --provenance`, cut the GitHub release from the already-consolidated
+  `## [version]` changelog section, and rotate the milestone.
+
+The skill hands off by triggering the workflow with `workflow_dispatch`
+(`mcp__github__actions_run_trigger`, passing the target `version`). The workflow
+keeps its `push: tags: ['v*']` trigger as a fallback for maintainers with a
+local checkout. Because a tag pushed by the built-in `GITHUB_TOKEN` does not
+re-trigger the `push: tags` event (GitHub loop prevention), the dispatch path
+publishes inline in the same run rather than depending on the tag trigger — so
+no PAT is required. The only setup cost is a one-time tag-protection **bypass
+for `github-actions[bot]`**.
+
+## Consequences
+
+- A release can be cut from any MCP-only environment (web, mobile-driven
+  sessions) with no `gh` CLI and no local tag push.
+- The intelligent changelog consolidation stays in the skill; the workflow only
+  reads the finished section, avoiding a brittle consolidation script.
+- Milestone rotation and GitHub-release creation move from the skill into the
+  workflow, where the required `gh`/API access actually exists; both are
+  idempotent and best-effort.
+- New coupling: the workflow trusts that `main`'s `package.json` version matches
+  the dispatched `version` (guarded by an explicit check) and that the
+  `## [version]` changelog section is present and consolidated before dispatch.
+- Requires the `github-actions[bot]` tag-protection bypass; without it the
+  dispatch path fails at the tag-creation step.

--- a/decisions/0037-mcp-orchestrated-release.md
+++ b/decisions/0037-mcp-orchestrated-release.md
@@ -32,12 +32,16 @@ Split the release across two actors, matched to what each can do:
 
 The skill hands off by triggering the workflow with `workflow_dispatch`
 (`mcp__github__actions_run_trigger`, passing the target `version`). The workflow
-keeps its `push: tags: ['v*']` trigger as a fallback for maintainers with a
-local checkout. Because a tag pushed by the built-in `GITHUB_TOKEN` does not
-re-trigger the `push: tags` event (GitHub loop prevention), the dispatch path
-publishes inline in the same run rather than depending on the tag trigger — so
-no PAT is required. The only setup cost is a one-time tag-protection **bypass
-for `github-actions[bot]`**.
+is dispatch-only and publishes inline in that run.
+
+Tag creation needs a credential the tag-protection ruleset will honor.
+`github-actions[bot]` cannot be added to a repository ruleset's bypass list
+(only roles and installed Apps are selectable), so the built-in `GITHUB_TOKEN`
+cannot create a `v*` tag. The workflow therefore uses a `RELEASE_TOKEN` secret —
+a fine-grained PAT owned by a repo admin (who is in the bypass list) — **solely
+for the tag push**; every other step (`npm publish`, GitHub release, milestone
+rotation) uses `GITHUB_TOKEN`. The `push: tags: ['v*']` trigger is deliberately
+omitted: a PAT-pushed tag would re-fire it and double-publish.
 
 ## Consequences
 
@@ -51,5 +55,10 @@ for `github-actions[bot]`**.
 - New coupling: the workflow trusts that `main`'s `package.json` version matches
   the dispatched `version` (guarded by an explicit check) and that the
   `## [version]` changelog section is present and consolidated before dispatch.
-- Requires the `github-actions[bot]` tag-protection bypass; without it the
-  dispatch path fails at the tag-creation step.
+- Requires a `RELEASE_TOKEN` admin PAT secret; without it the dispatch path
+  fails at the tag-creation step. The PAT is used only for the tag push, so its
+  blast radius is limited to Contents write. If the PAT is given an expiry it
+  must be rotated.
+- Dropping the `push: tags` trigger removes the local-tag-push fallback; a
+  maintainer with a checkout releases via `gh workflow run release.yml` or the
+  Actions UI instead.


### PR DESCRIPTION
## Summary

Makes `/release` runnable from an MCP-only environment (no `gh` CLI, no local tag push — e.g. Claude Code on the web or a phone). The skill now drives the version bump, changelog consolidation, and the release PR + merge entirely through GitHub MCP tools, then triggers `release.yml` via `workflow_dispatch`. The workflow does everything an MCP session can't: create the `v*` tag, `npm publish --provenance`, cut the GitHub release from the consolidated changelog notes, and rotate the milestone.

## Design decisions

- [ADR-0037: MCP-orchestrated release with workflow finalization](decisions/0037-mcp-orchestrated-release.md) — split the release between the skill (MCP-reachable steps + judgement-based changelog consolidation) and the workflow (tag/publish/release/milestone), handing off via `workflow_dispatch`.

## Non-trivial changes

- **`.github/workflows/release.yml`**: Converted from a tag-triggered publisher into a **dispatch-only** release pipeline with a `version` input. It verifies `package.json` matches the requested version, runs the full lint/typecheck/test gate, publishes to npm, then creates+pushes the tag, cuts an idempotent GitHub release (consolidated `## [version]` notes rather than `--generate-notes`), and rotates the milestone. The tag push uses a new `RELEASE_TOKEN` admin PAT secret — `github-actions[bot]` can't be added to the `v*` tag-protection ruleset's bypass list, so `GITHUB_TOKEN` can't create the tag; every other step still uses `GITHUB_TOKEN`. The `push: tags` trigger was intentionally dropped: a PAT-pushed tag would re-fire it and double-publish.
- **`.claude/skills/release/SKILL.md`**: Rewritten from a `gh`+local-git script into an MCP-driven procedure (`create_branch` → edit files → `push_files` → `create_pull_request` → `merge_pull_request` → `actions_run_trigger`). Preconditions now require the `RELEASE_TOKEN` PAT. Changelog consolidation stays in the skill (the semantic bullet-merge the workflow can't do); the workflow only reads the finished section.

## Operational prerequisite

Before the new flow can publish, a `RELEASE_TOKEN` secret must be added: a fine-grained PAT owned by a repo admin, scoped to this repo with **Contents: read+write**. `NPM_TOKEN` is unchanged.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [ ] Tests added or updated for changed behavior — N/A (workflow/skill/docs only; no runtime code)
- [ ] If a new distribution was added — N/A
- [ ] If a new distribution was added — N/A
- [x] `CHANGELOG.md` updated — intentionally skipped (tooling/docs change, not user-visible library behavior)
- [x] Production-code diff is under ~400 lines (tests excluded)

## Comprehension checklist

- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* a PAT is required instead of `GITHUB_TOKEN` (ruleset bypass limitation)
- [ ] I understand *why* the `push: tags` trigger was dropped (PAT double-publish)
- [ ] WHY comments are present where the logic is non-obvious

<details>
<summary>Trivial changes</summary>

- **`.claude/README.md`**: Updated the `/release` pipeline description and the agent-flow line to reflect the MCP + dispatch-workflow split.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxmxQjpLTw3ULX1J4WZr3K)_