### PR TITLE
Fix premature-convergence bug in gen-dist-refs.py dncbeta

### DIFF
--- a/scripts/gen-dist-refs.py
+++ b/scripts/gen-dist-refs.py
@@ -170,13 +170,17 @@ def dncbeta_cdf(a, b, l1, l2, x):
         while True:
             term = wr * pois_w(h2, si) * Ireg(mpf(a) + r, mpf(b) + si, x)
             inner += term
-            if si > h2 + 5 and (wr * pois_w(h2, si)) < mpf('1e-55'):
+            # Convergence must track the actual accumulated term, not the raw Poisson-weight
+            # product alone: for si far from its Poisson mean, wr * pois_w(h2, si) is already
+            # vanishingly small while the Ireg-weighted term has not converged, silently
+            # truncating real probability mass (#1108, #1111).
+            if si > h2 + 5 and fabs(term) < fabs(inner) * mpf('1e-55'):
                 break
             si += 1
             if si > 5000:
                 break
         s += inner
-        if r > h1 + 5 and wr < mpf('1e-55'):
+        if r > h1 + 5 and fabs(inner) < fabs(s) * mpf('1e-55'):
             break
         r += 1
         if r > 5000:
@@ -201,13 +205,15 @@ def dncbeta_pdf(a, b, l1, l2, x):
             bj = mpf(b) + si
             term = wr * pois_w(h2, si) * exp((aj - 1) * log(x) + (bj - 1) * log(1 - x) - log(betafn(aj, bj)))
             inner += term
-            if si > h2 + 5 and (wr * pois_w(h2, si)) < mpf('1e-55'):
+            # See dncbeta_cdf's comment (#1108, #1111): convergence must track the actual
+            # accumulated term, not the raw Poisson-weight product.
+            if si > h2 + 5 and fabs(term) < fabs(inner) * mpf('1e-55'):
                 break
             si += 1
             if si > 5000:
                 break
         s += inner
-        if r > h1 + 5 and wr < mpf('1e-55'):
+        if r > h1 + 5 and fabs(inner) < fabs(s) * mpf('1e-55'):
             break
         r += 1
         if r > 5000:


### PR DESCRIPTION
Closes #1111

## Summary
- Fixed the same premature-convergence bug #1108 fixed in `scripts/precision-refs-continuous.py`, but in the duplicate `dncbeta_cdf`/`dncbeta_pdf` implementation in `scripts/gen-dist-refs.py`.
- The convergence checks compared only the raw Poisson-weight product (`wr * pois_w(h2, si)` / `wr`) against `1e-55`, not the actual accumulated term or running sum. For `(r, si)` far from the joint Poisson peak, the raw weight underflows well before the Ireg-weighted (or Beta-density-weighted) term has actually converged, silently truncating real probability mass at large lambda or x far from 0.5.
- Replaced both checks with a relative check against the actual accumulated term/sum magnitude (`fabs(term) < fabs(inner) * mpf('1e-55')` and `fabs(inner) < fabs(s) * mpf('1e-55')`), mirroring the fix already applied to the same function in `scripts/precision-refs-continuous.py`.

## Non-trivial changes
- **`scripts/gen-dist-refs.py`**: `dncbeta_cdf`/`dncbeta_pdf` convergence-loop break conditions now track actual term/sum magnitude instead of the raw Poisson-weight proxy. Verified old-vs-new behavior on large-lambda, off-center-x cases (e.g. `l1=800, l2=3, x=0.999` and `l1=l2=120, x=0.95`) — no silent value changes for the parameter ranges exercised by the existing test suite; the fix hardens the convergence guarantee for future large-lambda/off-center-x reference generation.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

## Checklist
- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green, coverage thresholds met)
- [x] `npm run typecheck` passes
- [x] This is test-infrastructure/tooling (not shipped library code); no `src/` changes required
- [x] `CHANGELOG.md` update skipped — pure test-tooling fix, not user-visible

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1bqpwSJ5bHVu5egtrfSRH)_