### PR TITLE
Add direct test for Distribution._powellOptions() default

### DIFF
--- a/test/dist-base-fit-2.js
+++ b/test/dist-base-fit-2.js
@@ -1,10 +1,15 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
 import * as dist from '../src/dist'
+import Distribution from '../src/dist/_distribution'
 
 describe('dist', () => {
   describe('Distribution', () => {
     describe('.fit()', () => {
+      it('Distribution._powellOptions base class should return {} (no override)', () => {
+        assert.deepEqual(Distribution._powellOptions(), {})
+      })
+
       it('Frechet._fitInit should handle constant data', () => {
         // || 1 guard: all equal → zero variance in reciprocals → fallback to 1
         const init = dist.Frechet._fitInit([5, 5, 5])


### PR DESCRIPTION
## Summary

Adds a direct unit test asserting `Distribution._powellOptions()` returns `{}` by default, mirroring the existing direct `_fitPenalty()` base-class test in `test/dist-base-fit-1.js`. This guards the base-class default that ~200 distributions silently rely on for `fit()`'s Powell optimizer options, independent of the behavioral coverage already provided by the `DoublyNoncentralF.fit` regression test (#1063) for the override path.

Closes #1091

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` (N/A — no new distribution)
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) (N/A — no new distribution)
- [x] `CHANGELOG.md` updated under `## [Unreleased]` (skip for pure refactors/docs/tests) — skipped; test-only change per CLAUDE.md's changelog rule
- [x] Production-code diff is under ~400 lines (tests excluded) — 0 lines of production code changed (test-only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RvvJmBAbQQAYKLTtmNRJy8)_