### PR TITLE
Fix ZeroDivisionError at x=0 in precision-refs-continuous.py

### DIFF
--- a/scripts/precision-refs-continuous.py
+++ b/scripts/precision-refs-continuous.py
@@ -580,6 +580,8 @@ def pdf(name, p, x):
     if name == 'InverseGaussian':
         return ig_pdf(p[0], p[1], x)
     if name == 'InvertedWeibull':
+        if x <= 0:
+            return mpf(0)
         c = mpf(p[0])
         return c * power(x, -1 - c) * exp(-1 / power(x, c))
     if name == 'IrwinHall':
@@ -897,6 +899,8 @@ def cdf(name, p, x):
         lam, k, alpha = mpf(p[0]), mpf(p[1]), mpf(p[2])
         return power(cdf('Weibull', [lam, k], x), alpha)
     if name == 'F':
+        if x <= 0:
+            return mpf(0)
         d1, d2 = int(round(p[0])), int(round(p[1]))
         y = d1 * x
         return Ireg(mpf(d1) / 2, mpf(d2) / 2, 1 / (1 + mpf(d2) / y))
@@ -966,6 +970,8 @@ def cdf(name, p, x):
     if name == 'InverseGaussian':
         return ig_cdf(p[0], p[1], x)
     if name == 'InvertedWeibull':
+        if x <= 0:
+            return mpf(0)
         c = mpf(p[0])
         return exp(-1 / power(x, c))
     if name == 'IrwinHall':
@@ -1051,6 +1057,8 @@ def cdf(name, p, x):
     if name == 'NoncentralChi2':
         return ncx2_cdf(int(round(p[0])), p[1], x)
     if name == 'NoncentralF':
+        if x <= 0:
+            return mpf(0)
         d1, d2, lam = int(round(p[0])), int(round(p[1])), mpf(p[2])
         y = d1 * x
         return ncbeta_cdf(mpf(d1) / 2, mpf(d2) / 2, lam, 1 / (1 + mpf(d2) / y))


### PR DESCRIPTION
## Summary

`F` and `NoncentralF`'s `cdf()`, and `InvertedWeibull`'s `pdf()`/`cdf()`, in `scripts/precision-refs-continuous.py` divided by a term that is exactly zero at the left edge of support (`x = 0`), raising an uncaught (blank-message) mpmath `ZeroDivisionError` instead of returning the mathematically correct value of `0`. This adds an `if x <= 0: return mpf(0)` guard before each division. This is dev-only tooling (regenerates `test/precision-continuous.js` reference values) — no shipped `src/` distribution code is touched, per the issue's explicit scope.

Closes #1115

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior — verified via `python3 scripts/precision-refs-continuous.py --only F,InvertedWeibull,NoncentralF` (94 values, 0 mismatches) and direct calls confirming `cdf('F',[5,5],0)`, `pdf('InvertedWeibull',[2],0)`, `cdf('InvertedWeibull',[2],0)`, `cdf('NoncentralF',[5,5,2],0)` all return `0` without raising
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, no new distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped; this is a dev-tooling-only fix with no user-visible effect on the shipped library
- [x] Production-code diff is under ~400 lines (tests excluded) — 8 lines

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical (adds a boundary guard mirroring an existing pattern in the same file, in a non-shipped dev script)._

<details>
<summary>Trivial changes</summary>

- **`scripts/precision-refs-continuous.py`**: Added `if x <= 0: return mpf(0)` guards to the `F` (cdf), `InvertedWeibull` (pdf + cdf), and `NoncentralF` (cdf) branches, before the divisions that were crashing at `x = 0`.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_011frThwMGXCiGmGE13btJ1F)_