### PR TITLE
Fix precision-refs-continuous.py's dormant self_check(), add DNCBeta large-lambda anchor

### DIFF
--- a/scripts/dump-dist-cases-json.js
+++ b/scripts/dump-dist-cases-json.js
@@ -1,0 +1,18 @@
+// Bridges test/dist-cases-continuous.js's scipy-vetted refVals into precision-refs-continuous.py's
+// self_check() -- @babel/register lets require() load the ESM-syntax test file the same way mocha
+// does, and evaluating params() here (rather than parsing the source as text) survives any future
+// closure shape, including Hyperexponential's nested { weight, rate } objects.
+require('@babel/register')()
+
+const cases = require('../test/dist-cases-continuous.js').default
+
+const data = cases.map(d => ({
+  name: d.name,
+  refVals: d.refVals || null,
+  cases: (d.cases || []).map(c => ({
+    params: c.params(),
+    refVals: c.refVals || null
+  }))
+}))
+
+process.stdout.write(JSON.stringify(data))

--- a/scripts/precision-refs-continuous.py
+++ b/scripts/precision-refs-continuous.py
@@ -17,6 +17,7 @@ Usage:    python3 scripts/precision-refs-continuous.py            # rewrites the
           python3 scripts/precision-refs-continuous.py --check    # self-check only
 """
 import json
+import subprocess
 import sys
 from mpmath import (mp, mpf, pi, sqrt, exp, log, expm1, log1p, cosh, tanh,
                     atan, asin, asinh, acos, sin, cos, gamma as gammafn, loggamma,
@@ -674,11 +675,7 @@ def pdf(name, p, x):
         return d1 * d2 / power(d2 + d1 * x, 2) * ncbeta_pdf(mpf(d1) / 2, mpf(d2) / 2, lam, y)
     if name == 'NoncentralT':
         nu, mu = int(round(p[0])), mpf(p[1])
-        # f(x) = nu/x * (F_{nu+2}(x*sqrt(1+2/nu), mu) - F_nu(x, mu)) (ranjs NoncentralT._pdf)
-        if x == 0:
-            from mpmath import diff
-            return diff(lambda t: nct_cdf(nu, mu, t), mpf('1e-30'))
-        return mpf(nu) * (nct_cdf(nu + 2, mu, x * sqrt(1 + mpf(2) / nu)) - nct_cdf(nu, mu, x)) / x
+        return nct_pdf(nu, mu, x)
     if name == 'Normal':
         mu, sigma = mpf(p[0]), mpf(p[1])
         return exp(-HALF * ((x - mu) / sigma) ** 2) / (sigma * SQRT2PI)
@@ -1180,13 +1177,43 @@ def cdf(name, p, x):
 # self-check against scipy refVals already vetted in dist-cases-continuous.js
 # =========================================================================
 
+# Frozen regression anchor for the #1108/#1086 premature-convergence bug -- values are the
+# mpmath mp.dps=50 references already recorded in test/precision-continuous.js:993-998,
+# duplicated here (not re-derived from dncbeta_pdf/dncbeta_cdf) so this check is non-tautological.
+LARGE_LAMBDA_ANCHORS = [{
+    'name': 'DoublyNoncentralBeta',
+    'refVals': None,
+    'cases': [{
+        'params': [2, 2, 1200, 1200],
+        'refVals': [
+            {'x': 0.3, 'pdf': 3.031637276579777e-21, 'cdf': 5.709664737795533e-24},
+            {'x': 0.5, 'pdf': 19.58073930064019, 'cdf': 0.5}
+        ]
+    }]
+}]
+
+
 def self_check(only=None):
-    with open('test/cases-continuous.json') as fh:
-        data = json.load(fh)
+    # dist-cases-continuous.js is a real ES module (cases[*].params is a closure); dump-dist-cases-
+    # json.js loads it exactly the way mocha does (via @babel/register) and evaluates every closure,
+    # so this always checks against the live file instead of a stale or nonexistent snapshot.
+    # See solutions/testing/2026-07-24-1141-precision-refs-self-check-never-ran.md
+    result = subprocess.run(['node', 'scripts/dump-dist-cases-json.js'], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stderr, flush=True)
+        raise RuntimeError('dump-dist-cases-json.js failed')
+    data = json.loads(result.stdout)
+    # PARAM_SETS is this generator's registry of distributions it actually implements pdf()/cdf()
+    # for; test/dist-cases-continuous.js covers a couple more (e.g. TruncatedExponential) that this
+    # script never implemented, which would otherwise show up as a spurious ERROR, not a mismatch.
+    implemented = set(PARAM_SETS.keys())
     bad = 0
     checked = 0
-    for d in data:
+    for d in data + LARGE_LAMBDA_ANCHORS:
         name = d['name']
+        if name not in implemented:
+            print(f'  ... skipping {name} (not implemented in this generator)', flush=True)
+            continue
         if only and name not in only:
             continue
         print(f'  ... {name}', flush=True)

--- a/solutions/testing/2026-07-24-1141-precision-refs-self-check-never-ran.md
+++ b/solutions/testing/2026-07-24-1141-precision-refs-self-check-never-ran.md
@@ -1,0 +1,44 @@
+---
+date: 2026-07-24T11:41:09Z
+category: "testing"
+problem: "precision-refs-continuous.py's self_check()/--check safety net had never once actually run since it was written"
+status: complete
+related_issue: "#1110"
+related_plan: "thoughts/plans/2026-07-23-2018-precision-refs-continuous-self-check.md"
+tags: [self-check, dormant-safety-net, python-node-bridge, es-module-bridge, precision-refs, dncbeta, bug-triage]
+---
+
+# Solution: precision-refs-continuous.py's `self_check()` had never once actually run
+
+**Date**: 2026-07-24
+**Category**: testing
+**Related Issue**: #1110
+
+## Problem
+
+`scripts/precision-refs-continuous.py`'s `self_check()` — the mechanism meant to cross-check this script's own mpmath-based `pdf()/cdf()` reimplementation against the scipy-vetted `refVals` hand-authored in `test/dist-cases-continuous.js` — opened `test/cases-continuous.json`, a file that has never existed anywhere in the repo. Every `--check` invocation (and every bare no-argument invocation, since the literal string `'--check'` is never actually compared against `sys.argv[1]` anywhere in the file) raised `FileNotFoundError` immediately, before checking a single value. This safety net — explicitly documented as the intended guard against exactly the class of silent-truncation bug fixed in #1108 — had never once actually run since it was written.
+
+## Root Cause
+
+The self-check was written against an intended JSON bridge file that nothing in the codebase ever produces — a dependency assumed to exist (or planned but never wired up) and never verified end-to-end. Because the failure mode was an immediate, unhandled `FileNotFoundError` rather than a silent no-op, it should have been maximally visible — yet it went unnoticed because nothing in CI or `npm test` invokes this Python script's `--check` path at all; it is tooling adjacent to the test suite, not part of it, so there was no automated forcing function to ever exercise the broken path.
+
+## Fix
+
+Replaced the static-file read with a live bridge: a new `scripts/dump-dist-cases-json.js` (`require('@babel/register')()` then `require('../test/dist-cases-continuous.js')`) evaluates every `cases[].params()` closure and prints the real, current scipy-vetted test data as JSON. `self_check()` invokes it via `subprocess.run(...)` instead of opening a static artifact, so there is nothing to go stale — this mirrors exactly how mocha itself loads the same ES-module test file, and precedent for Python-to-Node subprocess bridging already existed in `scripts/refvals-issue-135.py`.
+
+Also added a frozen `LARGE_LAMBDA_ANCHORS` regression constant (`DoublyNoncentralBeta(2,2,1200,1200)`) duplicated from already-reviewed mpmath mp.dps=50 values already recorded in `test/precision-continuous.js:993-998` — deliberately *not* re-derived from the `dncbeta_pdf`/`dncbeta_cdf` code under test, so the check stays non-tautological — to guard the exact #1108/#1086 premature-convergence bug class going forward. An `implemented = set(PARAM_SETS.keys())` skip-filter was added so distributions this generator's dispatch doesn't implement (e.g. `TruncatedExponential`) are logged as skipped rather than producing a spurious error.
+
+The moment the check actually ran for the first time, it surfaced **41 pre-existing latent mismatches across ~15 other distributions** (missing out-of-support clamping, `pdf(0)` boundary-limit bugs, complex-number crashes on out-of-domain input, div-by-zero at x=0) that had been silently accumulating in this script's mpmath dispatch for the entire time the check was broken. One trivial case (`NoncentralT`'s `pdf(0)` using a broken `mpmath.diff()` numerical-derivative hack instead of the already-correct `nct_pdf()` closed-form helper, which happened to sit right next to it in the same file) was fixed inline. The rest were triaged and filed as separate follow-up issues (#1115, #1116, #1117) rather than folded into this PR, per the one-concern-per-issue / PR-size-cap conventions — fixing them would have meant touching boundary-handling formulas across ~10 unrelated distributions, far beyond #1110's stated scope.
+
+## Prevention Strategy
+
+Any "safety net" script or check (self-tests, regression guards, `--check` flags) must be exercised at least once, ideally in CI, immediately after being written — a check that has never successfully completed a single run provides *zero* protection while looking, from reading the code, exactly like it does. When adding or restoring such a mechanism, budget explicitly for the backlog-surfacing effect: the first successful run of a long-dormant self-check should be expected to reveal an unknown quantity of unrelated latent bugs, and the fix PR should triage-and-file those rather than absorb them, keeping the PR scoped to "make the check run" rather than "fix everything it finds."
+
+## Related Solutions
+
+- `solutions/correctness/2026-07-23-1108-doubly-noncentral-beta-recursivesum-absolute-floor-truncation.md` — the premature-convergence bug this issue's `LARGE_LAMBDA_ANCHORS` case now guards against; documents the same `dncbeta_pdf`/`dncbeta_cdf` functions this self-check exercises.
+- `solutions/correctness/2026-07-23-1707-doubly-noncentral-beta-relocated-walk-and-issue-premise.md` — prior regression-testing methodology context for the same generator script.
+
+## Key Insight
+
+A self-check/regression-guard that has never successfully executed (due to a broken dependency, like opening a file nothing writes) is indistinguishable from a working one by reading the code — the only way to know a safety net is real is to have watched it actually complete a run at least once, and doing so for the first time after a long dormancy should be expected to surface an unrelated backlog of latent bugs, which is a discovery event to triage, not scope-creep to fix in the same PR.


### PR DESCRIPTION
## Summary

`scripts/precision-refs-continuous.py`'s `self_check()` opened `test/cases-continuous.json`, a file nothing in the repo ever wrote, so `--check` raised `FileNotFoundError` immediately — this safety net had never once actually run. Fixed by adding `scripts/dump-dist-cases-json.js`, a small Node helper that loads `test/dist-cases-continuous.js` the same way mocha does (via `@babel/register`) and evaluates every `params()` closure, consumed via `subprocess` from Python instead of a static file. Also adds a frozen `LARGE_LAMBDA_ANCHORS` regression case (`DoublyNoncentralBeta(2,2,1200,1200)`, values duplicated from `test/precision-continuous.js`'s existing mpmath mp.dps=50 comments so the check stays non-tautological) guarding the #1108/#1086 premature-convergence bug class, and a skip-filter for distributions this generator doesn't implement (e.g. `TruncatedExponential`).

Running `self_check()` for the first time surfaced 41 pre-existing mismatches across ~15 unrelated distributions' formulas in this same script. One trivial case (`NoncentralT`'s `pdf(0)` using a broken `mpmath.diff()` hack instead of the already-correct `nct_pdf()` helper) is fixed inline here; the rest are filed as separate follow-ups (#1115, #1116, #1117) per the one-concern-per-issue convention, since they're non-trivial and out of this issue's scope.

Closes #1110

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 8000 passing)
- [ ] `npm run typecheck` passes — pre-existing/environmental failure unrelated to this PR (`dist/index.d.ts` doesn't exist because `npm run build` hasn't been run in this environment; this PR touches zero files under `src/`)
- [x] Tests added or updated for changed behavior — this is test-infrastructure/tooling (explicitly out of scope for `src/` changes per #1110); verification was manual (`python3 scripts/precision-refs-continuous.py --check`), documented in the linked plan
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, no new distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — not user-visible (dev-only tooling script, never shipped in the npm package)
- [x] Production-code diff is under ~400 lines (tests excluded) — ~97 lines across 2 files

## Test plan

- [x] `python3 scripts/precision-refs-continuous.py --check` completes without `FileNotFoundError` (3113 values checked)
- [x] `python3 scripts/precision-refs-continuous.py --only DoublyNoncentralBeta` shows the new large-lambda anchor passing with 0 mismatches
- [x] `npm run standard && npm test` pass (8000 passing, coverage thresholds met)


---
_Generated by [Claude Code](https://claude.ai/code/session_014sHhGeaJSbxFMcdHUw8ucU)_