### PR TITLE
Guard paramCountCases loop against vacuous aic()/bic() passes

### DIFF
--- a/test/dist-base.js
+++ b/test/dist-base.js
@@ -1299,6 +1299,13 @@ describe('dist', () => {
         assert.strictEqual(d.k, k)
       })
 
+      // A sample outside the distribution's support drives lnL(sample) to -Infinity, which makes
+      // aic()/bic() below both evaluate to Infinity regardless of k, passing by Infinity === Infinity
+      // coincidence. This guard fails loudly instead, so a future case needs its own sample override.
+      it('lnL(sample) should be finite so aic()/bic() below genuinely discriminate on k', () => {
+        assert(Number.isFinite(d.lnL(sample)), `lnL(sample) is ${d.lnL(sample)} for ${name} - add a custom sample override for this case`)
+      })
+
       it(`aic() should use the corrected parameter penalty (k=${k})`, () => {
         assert.strictEqual(d.aic(sample), 2 * (k - d.lnL(sample)))
       })


### PR DESCRIPTION
## Summary

Adds an `assert(Number.isFinite(d.lnL(sample)), ...)` guard inside `test/dist-base.js`'s `paramCountCases` loop, before the `aic()`/`bic()` sub-assertions. If a case's sample falls outside its distribution's support, `lnL(sample)` is `-Infinity`, which makes `aic()`/`bic()` both evaluate to `Infinity` regardless of `this.k` — silently passing via `Infinity === Infinity` coincidence instead of actually testing the parameter-count penalty. The new guard fails loudly and immediately points at the offending case instead.

Closes #1056

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [ ] `npm run typecheck` passes — not applicable to this diff (test-only, no JSDoc/production code touched); typecheck requires `dist/index.d.ts` from a prior `npm run build`, which is an environment prerequisite unrelated to this change
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — n/a, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — n/a, no new distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — n/a, test-only change (per CLAUDE.md: "Pure refactors, test-only changes, and doc-only changes do not need a changelog entry")
- [x] Production-code diff is under ~400 lines (tests excluded) — 0 lines of production code changed; 7 lines added to `test/dist-base.js`

## Verification

- Manually reproduced the bug this guards against: temporarily removed `PowerLaw`'s custom `sample` override and confirmed the new guard assertion fails loudly (`lnL(sample) is -Infinity for PowerLaw`) while the `aic()`/`bic()` assertions below it still pass vacuously — exactly the failure mode described in #1056.
- Restored the override and confirmed all 22 existing `paramCountCases` entries (88 assertions) pass with the guard in place.
- Full suite: 7933 passing, coverage thresholds met.

## Code Health

`test/dist-base.js` drops from Code Health 10.0 to 9.09 with this change, flagged for "Number of Functions in a Single Module" (178 functions total — this PR's one added `it()` block tips it over CodeScene's Brain Class threshold). `test/dist-base.js` is a long-standing table-driven test file (1485+ lines) where every `it`/`describe` block counts as a function; splitting it into multiple files to bring the count back down is a major cross-file refactor that is out of scope for this trivial test-infra guard clause. Per CLAUDE.md's Code Health rule ("If a smell cannot be fixed within reasonable scope... document why in the PR description and proceed"), documenting here rather than attempting the refactor. A follow-up issue to split `test/dist-base.js` could be filed separately if the maintainer wants to address the underlying file size.
