### PR TITLE
Allow minor and major version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,6 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     versioning-strategy: increase
-    # devDependencies are build tooling, not shipped to consumers; minor/major
-    # bumps (e.g. ESLint 7→9, Rollup majors) often carry breaking config or
-    # plugin-API changes that warrant manual review rather than an automated PR.
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     groups:
       babel:
         patterns:


### PR DESCRIPTION
Remove the ignore rule that restricted Dependabot to patch-only
updates, so it now opens PRs for minor and major dependency bumps
as well.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AHVssRRqUueAWDiAacnUAd