### PR TITLE
Defensively document chi2_pdf's +inf boundary at other call sites

### DIFF
--- a/scripts/precision-refs-continuous.py
+++ b/scripts/precision-refs-continuous.py
@@ -284,6 +284,9 @@ def nct_cdf(nu, mu, t):
     # F(t) = integral_0^inf Phi(t*sqrt(v/nu) - mu) * chi2_pdf(nu, v) dv.
     # 35 working digits keep the quadrature ~1e-30 accurate (far below float64) while
     # roughly halving the adaptive-subdivision cost that dominates the (doubly-)noncentral-t runs.
+    # Relies on nu >= 2 so chi2_pdf(nu, v) stays finite as v->0 (chi2_pdf returns +inf for
+    # df<2, which quad()'s tanh-sinh rule never literally samples at the v=0 endpoint anyway,
+    # but a future nu<2 param set or a quadrature-rule change would feed +inf into f() directly).
     f = lambda v: Phi(t * sqrt(v / nu) - mu) * chi2_pdf(nu, v)
     with mp.workdps(35):
         return +quad(f, [0, nu, inf])
@@ -486,6 +489,11 @@ def pdf(name, p, x):
         return 2 * x * pdf('Chi2', [k], x * x)
     if name == 'Chi2':
         k = int(round(p[0]))
+        # Unlike 'Chi' above, no x==0 special case is needed here: chi2_pdf(k,0) returning
+        # +inf for k<2 *is* the correct chi-squared density at its pole, not a 0*inf artifact
+        # to unwrap. Currently unreached in practice because xvalues()/invcdf() never probe the
+        # literal left support edge (see invcdf()'s "never evaluate cdf at the lower boundary"
+        # comment) -- a manual x-value override at x=0 would exercise this branch directly.
         return chi2_pdf(k, x)
     if name in ('Dagum',):
         pp, a, b = mpf(p[0]), mpf(p[1]), mpf(p[2])


### PR DESCRIPTION
Closes #1123

## Summary
- `chi2_pdf(df, v)` in `scripts/precision-refs-continuous.py` was recently changed (#1116/#1125) so `v == 0` now returns `+inf` when `df < 2`, rather than always `0`. Two other consumers of `chi2_pdf` had a latent, undocumented dependency on this new boundary behavior.
- `nct_cdf`'s mpmath `quad()` integrand (`Phi(...) * chi2_pdf(nu, v)`) now carries an inline comment documenting that it relies on `nu >= 2` to stay finite as `v -> 0`, and why that currently always holds (all `NoncentralT`/`DoublyNoncentralT` parameter sets use `nu >= 5`, and mpmath's tanh-sinh rule never literally samples the `v=0` endpoint).
- The `'Chi2'` pdf dispatch branch (`return chi2_pdf(k, x)`) now carries a comment explaining why, unlike the sibling `'Chi'` branch, no `x == 0` special case is needed: `chi2_pdf(k, 0) = +inf` for `k < 2` *is* the mathematically correct density at its pole, not a `0*inf` artifact to unwrap — and the path is currently unreached since `xvalues()`/`invcdf()` never probe the literal left support edge.

## Non-trivial changes
_No non-trivial changes — this PR is purely documentation (comments only, no logic changed)._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`scripts/precision-refs-continuous.py`**: two comment blocks added at `nct_cdf`'s quadrature call site and the `'Chi2'` pdf dispatch branch; zero lines removed, zero logic changed.

</details>

## Verification
- `npm run standard`, `npm run jsdoclint`, `npm test` (8000 passing, coverage thresholds met), `npm run build && npm run typecheck` all pass.
- `python3 scripts/precision-refs-continuous.py --only Chi,Chi2,NoncentralT,DoublyNoncentralT` — 102 values checked, 0 mismatches.
- `python3 scripts/precision-refs-continuous.py` (full self-check, no `--only` filter) was kicked off but is still running at PR-open time — it's a ~50+ minute mpmath run in this environment. Since the diff is comment-only with zero behavior change, no logic path is affected beyond what the scoped run above already covers.

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_012nG72Y3EB9pMpQeup248AQ)_