### PR TITLE
resolve: auto-launch the recommended skill instead of asking

### DIFF
--- a/.claude/skills/resolve/SKILL.md
+++ b/.claude/skills/resolve/SKILL.md
@@ -1,10 +1,10 @@
 # Resolve Skill
 
-You are triaging a GitHub issue to recommend the fastest, safest workflow: `/hotfix`, `/fix`, or `/build`.
+You are triaging a GitHub issue to pick and launch the fastest, safest workflow: `/hotfix`, `/fix`, or `/build`.
 
 ## Core Principle
 
-Match the issue's complexity to the right pipeline. Recommending too lightweight a skill (e.g., `/hotfix` for something that needs design decisions) wastes time when the user hits a wall mid-flow. Recommending too heavy a skill (e.g., `/build` for a one-liner) slows delivery unnecessarily. This skill reads the issue and does a lightweight codebase probe to produce a confident recommendation before any work starts.
+Match the issue's complexity to the right pipeline. Picking too lightweight a skill (e.g., `/hotfix` for something that needs design decisions) wastes time when the pipeline hits a wall mid-flow. Picking too heavy a skill (e.g., `/build` for a one-liner) slows delivery unnecessarily. This skill reads the issue, does a lightweight codebase probe to produce a confident recommendation, and then automatically launches that recommended skill — no manual selection step.
 
 ## Skill Selection Criteria
 
@@ -90,26 +90,25 @@ Pick exactly one of `/hotfix`, `/fix`, or `/build`. Present it as:
 >
 > **Concerns / caveats:** \<anything the user should watch for mid-flow, or "None"\>
 
-### 5. Offer Next Steps
+### 5. Launch the Recommended Skill
 
-Ask the user what to do using selectable options. Always include all three skill options plus a "just show the recommendation" option so the user can decide:
+Immediately after presenting the recommendation, invoke the recommended skill via the Skill tool, passing the issue number/URL as its argument (e.g. recommended `/build` on issue #123 → invoke `build` with argument `123`). Do not pause for confirmation and do not ask the user to pick — the whole point of this skill is to remove that manual step.
 
-- Run `/hotfix #<number>` now
-- Run `/fix #<number>` now
-- Run `/build #<number>` now
-- Just show the recommendation (do not start work)
+> "Launching `/hotfix` for #\<number\> based on the signals above."
 
-Pre-select the option that matches your recommendation.
+Then invoke the skill and let it run its own workflow (branching, coding, tests, review, ship) to completion. `/resolve`'s job ends once the child skill has been launched — do not duplicate or second-guess its internal steps.
+
+**Exception — genuine toss-up:** if, after the codebase probe, the signals are still evenly split between two skills (not merely "could go either way with a slight lean" — actually balanced), apply the tiebreaker rules first. Only if the tiebreaker itself doesn't resolve it (which should be rare), stop and ask the user with `AskUserQuestion` instead of guessing. This is the sole case where `/resolve` pauses.
 
 ## Rules
 
 ### DO:
 - Base the recommendation on signals from both the issue text and the codebase probe
-- Explain exactly why you picked the recommendation — the user must be able to override intelligently
-- Always offer selectable options; never auto-start a pipeline
+- Explain exactly why you picked the recommendation before launching it
+- Auto-launch the recommended skill via the Skill tool — do not wait for user approval
 
 ### DO NOT:
-- Start any work (branching, coding, commits) — this skill is recommendation-only
 - Recommend `/build` because the issue body is long — verbosity is not a complexity proxy
 - Skip the codebase probe — an issue that sounds simple may touch many files
 - Recommend `/hotfix` if any design decision is open, even a small one
+- Ask the user to choose when the tiebreaker rules already resolve the ambiguity — only escalate on a genuine, unresolved toss-up

--- a/.claude/skills/resolve/SKILL.md
+++ b/.claude/skills/resolve/SKILL.md
@@ -4,7 +4,7 @@ You are triaging a GitHub issue to pick and launch the fastest, safest workflow:
 
 ## Core Principle
 
-Match the issue's complexity to the right pipeline. Picking too lightweight a skill (e.g., `/hotfix` for something that needs design decisions) wastes time when the pipeline hits a wall mid-flow. Picking too heavy a skill (e.g., `/build` for a one-liner) slows delivery unnecessarily. This skill reads the issue, does a lightweight codebase probe to produce a confident recommendation, and then automatically launches that recommended skill — no manual selection step.
+Match the issue's complexity to the right pipeline. Picking too lightweight a skill (e.g., `/hotfix` for something that needs design decisions) wastes time when the pipeline hits a wall mid-flow. Picking too heavy a skill (e.g., `/build` for a one-liner) slows delivery unnecessarily. This skill reads the issue, does a lightweight codebase probe to produce a confident recommendation, and then automatically launches that recommended skill — no manual selection step. When no issue is named, it also picks *which* issue from the open backlog before triaging it, using the same priority/difficulty ranking as `/next`.
 
 ## Skill Selection Criteria
 
@@ -26,7 +26,20 @@ Match the issue's complexity to the right pipeline. Picking too lightweight a sk
 
 ## Workflow
 
-When the user invokes `/resolve <number>`:
+When the user invokes `/resolve <number>` or bare `/resolve` (no issue given):
+
+### 0. Pick an Issue (only when no `<number>` was given)
+
+Skip straight to Step 1 if the user passed a number or URL.
+
+Otherwise, select the top candidate from the open backlog using the **same ranking as `/next`**: priority tier desc (high > medium > low > unlabeled), then difficulty desc (trivial > moderate > difficult > unlabeled) as the tiebreak, then issue number asc. Do not invent a different ranking — reuse this one so `/resolve` and `/next` never disagree on what "next" means.
+
+1. Run `python3 .claude/skills/next/rank_issues.py` and take `ranked[0]` (the top of the unblocked list; entries in `blocked` are excluded — never pick a blocked issue).
+   - **`gh` unavailable:** fall back to `mcp__github__list_issues` (`state: OPEN`, paginate via `after`/`pageInfo` until exhausted), extract each issue's priority/difficulty labels, and rank them in memory using the same rule above (skip dependency/`blocked` detection in this fallback — priority and difficulty alone are enough).
+2. If there are no open issues (or every open issue is blocked in the script path), stop and report: "No open, unblocked issues found — nothing to resolve."
+3. Report the pick before continuing:
+   > "No issue given — picking from the backlog: **#\<number\> — \<title\>** (priority: \<p\>, difficulty: \<d\>)."
+4. Continue to Step 1 using this issue's number.
 
 ### 1. Fetch the Issue
 
@@ -106,9 +119,11 @@ Then invoke the skill and let it run its own workflow (branching, coding, tests,
 - Base the recommendation on signals from both the issue text and the codebase probe
 - Explain exactly why you picked the recommendation before launching it
 - Auto-launch the recommended skill via the Skill tool — do not wait for user approval
+- When no issue is given, reuse `/next`'s exact ranking (priority tier, then difficulty) instead of inventing a new one
 
 ### DO NOT:
 - Recommend `/build` because the issue body is long — verbosity is not a complexity proxy
 - Skip the codebase probe — an issue that sounds simple may touch many files
 - Recommend `/hotfix` if any design decision is open, even a small one
 - Ask the user to choose when the tiebreaker rules already resolve the ambiguity — only escalate on a genuine, unresolved toss-up
+- Pick a blocked issue (one with open, unresolved dependencies) when auto-selecting from the backlog


### PR DESCRIPTION
Step 5 now invokes /hotfix, /fix, or /build directly via the Skill
tool once the recommendation is made, instead of presenting selectable
options. The only remaining pause is a genuine toss-up that survives
the existing tiebreaker rules.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013q5pVyQE7LoSMUYrTSKcbY