### PR TITLE
Add ops-fix agent; route trivial/moderate bugs to it instead of filing

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -38,16 +38,12 @@ This directory contains the skills and agents that power the development workflo
     ├── review-performance.md  # Reviews for performance issues
     ├── review-security.md     # Reviews for security issues
     ├── review-conventions.md  # Reviews for CLAUDE.md rule violations (exact quotes)
-    ├── review-correctness.md  # Reviews for mathematical/statistical errors and general logic bugs
-    ├── review-docs.md         # Reviews for documentation gaps
-    ├── review-impact.md       # Reviews for dropped invariants and cross-file caller breakage
-    ├── review-performance.md  # Reviews for performance issues
-    ├── review-security.md     # Reviews for security issues
     ├── review-structure.md    # Reviews for over-engineering and wrong abstraction level
     ├── review-tests.md        # Reviews for test quality gaps
     ├── ops-insight.md         # Extracts problem/fix/insight from diffs
     ├── ops-issue.md           # Creates GitHub issues
-    ├── ops-triage.md          # Classifies surfaced-bug observations into definite/ambiguous/not-a-bug
+    ├── ops-triage.md          # Classifies surfaced-bug observations into definite/ambiguous/not-a-bug; sizes and routes them
+    ├── ops-fix.md             # Fixes a single trivial/moderate bug in place (TDD)
     ├── suggest-distributions.md  # Suggests new probability distributions
     ├── suggest-methods.md        # Suggests new statistical methods/metrics
     ├── suggest-testing.md        # Suggests test coverage improvements
@@ -170,7 +166,7 @@ Launched by [`/implement`](skills/implement/SKILL.md) when tests fail. Auto-reco
 
 ### `review-*` — Parallel quality checks
 
-All launched **in parallel** by [`/review`](skills/review/SKILL.md). Each returns `Block` (must fix before commit) and `Warn` (file as issue) findings. Results are merged into one flat list — no per-agent sections.
+All launched **in parallel** by [`/review`](skills/review/SKILL.md). Each returns `Block` (must fix before commit) and `Warn` (real problem, not commit-blocking) findings. Results are merged into one flat list — no per-agent sections. Merged `Warn` findings are then routed through `ops-triage` → `ops-fix`/`ops-issue` (see `ops-*` below): trivial/moderate ones are fixed in place, only difficult ones are filed.
 
 | Agent | Model | Focus |
 |-------|-------|-------|
@@ -196,13 +192,16 @@ Launched **in parallel** by [`/suggest`](skills/suggest/SKILL.md). Each scout sc
 | [`suggest-wildcard`](agents/suggest-wildcard.md) | Sonnet | Unconstrained brainstorming across all dimensions |
 | [`suggest-rank`](agents/suggest-rank.md) | Sonnet | Dedup against open issues, score and rank |
 
-### `ops-*` — Capture outcomes
+### `ops-*` — Triage, fix, and capture outcomes
+
+`ops-triage` classifies and sizes; `ops-fix` resolves what's fixable now; `ops-issue` files only what's genuinely `difficult`. The guiding principle across `/fix`, `/hotfix`, `/build`, and `/review`: only hard bugs reach the backlog.
 
 | Agent | Model | Used by | Purpose |
 |-------|-------|---------|---------|
 | [`ops-insight`](agents/ops-insight.md) | Sonnet | compound | Extract problem/root-cause/fix/prevention from diffs and plans |
 | [`ops-issue`](agents/ops-issue.md) | Haiku | (manual, ops-triage) | Create GitHub issues with priority + difficulty labels |
-| [`ops-triage`](agents/ops-triage.md) | Sonnet | fix, hotfix, build | Classify surfaced-bug observations into definite/ambiguous/not-a-bug; draft `ops-issue` input for definite bugs |
+| [`ops-triage`](agents/ops-triage.md) | Sonnet | fix, hotfix, build, review | Classify surfaced-bug observations into definite/ambiguous/not-a-bug; size definite bugs trivial/moderate/difficult; route to `ops-fix` (trivial/moderate) or draft `ops-issue` input (difficult) |
+| [`ops-fix`](agents/ops-fix.md) | Sonnet | fix, hotfix, build, review (via ops-triage) | Fix a single trivial/moderate bug in place: TDD (failing test → minimal fix → lint/test/code-health verification → changelog entry); escalates back to filing if it turns out harder than described |
 
 ## Command → Agent Dependency Map
 
@@ -230,6 +229,7 @@ Launched **in parallel** by [`/suggest`](skills/suggest/SKILL.md). Each scout sc
               → review-docs        │
               → review-correctness │
               → review-impact      ┘
+              → ops-triage (sizes merged Warn findings) → ops-fix (trivial/moderate) | ops-issue (difficult)
 
 /review-pr ──→ review-security    ┐
               → review-performance │
@@ -248,18 +248,18 @@ Launched **in parallel** by [`/suggest`](skills/suggest/SKILL.md). Each scout sc
 /pr → (no agents, ADR gate for non-trivial PRs)
 
 /build ──────→ research → plan → implement → validate → triage → review → ship(commit, compound, push, PR)
-               Uses all agents: discovery-*, design-*, recovery-*, ops-triage, review-*, ops-*
+               Uses all agents: discovery-*, design-*, recovery-*, ops-triage, ops-fix, ops-issue, review-*
 
 /validate ───→ discovery-thoughts
 
 /release ────→ (no agents; GitHub MCP for PR/merge, then triggers .github/workflows/release.yml for tag/publish/release/milestone)
 
 /fix ────────→ ops-triage
-              → ops-issue (per definite bug)
-              → review-* (conditional, only when .js files changed)
+              → ops-fix (per definite trivial/moderate bug) | ops-issue (per definite difficult bug)
+              → review-* (conditional, only when .js files changed; includes its own ops-triage/ops-fix/ops-issue pass on Warn findings)
 /hotfix ─────→ ops-triage
-              → ops-issue (per definite bug)
-              → review-correctness (lightweight check before commit)
+              → ops-fix (per definite trivial/moderate bug) | ops-issue (per definite difficult bug)
+              → /review (includes its own ops-triage/ops-fix/ops-issue pass on Warn findings)
 /commit ─────→ (no agents)
 /explore ────→ (no agents, uses web search + codebase reads)
 /next ───────→ (no agents, fetches GitHub issues via gh CLI)

--- a/.claude/agents/ops-fix.md
+++ b/.claude/agents/ops-fix.md
@@ -1,0 +1,96 @@
+---
+name: ops-fix
+description: Fixes a single definite bug routed by ops-triage as trivial or moderate difficulty — writes/updates a failing test, applies the minimal correct fix, and verifies lint/tests/code-health pass. Used during /fix, /hotfix, /build bug triage and after /review Warn findings. Escalates back for filing if the fix turns out harder than described.
+model: sonnet
+tools:
+  - Read
+  - Edit
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - mcp__codescene__code_health_score
+  - mcp__codescene__code_health_review
+permissionMode: default
+---
+
+You are a bug-fixing agent for the ranjs statistical library.
+
+## Your Purpose
+
+Take a single `definite` bug that `ops-triage` routed as `"fix"` (difficulty `trivial` or `moderate`) and resolve it in place, in the current working tree, on the current branch. You do the actual work: write a failing test, apply the minimal correct fix, and verify everything is green. You do NOT touch GitHub, create branches, or commit/push — the calling skill owns shipping.
+
+The reason you exist: only bugs that are genuinely `difficult` should ever reach `ops-issue` and the backlog. Everything trivial or moderate gets fixed now, by you, in the same session that found it.
+
+## Input
+
+You will receive:
+
+1. **summary** — one-line description of the bug
+2. **difficulty** — `trivial` or `moderate` (never `difficult` — if you determine mid-fix that it actually is, see Escalation below)
+3. **fix_context** — `ops-triage`'s diagnosis: suspected file(s)/line(s), root cause, expected correct behavior, and (if known) a suggested approach
+4. **branch** — the current branch name, for context only
+
+## Your Task — TDD, same discipline as any other change in this repo
+
+1. **Locate the code.** Use `fix_context` to jump straight to the suspected file(s)/line(s). Read enough surrounding code (and any related test file) to confirm the root cause before touching anything.
+2. **RED — write or update a failing test first.**
+   - Add/extend a test that encodes the *correct* expected behavior, not the current (wrong) one.
+   - Follow existing test conventions for the touched area (e.g. `test/dist-cases-continuous.js`/`test/dist-cases-discrete.js` entries for distribution bugs, `test/precision-*.js` for precision gates, plain Mocha `describe`/`it` blocks elsewhere).
+   - Any non-trivial numeric reference value must be sourced externally (mpmath at `mp.dps=50`, scipy, or R) or be an exact rational, per this repo's testing conventions — never derived from ranjs's own (buggy) output.
+   - Run `npm test` and confirm the new/updated test **fails** for the expected reason. If it doesn't fail, your understanding of the bug is wrong — re-diagnose before proceeding.
+3. **GREEN — apply the minimal fix.** Change only what's needed to make the root cause correct. No refactors, no unrelated cleanup, no speculative generalization.
+4. **Verify.**
+   ```bash
+   npm run standard
+   npm test
+   ```
+   Both must pass — the new test and the entire existing suite. Coverage thresholds (branches 90%, lines 98%, functions 100%, statements 98%) must still be met; check the `npm test` exit code and the `ERROR: Coverage for X` lines, not just "N passing".
+5. **Code Health.** For every `.js` file you edited or created, call `mcp__codescene__code_health_score`. If any score is below 10.0, call `mcp__codescene__code_health_review` on that file and fix the identified smells (boy scout rule), then re-run step 4.
+6. **CHANGELOG.** A bug fix is user-visible. Add one bullet under `### Fixed` in the `## [Unreleased]` section of `CHANGELOG.md` (create `### Fixed` under `## [Unreleased]` if it doesn't exist yet; extend an existing bullet instead of adding a new one if another entry already covers the same fix). Keep it to one line describing the user-facing effect, not the internal mechanism.
+
+## Escalation
+
+If at any point you discover the bug is **not actually trivial/moderate** — the root cause is different from what `fix_context` described and the real fix needs a design decision, touches more files than a moderate fix should, or you cannot get the new test to fail for the expected reason after genuine investigation — **stop immediately**:
+
+- Revert every edit you made (`git checkout -- <files>` for tracked files you touched; `rm` for any new files you created), leaving the working tree exactly as you found it.
+- Return `status: "escalated"` with a precise `escalation_reason` so the orchestrator can route this to `ops-issue` instead.
+
+Do not ship a half-finished fix. Do not leave the working tree dirty on escalation.
+
+## Output Format
+
+Return JSON wrapped in a markdown code block. No prose outside the block.
+
+```json
+{
+  "status": "fixed",
+  "summary": "<original bug summary>",
+  "root_cause": "<one line — what was actually wrong>",
+  "files_changed": ["<path>", "..."],
+  "test_added": "<file:line or description of the new/updated test>",
+  "verification": "npm run standard && npm test — PASSED",
+  "code_health": "<N/A, or '<file>: <before> → <after>, fixed <smell>' per touched file>",
+  "changelog_entry_added": true
+}
+```
+
+or, on escalation:
+
+```json
+{
+  "status": "escalated",
+  "summary": "<original bug summary>",
+  "escalation_reason": "<precise explanation of why this needs a human / a filed issue instead>",
+  "files_changed": []
+}
+```
+
+## Rules
+
+- **Minimal fix only.** One root cause → one fix. No drive-by refactors, no touching unrelated code even if it looks improvable.
+- **Never weaken a test to make it pass.** If an existing test's expected value is provably wrong, say so explicitly in `root_cause` and correct it with a properly-sourced reference value — don't loosen a tolerance or delete an assertion to get green.
+- **Never skip RED.** A test that passes before your fix is written is not testing the bug — rewrite it.
+- **Never commit, push, or touch git branches/remotes.** Your job ends at a clean, green working tree; the calling skill ships it.
+- **Never fabricate a numeric reference value.** If you can't derive one from mpmath/scipy/R or exact rational arithmetic, escalate rather than guess.
+- **When in doubt, escalate.** A wrongly-forced trivial/moderate fix that ships a subtly broken patch is worse than one extra filed issue.

--- a/.claude/agents/ops-triage.md
+++ b/.claude/agents/ops-triage.md
@@ -1,6 +1,6 @@
 ---
 name: ops-triage
-description: Classifies candidate bug observations from a fix/build session into definite/ambiguous/not-a-bug buckets and produces structured input for ops-issue. Pure analysis — does not file issues.
+description: Classifies candidate bug observations from a fix/build/review session into definite/ambiguous/not-a-bug buckets, sizes definite bugs as trivial/moderate/difficult, and routes trivial/moderate ones to ops-fix while only difficult ones get drafted for ops-issue. Pure analysis — does not file issues or fix code.
 model: sonnet
 tools:
   - Read
@@ -13,22 +13,27 @@ You are a bug-triage agent for the ranjs statistical library.
 
 ## Your Purpose
 
-Look at observations that surfaced during a `/hotfix`, `/fix`, or `/build` session and decide which deserve a GitHub bug issue. The orchestrator hands you a list of candidate concerns it noticed; you classify each as **definite bug**, **ambiguous**, or **not a bug**, with one-line reasoning. For definite bugs you also draft the issue fields (title, body, priority, difficulty) so the orchestrator can hand them straight to `ops-issue`.
+Look at observations that surfaced during a `/hotfix`, `/fix`, `/build`, or `/review` session and decide which deserve attention. The orchestrator hands you a list of candidate concerns it noticed (or a list of already-vetted `Warn` findings from `/review`); you classify each as **definite bug**, **ambiguous**, or **not a bug**, with one-line reasoning. For definite bugs you also size the complexity (`trivial`/`moderate`/`difficult`) and decide the **route**:
 
-You do NOT call `ops-issue` yourself. You do NOT touch GitHub. You analyze; the orchestrator acts.
+- `trivial` or `moderate` → **`route: "fix"`** — hand off to the `ops-fix` agent to resolve in place during this session.
+- `difficult` → **`route: "file"`** — draft the issue fields (title, body, priority, difficulty) so the orchestrator can hand them straight to `ops-issue`.
+
+The guiding principle: **only bugs that are genuinely hard get filed.** Everything trivial or moderate should be fixed in-place during the session that found it, not deferred to a backlog.
+
+You do NOT call `ops-issue` or `ops-fix` yourself. You do NOT touch GitHub or write code. You analyze; the orchestrator acts.
 
 ## Input
 
 You will receive:
 
 1. **branch** — the current branch name
-2. **session_kind** — one of `hotfix`, `fix`, `build`
+2. **session_kind** — one of `hotfix`, `fix`, `build`, `review`
 3. **target_issue** — the issue being worked on (e.g. `#134`), or `null` if topic-driven
-4. **observations** — an array of candidate concerns the orchestrator noticed. Each entry has:
+4. **observations** — an array of candidate concerns. Each entry has:
    - `summary` — one-line description
    - `stage` — where it surfaced (`research`, `implement`, `validate`, `review`, `ship`)
    - `evidence` — file:line references, log snippets, or empirical results
-   - `orchestrator_call` — the orchestrator's tentative classification (`bug | suspect | not-a-bug`) and why
+   - `orchestrator_call` — the orchestrator's tentative classification (`bug | suspect | not-a-bug`) and why. When `session_kind` is `review`, these are `Warn` findings already vetted as real problems by a specialized review agent (`orchestrator_call` will be `bug` in almost every case) — you are sizing them for routing, not re-litigating whether they're real.
 5. **diff_path** *(optional)* — path to a patch file for the current branch, in case you need to inspect code yourself
 
 If `observations` is empty, the orchestrator believes nothing surfaced. Still skim the diff (if provided) for obvious red flags before concluding the session is clean.
@@ -61,17 +66,17 @@ For each observation:
    - `ambiguous` — could be a bug OR could be expected behavior; needs a human call. Includes anything where the call hinges on policy ("should constructor reject this input?") rather than math.
    - `not-a-bug` — falls into the "NOT bugs" list above, or the evidence is too thin.
 2. **Reason in one line.** Cite the test, formula, or empirical result that drove the call.
-3. **For `definite` only**, also draft:
+3. **For `definite` only**, also size and route:
    - `title` — imperative, ≤70 chars, starts with a verb (e.g. "Fix off-by-one in DiscreteUniform CDF").
-   - `body` — uses the standard `ops-issue` template (Goal / Scope / Acceptance Criteria / Out of Scope). The "Goal" should describe the bug as seen by a user. The "Scope" should name the file(s) suspected of containing the bug.
-   - `priority` — one of `high`/`medium`/`low`. Default to `medium` unless the bug returns NaN, wrong support, or silently accepts invalid input (then `high`).
-   - `difficulty` — one of `difficult`/`moderate`/`trivial`. Use these precise criteria:
+   - `difficulty` — one of `trivial`/`moderate`/`difficult`. Use these precise criteria:
      - `trivial` — 1–5 lines, fix is fully obvious from the evidence (wrong constant, missing constraint, off-by-one), no design decision needed, can be described as a concrete edit.
-     - `moderate` — up to ~20 lines, may require reading adjacent code or verifying a formula but no architectural choice.
-     - `difficult` — deeper investigation needed, algorithm change, or multi-file coordination required.
-   - `fix_inline` — `true` if `difficulty == "trivial"` **and** you can describe the fix precisely enough for the orchestrator to apply it without additional context-gathering; `false` otherwise.
-   - `fix_suggestion` — only present when `fix_inline: true`. A concrete one-line description of the edit: file path, line reference, and what to change (e.g., `"src/dist/foo.js:42 — change \`x < 0\` to \`x <= 0\`"`). Omit for `fix_inline: false`.
-   - `extra_labels` — should always include `bug`.
+     - `moderate` — up to ~20 lines, may require reading adjacent code, tracing a caller, or verifying a formula, but no architectural choice and no multi-file redesign.
+     - `difficult` — deeper investigation needed, algorithm change, ambiguous root cause, or multi-file coordination required.
+   - `route` — derived directly from `difficulty`: `"fix"` when `difficulty` is `trivial` or `moderate`, `"file"` when `difficulty` is `difficult`. Never route a `difficult` bug to `"fix"` — the entire point of the split is that only genuinely hard bugs get filed, and "hard" is exactly what `difficult` means.
+   - `fix_context` — **required when `route == "fix"`**. Everything the `ops-fix` agent needs to act without re-deriving your diagnosis: the file(s)/line(s) suspected, the root cause, the expected correct behavior, and — if you can tell — a concrete suggested approach (e.g. `"src/dist/foo.js:42 — change \`x < 0\` to \`x <= 0\`; _fitInit at line 58 has the matching off-by-one"`). Be as precise as the evidence allows, but do not fabricate a fix you aren't confident in — the ops-fix agent will investigate further for `moderate` cases, so a well-scoped pointer is enough; it does not need to be a finished patch.
+   - `body` — **required when `route == "file"`**. Uses the standard `ops-issue` template (Goal / Scope / Acceptance Criteria / Out of Scope). The "Goal" should describe the bug as seen by a user. The "Scope" should name the file(s) suspected of containing the bug.
+   - `priority` — **required when `route == "file"`**. One of `high`/`medium`/`low`. Default to `medium` unless the bug returns NaN, wrong support, or silently accepts invalid input (then `high`).
+   - `extra_labels` — **required when `route == "file"`**. Should always include `bug`.
 
 ## Output Format
 
@@ -84,11 +89,11 @@ Return JSON wrapped in a markdown code block. No prose outside the block.
       "summary": "<original observation summary>",
       "reason": "<one line>",
       "title": "<imperative ≤70 chars>",
-      "body": "<full markdown body using ops-issue template>",
+      "difficulty": "trivial|moderate|difficult",
+      "route": "fix|file",
+      "fix_context": "<file:line, root cause, expected behavior, suggested approach; present only when route == \"fix\">",
+      "body": "<full markdown body using ops-issue template; present only when route == \"file\">",
       "priority": "high|medium|low",
-      "difficulty": "difficult|moderate|trivial",
-      "fix_inline": true,
-      "fix_suggestion": "<file:line — what to change; only present when fix_inline is true>",
       "extra_labels": ["bug"]
     }
   ],

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -135,8 +135,8 @@ The agent returns three buckets: `definite`, `ambiguous`, `not_a_bug`.
 
 **Step 4.5c — Act on the result.**
 
-- **`definite` with `fix_inline: true`** (trivial): apply the fix on the fly using `fix_suggestion`, run `npm run standard && npm test`. Do **not** file an issue. Count as "fixed inline".
-- **`definite` with `fix_inline: false`** (non-trivial): invoke `ops-issue` once per entry with the drafted `title`/`body`/`priority`/`difficulty`/`extra_labels`. Collect the returned issue URLs.
+- **`definite` with `route: "fix"`** (trivial/moderate): spawn the `ops-fix` agent with `summary`, `difficulty`, `fix_context`, and `branch`, one bug at a time (sequentially — they share the working tree). On `status: "fixed"`, count as "fixed inline". On `status: "escalated"`, fall back to `ops-issue` using the entry's drafted `title`/`priority`/`extra_labels` and a body built from `summary` + the escalation reason.
+- **`definite` with `route: "file"`** (difficult): invoke `ops-issue` once per entry with the drafted `title`/`body`/`priority`/`extra_labels`. Collect the returned issue URLs.
 - **`ambiguous` (escalate in batch)**: Use a single `AskUserQuestion` with one question per entry, options "File issue" / "Skip", plus an "Other" fallback. For each "File issue" answer, invoke `ops-issue` using the `draft_title`. Skip the rest silently.
 - **`not_a_bug`**: silent.
 

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -58,8 +58,8 @@ Compile observations noticed during steps 3–4 (pre-existing NaN at a boundary,
 Spawn the `ops-triage` agent with `branch`, `session_kind: "fix"`, `target_issue`, the `observations` list, and a `diff_path` (write `git diff main...HEAD` to `.claude/tmp/triage-diff-<branch>.patch` if not already done).
 
 Act on the result:
-- **`definite` with `fix_inline: true`** (trivial): apply the fix on the fly using `fix_suggestion`, run `npm run standard && npm test`. Do **not** file an issue. Count as "fixed inline".
-- **`definite` with `fix_inline: false`** (non-trivial): invoke `ops-issue` once per entry with the drafted fields. Collect URLs.
+- **`definite` with `route: "fix"`** (trivial/moderate): spawn the `ops-fix` agent with `summary`, `difficulty`, `fix_context`, and `branch`, one bug at a time (sequentially — they share the working tree). On `status: "fixed"`, count as "fixed inline". On `status: "escalated"`, fall back to `ops-issue` using the entry's drafted `title`/`priority`/`extra_labels` and a body built from `summary` + the escalation reason.
+- **`definite` with `route: "file"`** (difficult): invoke `ops-issue` once per entry with the drafted fields. Collect URLs.
 - **`ambiguous`**: one batched `AskUserQuestion` (File issue / Skip / Other). For each "File issue", invoke `ops-issue`.
 - **`not_a_bug`**: silent.
 

--- a/.claude/skills/hotfix/SKILL.md
+++ b/.claude/skills/hotfix/SKILL.md
@@ -66,8 +66,8 @@ Compile observations noticed during step 4 (a flaky test, a pre-existing NaN at 
 Spawn the `ops-triage` agent with `branch`, `session_kind: "hotfix"`, `target_issue`, the `observations` list, and a `diff_path` (write `git diff main...HEAD` to `.claude/tmp/triage-diff-<branch>.patch` first).
 
 Act on the result:
-- **`definite` with `fix_inline: true`** (trivial): apply the fix on the fly using `fix_suggestion`, run `npm run standard && npm test`. Do **not** file an issue. Count as "fixed inline".
-- **`definite` with `fix_inline: false`** (non-trivial): invoke `ops-issue` once per entry with the drafted fields. Collect URLs.
+- **`definite` with `route: "fix"`** (trivial/moderate): spawn the `ops-fix` agent with `summary`, `difficulty`, `fix_context`, and `branch`, one bug at a time (sequentially — they share the working tree). On `status: "fixed"`, count as "fixed inline". On `status: "escalated"`, fall back to `ops-issue` using the entry's drafted `title`/`priority`/`extra_labels` and a body built from `summary` + the escalation reason.
+- **`definite` with `route: "file"`** (difficult): invoke `ops-issue` once per entry with the drafted fields. Collect URLs.
 - **`ambiguous`**: one batched `AskUserQuestion` (File issue / Skip / Other). For each "File issue", invoke `ops-issue`.
 - **`not_a_bug`**: silent.
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -85,7 +85,23 @@ Wait for all eight. Then merge in four passes:
 
 **Pass D — Produce the merged list:** Block first, then Conflict (needs a human decision), then Warn.
 
-### 5. Generate Report
+### 5. Auto-fix Warn Findings (fully autonomous)
+
+Warn findings are real problems — each review agent only emits `Warn` for something it's already confident is wrong, just not commit-blocking. Rather than leaving them for a human to notice and file later, size and route them exactly like any other bug the pipeline finds: **fix what's fixable now, file only what's genuinely hard.**
+
+**Skip this step** if the merged Warn list from Pass D is empty.
+
+a. Spawn `ops-triage` with `branch`, `session_kind: "review"`, `target_issue` (the branch's linked issue if known, else `null`), and `observations` built from every Warn entry: `summary` = the finding's one-line description, `stage: "review"`, `evidence` = the file:line and the reviewing agent's rationale, `orchestrator_call: "bug"` (Warn findings are already vetted as real by a specialized reviewer — `ops-triage` is sizing them for routing, not re-litigating whether they're real).
+
+b. Act on the result the same way every other triage stage in this codebase does:
+   - **`definite` with `route: "fix"`** (trivial/moderate): spawn `ops-fix` with `summary`, `difficulty`, `fix_context`, `branch` — one bug at a time, sequentially (they share the working tree). On `status: "fixed"`, mark that Warn entry **fixed inline**. On `status: "escalated"`, fall through to filing (next bullet) using the entry's `title`, `priority: "medium"` (default), `extra_labels: ["bug"]`, and a body built from `summary` plus the escalation reason.
+   - **`definite` with `route: "file"`** (difficult): invoke `ops-issue` with the drafted fields. Mark that Warn entry **filed** with the returned URL.
+   - **`ambiguous`**: treat conservatively as filed, not skipped — invoke `ops-issue` using `draft_title` and a body built from `summary` plus the triage `reason`. Warn findings already passed one round of specialist review; don't silently drop them, and don't break full autonomy to ask a human mid-review.
+   - **`not_a_bug`**: drop silently — `ops-triage` is allowed to override a reviewer's false positive.
+
+c. After every `ops-fix` call has returned, run `npm run standard && npm test` once more as a final check across the combined set of in-place fixes. If it fails, **stop** — report the failure instead of proceeding to Step 6 with a broken tree.
+
+### 6. Generate Report
 
 > **Review: `<branch name>`**
 >
@@ -99,16 +115,16 @@ Wait for all eight. Then merge in four passes:
 > - [ ] `[domain-A vs domain-B]` file:line — **Domain-A says**: <position>. **Domain-B says**: <position>. Needs human decision.
 >
 > **Warn (<N>):**
-> - [ ] `[domain]` file:line — description and recommendation
+> - [x] `[domain]` file:line — description and recommendation — **fixed inline** | **filed: <URL>**
 >
-> **Verdict**: PASS | FAIL (<N> to fix before commit, <C> to decide, <M> to file)
+> **Verdict**: PASS | FAIL (<N> to fix before commit, <C> to decide)
 
-Verdict is FAIL if there are any Block items. Conflict and Warn items do not block commits — Conflicts need a human call, Warns should be filed as issues. If Block, Conflict, and Warn are all empty, output `Verdict: PASS` with no lists.
+Verdict is FAIL if there are any Block items. Conflict items do not block commits but need a human call. Warn items never block commits and are always resolved by Step 5 before this report is generated — every Warn line ends in "fixed inline" or "filed: `<URL>`", never left open. If Block, Conflict, and Warn are all empty, output `Verdict: PASS` with no lists.
 
-### 6. Next Steps
+### 7. Next Steps
 
 - **PASS**: "Review passed. Changes are ready to commit."
-- **FAIL**: "Review found <N> blocking issue(s). Fix them and run `/review` again. (<C> conflicts and <M> warn items — resolve/file after committing.)"
+- **FAIL**: "Review found <N> blocking issue(s). Fix them and run `/review` again. (<C> conflicts still need a human call.)"
 - **Conflicts present**: After listing them, ask the user to pick a side for each one using `AskUserQuestion` before proceeding.
 
 ## Rules
@@ -117,8 +133,9 @@ Verdict is FAIL if there are any Block items. Conflict and Warn items do not blo
 - Read the FULL diff before making any judgments
 - Be specific — cite file paths and line ranges for each issue
 - Focus on issues CI cannot catch
+- Resolve every Warn finding in Step 5 — fix trivial/moderate ones via `ops-fix`, file only difficult ones via `ops-issue`
 
 ### DO NOT:
 - Block on style preferences — only flag naming that breaks existing conventions
 - Duplicate what `npm run standard` already catches
-- Auto-fix issues — report them and let the user decide
+- Auto-fix Block or Conflict findings — report them and let the calling skill's auto-fix loop, or the user, decide. (Warn findings are the deliberate exception: Step 5 always resolves them via `ops-fix`/`ops-issue`.)


### PR DESCRIPTION
ops-triage now sizes every definite bug as trivial/moderate/difficult
and outputs a route ("fix" or "file") instead of the old trivial-only
fix_inline/fix_suggestion pair. Only difficult bugs still go to
ops-issue; trivial and moderate ones are handed to the new ops-fix
agent, which does the full TDD cycle in place (failing test, minimal
fix, lint/test/code-health verification, changelog entry) and
escalates back to filing only if the bug turns out harder than
described.

/fix, /hotfix, and /build's bug-triage steps are updated to use the
new route-based dispatch. /review gains a new step that runs its
merged Warn findings through the same ops-triage -> ops-fix/ops-issue
pipeline, so review warnings are resolved in place rather than left
as "file later" notes.

.claude/README.md documents the new agent and updated dependency map.