### PR TITLE
Clamp precision-refs pdf/cdf to support before formula dispatch

### DIFF
--- a/scripts/precision-refs-continuous.py
+++ b/scripts/precision-refs-continuous.py
@@ -384,6 +384,9 @@ def ih_cdf(n, x):
 
 def pdf(name, p, x):
     x = mpf(x)
+    lo, hi = support(name, p)
+    if (lo is not None and x < lo) or (hi is not None and x > hi):
+        return mpf(0)
     if name == 'Alpha':
         alpha, beta = mpf(p[0]), mpf(p[1])
         return beta * exp(-HALF * (alpha - beta / x) ** 2) / (x * x * Phi(alpha) * SQRT2PI)
@@ -787,6 +790,11 @@ def pdf(name, p, x):
 
 def cdf(name, p, x):
     x = mpf(x)
+    lo, hi = support(name, p)
+    if lo is not None and x < lo:
+        return mpf(0)
+    if hi is not None and x > hi:
+        return mpf(1)
     if name == 'Alpha':
         alpha, beta = mpf(p[0]), mpf(p[1])
         return Phi(alpha - beta / x) / Phi(alpha)


### PR DESCRIPTION
## Summary

`scripts/precision-refs-continuous.py`'s `pdf(name, p, x)` / `cdf(name, p, x)` evaluated the raw closed-form formula for `x` strictly outside a distribution's support, instead of returning the mathematically correct clamp value (`0` for pdf; `0`/`1` for cdf). For 13 distributions (Anglit, Beta, Exponential, Gamma, Lindley, LogGamma, LogNormal, Pareto, ShiftedLogLogistic, Trapezoidal, Triangular, Uniform, Weibull) this produced wrong nonzero values or an uncaught complex-number crash. This adds a guard at the top of both `pdf()` and `cdf()` that calls the existing `support(name, p)` helper and returns the clamp value before the `if name == ...` dispatch chain fires, for `x` strictly outside `[lo, hi]`. This is dev-only tooling (regenerates `test/precision-continuous.js` reference values) — no shipped `src/` distribution code is touched, per the issue's explicit scope.

Closes #1117

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior — verified via `python3 scripts/precision-refs-continuous.py --only <13 names>` (396 values, 0 mismatches) and confirmed all acceptance-criteria probes (e.g. `Anglit[3,0.5].pdf(2.6)`, `Beta[2,2].pdf(-0.1)`, `Weibull[2,2].cdf(-0.1)`, etc.) now return the correct clamp value. Also verified the 14 distributions that recursively call `pdf('Beta'/'Gamma'/'Weibull'/'LogNormal', ...)` internally (`BetaPrime`, `F`, `PERT`, `Erlang`, `DoubleGamma`, `Rayleigh`, `Gilbrat`, etc.) still compute correctly at interior points — no regression, since the guard only fires strictly outside `[lo, hi]`.
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A, no new distribution
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped; this is a dev-tooling-only fix with no user-visible effect on the shipped library (matching the precedent set by #1120)
- [x] Production-code diff is under ~400 lines (tests excluded) — 8 lines

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical (adds a boundary guard reusing the existing `support()` helper, in a non-shipped dev script)._

<details>
<summary>Trivial changes</summary>

- **`scripts/precision-refs-continuous.py`**: Added a guard to the top of `pdf(name, p, x)` and `cdf(name, p, x)` that calls `support(name, p)` and returns `0` (pdf, strictly outside `[lo, hi]`) or `0`/`1` (cdf, strictly below/above) before the `if name == ...` dispatch chain.

</details>

## Out of scope (confirmed pre-existing, not introduced by this change)

The full self-check (`--check`, all 111 distributions) surfaced 3 mismatches, all identical before and after this change (verified via `git stash`) and all explicitly named in issue #1117's own "Out of Scope" section as separate follow-up work:
- `NoncentralBeta[1,5,10].pdf(0)` and `Chi[1].pdf(0)` — boundary-exact (`x == lo`) cases, named verbatim in the issue text ("e.g. pdf(0) for Chi/NoncentralBeta").
- `Normal[0,2].cdf(-14)` and `ReciprocalInverseGaussian[0.5,4].cdf(0.2)` — tail-precision findings, named verbatim in the issue text ("separate, ambiguous root cause").

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCiWktfJ9oMDfo2CzBDCd8)_