### PR TITLE
Render nested options params in docs; prune filed todo.md items

### DIFF
--- a/.claude/skills/suggest/SKILL.md
+++ b/.claude/skills/suggest/SKILL.md
@@ -67,13 +67,34 @@ For each selected suggestion, use the `ops-issue` agent to create a GitHub issue
 
 Launch issue creation agents **in parallel** for all selected suggestions.
 
-### 7. Report
+Keep the mapping of `suggestion → created issue (number, URL)` — Step 7 needs it.
+
+### 7. Remove Filed Suggestions from `todo.md`
+
+`todo.md` is a backlog of not-yet-filed work. Once a suggestion has been filed as a GitHub issue, it no longer belongs there — leaving it in place produces a duplicate the next `/suggest` run (or a human) could re-file.
+
+For each issue created in Step 6:
+
+1. Search `todo.md` for an entry that corresponds to the filed suggestion. Match by title first (e.g. a suggestion titled "Waring distribution" against a `#### Waring` heading), then by clear topical overlap in the body text if no heading matches exactly. Be conservative — only treat it as a match if you're confident it's describing the same piece of work, not merely a related one.
+2. If a match is found, remove that entry entirely from `todo.md`:
+   - A distribution/section entry (`#### Heading` or `### Heading`) — delete the heading and its full body, up to (but not including) the next heading of the same or higher level.
+   - A list bullet (e.g. under a "Not Yet Filed" list) — delete just that bullet.
+   - A table row (e.g. under a "Filed as GitHub Issues" table) — this only applies to entries that were *not yet* filed, so new rows are never added here as a result of this step.
+   - Do not leave behind a placeholder, an "already filed" note, or a dangling link — the point is removal, not annotation.
+   - If removing the entry leaves its parent section (e.g. a "Not Yet Filed" list) completely empty, remove that now-empty parent heading too rather than leaving a heading with no content under it.
+3. If no match is found, skip — not every suggestion originates from `todo.md` (e.g. `suggest-testing` and `suggest-infra` findings usually don't).
+
+If any entries were removed, commit `todo.md` with a message referencing the filed issue number(s) (e.g. `Remove filed todo.md entries (#830, #831)`) and push to the current branch.
+
+### 8. Report
 
 > "Created <N> issue(s):
 >
 > | Issue | Title | Priority | Difficulty |
 > |-------|-------|----------|------------|
 > | #<N>  | ...   | ...      | ...        |"
+
+If any `todo.md` entries were removed, add a line noting which ones and for which issues.
 
 ## Rules
 
@@ -83,7 +104,10 @@ Launch issue creation agents **in parallel** for all selected suggestions.
 - Let the user pick — never auto-create issues
 - Use `ops-issue` for issue creation — never call `gh issue create` directly
 - Use multi-select so the user can pick multiple suggestions at once
+- After filing an issue, remove its corresponding entry from `todo.md` if one exists, and commit/push that change
 
 ### DO NOT:
 - Create issues without user confirmation
 - Skip the ranking/dedup step
+- Leave a stale `todo.md` entry in place for a suggestion that was just filed as an issue
+- Remove a `todo.md` entry that only loosely resembles the filed issue — when in doubt, leave it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The generated API docs (`npm run docs`) now render the individual fields of every options-object constructor (e.g. `ran.mc.RWM`'s `options.logDensity`, `options.config`, `options.initialState`; `ran.mc.HMC`'s additional `options.gradLogDensity`) as indented rows in the Parameters table, instead of silently dropping them behind a single opaque `options: Object` row. `documentation.js` nests dotted `@param` tags (e.g. `@param {Object} options.config`) under the parent param's `properties` array rather than returning them as flat top-level params; `docs/src/param-parser.js` never read that array, so every JSDoc'd nested field for every options-object constructor in the codebase (`RWM`, `AdaptiveMetropolis`, `HMC`, `NUTS`, `MALA`, `Gibbs`, `Slice`, `ParallelTempering`) was invisible in the rendered docs even though it was correctly documented in the source JSDoc. `docs/index.js`'s call-signature renderer is updated alongside to use only the top-level (depth-0) params, so signatures still read e.g. `RWM(options)` rather than incorrectly listing the newly-surfaced nested fields as separate positional arguments.
+
 ## [1.31.0] - 2026-07-20
 
 ### Added

--- a/docs/index.js
+++ b/docs/index.js
@@ -79,8 +79,11 @@ function sourceLink (location) {
 }
 
 function renderSignature (entry, params) {
-  const args = params.map((d, i) => `${d.optional ? '[' : ''}${i > 0 ? ', ' : ''}${d.name}`).join('')
-  const closers = params.filter(d => d.optional).map(() => ']').join('')
+  // `params` now includes flattened nested properties (e.g. options.config) alongside the
+  // actual positional arguments (depth 0) — only the latter belong in a call signature.
+  const topLevel = params.filter(d => d.depth === 0)
+  const args = topLevel.map((d, i) => `${d.optional ? '[' : ''}${i > 0 ? ', ' : ''}${d.name}`).join('')
+  const closers = topLevel.filter(d => d.optional).map(() => ']').join('')
   return `${entry.memberof}.${entry.name}(${args}${closers})`
 }
 
@@ -98,7 +101,9 @@ function parseEntry (entry) {
   const location = resolveLocation(entry)
   // entry.params, entry.returns[0] and entry.deprecated don't carry their own context, so
   // every DescParser call is given the enclosing entry's location for error reporting (#980).
-  const params = sourceParams.map(p => ParamParser(p, location))
+  // ParamParser returns a param plus its flattened nested properties (e.g. options.config),
+  // so this must flatMap rather than map or nested fields collapse back into arrays-of-arrays.
+  const params = sourceParams.flatMap(p => ParamParser(p, location))
   const throws = sourceThrows.map(ThrowsParser)
 
   return {

--- a/docs/src/param-parser.js
+++ b/docs/src/param-parser.js
@@ -1,15 +1,27 @@
 const DescParser = require('./desc-parser')
 const TypeParser = require('./type-parser')
 
-module.exports = (param, location) => {
-
+// documentation.js nests dotted @param tags (e.g. `@param {Object} options.config`) under the
+// parent param's `properties` array rather than returning them as flat top-level params (see
+// node_modules/documentation/src/nest.js). Recursing here is what surfaces options-object
+// constructors' actual fields (options.logDensity, options.config, ...) in the rendered
+// Parameters table instead of silently dropping them behind a single opaque "options: Object" row.
+module.exports = function ParamParser (param, location, depth = 0) {
   const isOptional = type => type.type === 'OptionalType' || typeof param.default !== 'undefined'
 
-  return {
-    name: param.name,
+  const row = {
+    // Last path segment only (documentation.js names nested properties by their full dotted
+    // path, e.g. "options.config") — depth-based indentation in the template already conveys
+    // the nesting, so repeating the parent prefix on every row would be redundant.
+    name: param.name.split('.').pop(),
     desc: DescParser(param, location),
     optional: isOptional(param.type),
     default: param.default && param.default.replace('=>', ' => '),
-    type: TypeParser(param.type)
+    type: TypeParser(param.type),
+    depth
   }
+
+  const children = (param.properties || []).flatMap(child => ParamParser(child, location, depth + 1))
+
+  return [row, ...children]
 }

--- a/docs/templates/index.pug
+++ b/docs/templates/index.pug
@@ -68,7 +68,7 @@ block content
                     tbody
                         each param in entry.params
                             tr
-                                td.param-name #{param.name}
+                                td.param-name(style=`padding-left: ${1 + param.depth * 1.25}em`) #{param.name}
                                 td.param-type
                                     each type in param.type
                                         code.type #{type}


### PR DESCRIPTION
## Summary
- Fixed the generated API docs so options-object constructors (`RWM`, `HMC`, `NUTS`, `MALA`, `Gibbs`, `AdaptiveMetropolis`, `Slice`, `ParallelTempering`) render their actual fields (`options.logDensity`, `options.config`, `options.initialState`, etc.) instead of a single opaque `options: Object` row — the fields were always documented in JSDoc but silently dropped by the doc generator.
- Updated the `/suggest` skill so that once a suggested issue is filed, its corresponding `todo.md` entry (if any) is removed, preventing the same backlog item from being re-suggested/re-filed later.

## Checklist
- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior — N/A: this PR fixes the docs-generation build tool and a `/suggest` skill workflow step, neither of which is covered by `npm test` (nyc's coverage scope is `src/**/*.js` only)
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Production-code diff is under ~400 lines (tests excluded)

## Non-trivial changes
- **`docs/src/param-parser.js`**: `documentation.js` nests dotted `@param` tags (e.g. `options.config`) under the parent param's `properties` array rather than returning them as flat top-level params. `ParamParser` never read that array, so every JSDoc'd nested field for every options-object constructor in the codebase was invisible in the rendered docs. Now recurses into `properties` and returns a flat, depth-tagged array of rows.
- **`docs/index.js`**: `renderSignature` previously used the same (now-flattened) params array to build the call signature, which would have incorrectly listed nested fields (`logDensity`, `config`, `initialState`, ...) as separate positional arguments (e.g. `RWM(options, logDensity, config, initialState)`). Filtered to depth-0 params so signatures still read `RWM(options)`.
- **`.claude/skills/suggest/SKILL.md`**: New Step 7 deletes a `todo.md` entry once the corresponding suggestion is filed as a GitHub issue (whole heading+body, a list bullet, or — conservatively — nothing if no confident match is found). This is a content-deletion workflow change worth double-checking for over-eager matching.

_No ADR added: this change is implementation-technique-level (a bug fix inside the docs-generation build tool and an internal `/suggest` skill workflow step) — it doesn't touch `Distribution`/base-class public API, module export structure, or any cross-cutting library convention, so it falls outside CLAUDE.md's ADR trigger criteria._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`CHANGELOG.md`**: Added a `### Fixed` entry under `[Unreleased]` documenting the docs-rendering fix.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqDso2mWS9kjkyAFMuSLsZ)_