### PR TITLE
Use explicit integer sample for BetaBinomial's paramCountCases entry

### DIFF
--- a/test/dist-base.js
+++ b/test/dist-base.js
@@ -1295,7 +1295,15 @@ describe('dist', () => {
     // issue #1049
     { name: 'PERT', ctor: () => new dist.PERT(0, 1, 3), k: 3, inherited: '2 from Beta' },
     { name: 'Bates', ctor: () => new dist.Bates(2, 0, 3), k: 3, inherited: '1 from IrwinHall' },
-    { name: 'BetaBinomial', ctor: () => new dist.BetaBinomial(5, 2, 3), k: 3, inherited: '2 from Categorical' },
+    {
+      name: 'BetaBinomial',
+      ctor: () => new dist.BetaBinomial(5, 2, 3),
+      k: 3,
+      inherited: '2 from Categorical',
+      // BetaBinomial is discrete with support {0, ..., n}, so the default (continuous-oriented) sample
+      // would only work via Distribution.pdf()'s implicit _toInt() rounding; use explicit integers instead.
+      sample: [0, 1, 2, 3, 4, 5, 1, 2, 3, 4]
+    },
     { name: 'SkewNormal', ctor: () => new dist.SkewNormal(0, 1, 2), k: 3, inherited: '2 from Normal' },
     { name: 'BirnbaumSaunders', ctor: () => new dist.BirnbaumSaunders(0, 1, 1), k: 3, inherited: '2 from Normal' },
     { name: 'JohnsonSB', ctor: () => new dist.JohnsonSB(0, 1, 3, 0), k: 4, inherited: '2 from Normal' },


### PR DESCRIPTION
## Summary

`BetaBinomial`'s entry in `test/dist-base.js`'s `paramCountCases` table reused the shared default (continuous-oriented) `sample` array for its `aic()`/`bic()` regression assertions, even though `BetaBinomial` is discrete. It only produced correct results because `Distribution.pdf()` implicitly rounds `x` via `_toInt()` for discrete-type distributions before indexing the PMF table, which obscured intent. This PR passes an explicit integer `sample: [0, 1, 2, 3, 4, 5, 1, 2, 3, 4]` (within `BetaBinomial(5, 2, 3)`'s support `{0,...,5}`) with an explanatory comment, matching the existing `PowerLaw`/`R` custom-sample pattern already in the same table.

Closes #1059

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, no new distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped; test-only change per the template's own guidance
- [x] Production-code diff is under ~400 lines (tests excluded) — 0 lines of production code changed

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical (one test-case object literal extended with an explicit `sample` field and a comment)._

## Code Health note

`test/dist-base.js` scores 9.09 via CodeScene, flagged only for "Number of Functions in a Single Module" (187 functions — a pre-existing god-file condition across the whole shared distribution-base test file). This PR adds zero new functions and touches 9 lines, so fixing that smell is out of scope here.

---
*Generated with [Claude Code](https://claude.ai/code)*


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTNBmSQiUA8e3YR5i8sLuU)_