### PR TITLE
Add protected _powellOptions hook to avoid fit() duplication

### DIFF
--- a/src/dist/_distribution.js
+++ b/src/dist/_distribution.js
@@ -722,7 +722,7 @@ class Distribution {
         return Infinity
       }
     }
-    const best = powell(objective, Distribution._feasibleStart(objective, x0))
+    const best = powell(objective, Distribution._feasibleStart(objective, x0), Cls._powellOptions())
     return new Cls(...best)
   }
 
@@ -904,6 +904,23 @@ class Distribution {
    */
   static _fitPenalty (dist) { // eslint-disable-line no-unused-vars
     return 0
+  }
+
+  /**
+   * The search budget passed to `fit()`'s Powell optimizer as its `options` argument. The
+   * base-class default returns `{}` (no override, so `powell()` falls back to its own
+   * defaults). Subclasses whose log-likelihood surface carries a long, near-flat ridge that a
+   * full-precision search chases almost indefinitely (e.g. `DoublyNoncentralBeta`, see #1077)
+   * override this to return a bounded `{ tol, maxIter }` instead of duplicating `fit()`'s body.
+   *
+   * @method _powellOptions
+   * @memberof ran.dist.Distribution
+   * @returns {Object} The options object to pass to `powell()`.
+   * @protected
+   * @ignore
+   */
+  static _powellOptions () {
+    return {}
   }
 
   // ─── PRIVATE INSTANCE ─────────────────────────────────────────────────────

--- a/src/dist/doubly-noncentral-beta.js
+++ b/src/dist/doubly-noncentral-beta.js
@@ -1,6 +1,5 @@
 import clamp from '../utils/clamp'
 import { recursiveSum } from '../algorithms'
-import powell from '../algorithms/powell'
 import { EPS, MAX_ITER } from '../core/constants'
 import { regularizedBetaIncomplete, beta as fnBeta, logGamma } from '../special'
 import noncentralChi2 from './_noncentral-chi2'
@@ -64,48 +63,6 @@ export default class DoublyNoncentralBeta extends Distribution {
       ps0: l2 === 0 ? 1 : Math.exp(s0 * Math.log(l2) - logGamma(s0 + 1)),
       b0: fnBeta(alpha + r0, beta + s0)
     }
-  }
-
-  // ─── PUBLIC STATIC ────────────────────────────────────────────────────────
-
-  /**
-   * Fits the distribution to a data set with a bounded Powell search budget. On data that
-   * genuinely mismatches this family (also inherited by DoublyNoncentralF, which delegates its
-   * _pdf/_cdf here), the nested double-Poisson-mixing log-likelihood carries a long, near-flat
-   * ridge between the shape and non-centrality parameters: a full-precision Powell search (the
-   * base class's default tol=1e-8, maxIter=200) chases negligible log-likelihood gains along this
-   * ridge almost indefinitely, at ever-increasing per-point cost since larger non-centrality
-   * parameters require more series terms to evaluate (#1063). Empirically, tol=1e-2/maxIter=15
-   * recovers parameters within this class's existing fit tolerances on well-matched data (matching
-   * the default optimizer's result within ordinary finite-sample noise) while bounding worst-case
-   * cost to roughly 1-2s instead of 13-30s+ on mismatched data.
-   * See solutions/performance/2026-07-22-0702-doubly-noncentral-fit-powell-ridge-cost.md
-   *
-   * @method fit
-   * @memberof ran.dist.DoublyNoncentralBeta
-   * @param {number[]} data Array of observations to fit.
-   * @returns {DoublyNoncentralBeta} A new instance of the same distribution with MLE parameters.
-   */
-  static fit (data) {
-    const Cls = this
-    const x0 = Cls._fitInit(data)
-    if (x0.length === 0) {
-      return new Cls()
-    }
-    if (Distribution._isExactFit(Cls)) {
-      return new Cls(...x0)
-    }
-    const objective = params => {
-      try {
-        const inst = new Cls(...params)
-        const v = -inst.lnL(data) + Cls._fitPenalty(inst)
-        return Number.isFinite(v) ? v : Infinity
-      } catch (_) {
-        return Infinity
-      }
-    }
-    const best = powell(objective, Distribution._feasibleStart(objective, x0), { tol: 1e-2, maxIter: 15 })
-    return new Cls(...best)
   }
 
   // ─── PROTECTED INSTANCE ───────────────────────────────────────────────────
@@ -176,6 +133,27 @@ export default class DoublyNoncentralBeta extends Distribution {
     const variance = data.reduce((s, x) => s + (x - mean) ** 2, 0) / n || 1e-4
     const factor = Math.max(mean * (1 - mean) / variance - 1, 0.1)
     return [mean * factor, (1 - mean) * factor, 0.5, 0.5]
+  }
+
+  /**
+   * Bounds fit()'s Powell search budget. On data that genuinely mismatches this family (also
+   * inherited by DoublyNoncentralF, which delegates its _pdf/_cdf here), the nested
+   * double-Poisson-mixing log-likelihood carries a long, near-flat ridge between the shape and
+   * non-centrality parameters: a full-precision Powell search (the base class's default
+   * tol=1e-8, maxIter=200) chases negligible log-likelihood gains along this ridge almost
+   * indefinitely, at ever-increasing per-point cost since larger non-centrality parameters
+   * require more series terms to evaluate (#1063). Empirically, tol=1e-2/maxIter=15 recovers
+   * parameters within this class's existing fit tolerances on well-matched data (matching the
+   * default optimizer's result within ordinary finite-sample noise) while bounding worst-case
+   * cost to roughly 1-2s instead of 13-30s+ on mismatched data.
+   * See solutions/performance/2026-07-22-0702-doubly-noncentral-fit-powell-ridge-cost.md
+   *
+   * @method _powellOptions
+   * @memberof ran.dist.DoublyNoncentralBeta
+   * @returns {Object} The bounded Powell search options.
+   */
+  static _powellOptions () {
+    return { tol: 1e-2, maxIter: 15 }
   }
 
   // ─── PRIVATE INSTANCE ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a protected static `Distribution._powellOptions()` hook (default `{}`) that `fit()` passes through to `powell()`, and replaces `DoublyNoncentralBeta`'s full `static fit()` duplication with a one-method override of that hook returning `{ tol: 1e-2, maxIter: 15 }`. `DoublyNoncentralF` (which extends `DoublyNoncentralBeta` and defines neither method itself) continues to inherit the bounded search budget through the static prototype chain, unchanged.

Closes #1077

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [ ] Tests added or updated for changed behavior — not applicable: this is a behavior-preserving refactor (`powell()`'s own destructuring defaults make an explicit `{}` identical to omitting the argument), and the existing `DoublyNoncentralF.fit should complete quickly...` regression test (#1063, `test/dist-base-fit-1.js`) already exercises the exact override path through the public `.fit()` API. A follow-up issue was filed to add a direct unit test for the base-class hook's `{}` default, mirroring the existing `_fitPenalty` default test.
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, no new distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (skip for pure refactors/docs/tests) — skipped, pure internal refactor with no user-visible behavior change
- [x] Production-code diff is under ~400 lines (tests excluded) — ~39 net lines across 2 files

## Review

Ran the full `/review` pipeline (spec-compliance + 8 parallel specialized agents: security, performance, structure, conventions, tests, docs, correctness, impact). Verdict: PASS. One Warn survived (missing direct unit test for the base-class hook default) and was filed as a follow-up issue rather than blocking this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QFTJ8NE3JPsCkRNmBCZQh3)_