### PR TITLE
Add marcumQ boundary-grid precision tests for Rice/NoncentralChi/NoncentralChi2

### DIFF
--- a/scripts/dump-dist-cases-json.js
+++ b/scripts/dump-dist-cases-json.js
@@ -2,7 +2,7 @@
 // self_check() -- @babel/register lets require() load the ESM-syntax test file the same way mocha
 // does, and evaluating params() here (rather than parsing the source as text) survives any future
 // closure shape, including Hyperexponential's nested { weight, rate } objects.
-require('@babel/register')()
+require('@babel/register').default()
 
 const cases = require('../test/dist-cases-continuous.js').default
 

--- a/scripts/precision-refs-continuous.py
+++ b/scripts/precision-refs-continuous.py
@@ -1405,6 +1405,15 @@ P_GRID = [mpf('0.1'), mpf('0.3'), mpf('0.53'), mpf('0.72'), mpf('0.9')]
 
 # Three parameter sets per distribution (two from dist-cases-continuous.js, one fresh).
 # Parameter-free distributions naturally have a single set.
+#
+# NoncentralChi/NoncentralChi2/Rice get extra sets approaching marcumQ's x<30
+# series/asymptotic dispatch threshold (src/special/marcum-q.js) -- every prior set for
+# these three left the dispatched x well under 30 (0.03-2), so this crossover had zero
+# precision-gate coverage (issue #1143). NoncentralChi2 gets both a below-30 and an
+# above-30 set (both pass); NoncentralChi/Rice get only the below-30 set -- their
+# above-30 sets ([5, 8] / [8, 1]) hit a genuine _zetaxy() cancellation bug in the
+# quadrature branch (2*eps/d2 vs eps^2/(d1*d2) near-cancel once d2 underflows for
+# y << 1), filed separately rather than papered over here.
 PARAM_SETS = {
     'Alpha': [[2, 2], [0.5, 0.5], [3, 1]],
     'Anglit': [[0, 2], [3, 0.5], [-1, 4]],
@@ -1491,8 +1500,8 @@ PARAM_SETS = {
     'Muth': [[0.5], [0.1], [1]],
     'Nakagami': [[2.5, 2], [0.5, 0.5], [1, 3]],
     'NoncentralBeta': [[2, 2, 2], [0.5, 5, 10], [0.1, 2, 10]],
-    'NoncentralChi': [[5, 2], [2, 0.5], [3, 1]],
-    'NoncentralChi2': [[11, 2], [5, 3], [2, 1]],
+    'NoncentralChi': [[5, 2], [2, 0.5], [3, 1], [5, 7.5]],
+    'NoncentralChi2': [[11, 2], [5, 3], [2, 1], [5, 58], [5, 62]],
     'NoncentralF': [[5, 5, 2], [2, 10, 0.5], [4, 6, 3]],
     'NoncentralT': [[5, 1], [5, 0], [8, 2]],
     'Normal': [[0, 2], [3, 0.5], [-1, 1]],
@@ -1505,7 +1514,7 @@ PARAM_SETS = {
     'Rayleigh': [[2], [0.5], [1]],
     'Reciprocal': [[5, 25], [1, 10], [2, 8]],
     'ReciprocalInverseGaussian': [[2, 2], [0.5, 4], [1, 1]],
-    'Rice': [[2, 2], [0.5, 2], [1, 1]],
+    'Rice': [[2, 2], [0.5, 2], [1, 1], [7, 1]],
     'ShiftedLogLogistic': [[0, 2, 2], [0, 2, -2], [0, 2, 0]],
     'SkewNormal': [[0, 2, 2], [0, 2, -2], [1, 1, 3]],
     'Slash': [[]],
@@ -1789,6 +1798,10 @@ PDFCDF_TOL = {
     ('DoublyNoncentralT', '[6, 2, 1]'): '1e-12',
     ('SkewNormal', '[1, 1, 3]'): '1e-12',
     ('Rice', '[0.5, 2]'): '1e-13',
+    ('Rice', '[7, 1]'): '5e-13',
+    ('NoncentralChi', '[5, 7.5]'): '5e-13',
+    ('NoncentralChi2', '[5, 58]'): '5e-13',
+    ('NoncentralChi2', '[5, 62]'): '5e-13',
     ('R', '[0.5]'): '1e-13',
 }
 # Per-(name, json-params) quantile round-trip tolerance (default 1e-14; per-group empirical:
@@ -1801,6 +1814,10 @@ Q_TOL = {
     ('Davis', '[2, 1, 4]'): '1e-12',
     ('DoublyNoncentralChi2', '[2, 3, 1, 1]'): '1e-13',
     ('NoncentralChi2', '[2, 1]'): '1e-13',
+    ('NoncentralChi2', '[5, 58]'): '5e-13',
+    ('NoncentralChi2', '[5, 62]'): '5e-13',
+    ('NoncentralChi', '[5, 7.5]'): '5e-13',
+    ('Rice', '[7, 1]'): '5e-13',
     ('DoublyNoncentralT', '[5, 1, 2]'): '1e-12',
     ('DoublyNoncentralT', '[6, 2, 1]'): '1e-12',
     ('FisherZ', '[1, 1]'): '4e-14',
@@ -1833,6 +1850,9 @@ _N_POLY = 'piecewise-polynomial Neumaier sum loses ~1 ULP beyond 1e-14'
 _N_ROOT = 'q() has no closed form (numerical root-finding), so the round-trip is accurate to a few ULPs beyond 1e-14'
 _N_BENK = 'q() switches to a Lambert-W asymptotic branch as b->1 (here b=0.9995); round-trip accurate to ~1e-9'
 _N_HALLEY = 'q() is a Cornish-Fisher/Halley approximation; the cdf-round-trip loses a few ULPs beyond 1e-14'
+_N_MARCUM = ('x sits near marcumQ\'s series/asymptotic dispatch threshold (x=30); pdf/cdf/quantile '
+             'measured up to ~1.2e-13 in JIT-order-dependent full-suite runs (V8 rounding differs '
+             'from an isolated run) -- gate at 5e-13')
 NOTES = {
     ('Bates', '[10, 5, 25]'): _N_POLY,
     ('Bates', '[5, -2, 2]'): _N_POLY,
@@ -1853,6 +1873,10 @@ NOTES = {
     ('DoublyNoncentralT', '[6, 2, 1]'): _N_NCT,
     ('SkewNormal', '[1, 1, 3]'): 'cdf uses Owen T and q() root-finds on it; both lose a few ULPs beyond 1e-14',
     ('Rice', '[0.5, 2]'): _N_SERIES,
+    ('Rice', '[7, 1]'): _N_MARCUM,
+    ('NoncentralChi', '[5, 7.5]'): _N_MARCUM,
+    ('NoncentralChi2', '[5, 58]'): _N_MARCUM,
+    ('NoncentralChi2', '[5, 62]'): _N_MARCUM,
     ('R', '[0.5]'): _N_SERIES,
     ('R', '[2]'): _N_SERIES,
     ('BaldingNichols', '[0.1, 0.1]'): _N_ROOT,

--- a/test/precision-continuous.js
+++ b/test/precision-continuous.js
@@ -3208,6 +3208,20 @@ const REFS = [
       { x: 2.870032352632938, pdf: 0.19862324918959134, cdf: 0.9 }
     ]
   },
+  // NoncentralChi[5,7.5]: x sits near marcumQ's series/asymptotic dispatch threshold (x=30); pdf/cdf/quantile measured up to ~1.2e-13 in JIT-order-dependent full-suite runs (V8 rounding differs from an isolated run) -- gate at 5e-13
+  {
+    name: 'NoncentralChi',
+    params: [5, 7.5],
+    tol: 5e-13,
+    qtol: 5e-13,
+    points: [
+      { x: 6.505569010691933, pdf: 0.17932022377048565, cdf: 0.1 },
+      { x: 7.247694376427309, pdf: 0.3542420602230855, cdf: 0.3 },
+      { x: 7.836839592589605, pdf: 0.4045565271965982, cdf: 0.53 },
+      { x: 8.336294189382912, pdf: 0.3418700397177332, cdf: 0.72 },
+      { x: 9.024839527808627, pdf: 0.17795311131153096, cdf: 0.9 }
+    ]
+  },
   {
     name: 'NoncentralChi2',
     params: [11, 2],
@@ -3246,6 +3260,34 @@ const REFS = [
       { x: 2.3631809667597996, pdf: 0.1566774646603099, cdf: 0.53 },
       { x: 3.8847437382582997, pdf: 0.09712966357108083, cdf: 0.72 },
       { x: 6.770130260953069, pdf: 0.0365587760021899, cdf: 0.9 }
+    ]
+  },
+  // NoncentralChi2[5,58]: x sits near marcumQ's series/asymptotic dispatch threshold (x=30); pdf/cdf/quantile measured up to ~1.2e-13 in JIT-order-dependent full-suite runs (V8 rounding differs from an isolated run) -- gate at 5e-13
+  {
+    name: 'NoncentralChi2',
+    params: [5, 58],
+    tol: 5e-13,
+    qtol: 5e-13,
+    points: [
+      { x: 43.78099019226955, pdf: 0.013541095426963547, cdf: 0.1 },
+      { x: 54.15946113115637, pdf: 0.024054046277784912, cdf: 0.3 },
+      { x: 63.18284944152266, pdf: 0.025435465133139268, cdf: 0.53 },
+      { x: 71.37623716721646, pdf: 0.020224060019314875, cdf: 0.72 },
+      { x: 83.48958891740753, pdf: 0.009734204702816305, cdf: 0.9 }
+    ]
+  },
+  // NoncentralChi2[5,62]: x sits near marcumQ's series/asymptotic dispatch threshold (x=30); pdf/cdf/quantile measured up to ~1.2e-13 in JIT-order-dependent full-suite runs (V8 rounding differs from an isolated run) -- gate at 5e-13
+  {
+    name: 'NoncentralChi2',
+    params: [5, 62],
+    tol: 5e-13,
+    qtol: 5e-13,
+    points: [
+      { x: 47.13037051154166, pdf: 0.013032297643811988, cdf: 0.1 },
+      { x: 57.892488444582135, pdf: 0.023238388717002373, cdf: 0.3 },
+      { x: 67.2203921302756, pdf: 0.02463494199742843, cdf: 0.53 },
+      { x: 75.67191039556722, pdf: 0.01962409906652587, cdf: 0.72 },
+      { x: 88.1410880548629, pdf: 0.009466611488950172, cdf: 0.9 }
     ]
   },
   {
@@ -3796,6 +3838,20 @@ const REFS = [
       { x: 1.5372641174371435, pdf: 0.48170928886664116, cdf: 0.53 },
       { x: 1.9709753266487888, pdf: 0.38288034076859595, cdf: 0.72 },
       { x: 2.6019473978067023, pdf: 0.19024802417179226, cdf: 0.9 }
+    ]
+  },
+  // Rice[7,1]: x sits near marcumQ's series/asymptotic dispatch threshold (x=30); pdf/cdf/quantile measured up to ~1.2e-13 in JIT-order-dependent full-suite runs (V8 rounding differs from an isolated run) -- gate at 5e-13
+  {
+    name: 'Rice',
+    params: [7, 1],
+    tol: 5e-13,
+    qtol: 5e-13,
+    points: [
+      { x: 5.797155731308308, pdf: 0.17666362533966992, cdf: 0.1 },
+      { x: 6.5497028587527515, pdf: 0.3496541744812064, cdf: 0.3 },
+      { x: 7.146200232866974, pdf: 0.399809886771418, cdf: 0.53 },
+      { x: 7.651351863957296, pdf: 0.3381634294981794, cdf: 0.72 },
+      { x: 8.347062470169687, pdf: 0.17621165107377856, cdf: 0.9 }
     ]
   },
   {


### PR DESCRIPTION
## Summary

First slice of #1143 ("Expand precision tests to a systematic parameter-space grid"). Adds boundary-adjacent parameter sets for the three distributions that share the `marcumQ`/`marcumP` regime dispatcher (`src/special/marcum-q.js`) — Rice, NoncentralChi, NoncentralChi2 — straddling its `x < 30` series/asymptotic dispatch threshold, which previously had zero precision-gate coverage (every existing parameter set for these three dispatched `x` well under 30, in the 0.03–2 range).

This is an intentionally partial delivery, not the full issue — see "Scope and follow-ups" below.

Addresses part of #1143

## What changed

- `scripts/precision-refs-continuous.py` — `PARAM_SETS['NoncentralChi']`/`['NoncentralChi2']`/`['Rice']` extended with boundary-straddling sets; `PDFCDF_TOL`/`Q_TOL`/`NOTES` overrides added for the new groups (all four settled at `5e-13` after full-suite verification, see below).
- `test/precision-continuous.js` — 4 new generated `REFS` groups (`NoncentralChi[5,7.5]`, `NoncentralChi2[5,58]`, `NoncentralChi2[5,62]`, `Rice[7,1]`).
- `scripts/dump-dist-cases-json.js` — fixed `require('@babel/register')()`, broken by `@babel/register` 8.x's move to an ESM-only build (`require()` now returns `{ default: register }` instead of the function directly). This blocked running the precision-refs self-check entirely; needed to verify the new entries.

## A genuine bug was found, and deliberately not shipped here

Two of the originally-planned six new parameter sets — `NoncentralChi(5,8)` and `Rice(8,1)`, the "above 30" side for those two distributions — trigger a real, previously-undiscovered catastrophic-cancellation bug in `_zetaxy()`'s quadrature branch: `d2 = w + 2*ys - 1` rounds to exactly `0` once `ys` underflows the ULP of `w≈1`, cascading into `NaN` that silently defeats a downstream NaN-unsafe guard (`NaN` comparisons are always `false` in JS) and produces wildly wrong quantile results (e.g. `Rice(8,1).q(0.1)` returns `1.86e-9` instead of the correct `≈6.79`, with no thrown error).

I attempted a local fix (rationalizing `w - 1` to avoid the direct-subtraction cancellation) but found it only relocates the cancellation to a deeper term in the same formula, producing a different but still silently-wrong finite value rather than a correct one. A proper fix needs an asymptotic re-derivation, not a local patch — filed separately as **#1179** rather than papered over with a loosened tolerance here. `NoncentralChi2`'s equivalent "above 30" case (`[5,62]`) does *not* hit this bug and is included.

The remaining special-function families (erfc-based: Normal/LogNormal/Levy/InverseGaussian; incomplete-beta-based: Beta/F/NoncentralBeta/NoncentralF/DoublyNoncentralBeta/DoublyNoncentralF) are tracked as a continuation in **#1178**.

## JIT-order-dependent flakiness

Two consecutive full `npm test` runs each surfaced a different point, in a different one of the four new groups, failing by ~1e-13–1.2e-13 — consistent with the repo's existing documented precedent (`UniformProduct`'s `#759` notes) for V8 rounding differing between an isolated run and `mocha --parallel`'s worker scheduling. Rather than whack-a-mole individual points, all four new/modified groups were given a uniform, generous `tol`/`qtol` of `5e-13` with a shared `_N_MARCUM` justification comment. Verified stable across 3 consecutive full `npm test` runs (8232–8233 passing, 0 failing, coverage thresholds met each time).

## Scope and follow-ups

- **#1178** — continuation of #1143 for the erfc-based and incomplete-beta-based families (explicitly deferring `DoublyNoncentralBeta`/`DoublyNoncentralF` pending #1149, which already flags that distribution's reference-computation as slow/possibly non-terminating at large λ).
- **#1179** — the `_zetaxy()` cancellation bug found above; a prerequisite before Rice/NoncentralChi's "above 30" marcumQ boundary can get full coverage.
- `todo.md` intentionally untouched — no entry verbatim matches #1143's original wording, and the closest candidate describes the full multi-family end state, not this first slice.

Full research and design rationale: `thoughts/research/2026-07-26-0602-precision-test-parameter-space-grid.md`, `thoughts/plans/2026-07-26-0620-precision-test-marcum-q-boundary-grid.md`.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green) — verified across 3 consecutive full runs
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — n/a, no new distribution
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — n/a
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped; test-only + dev-tooling change, no `src/` or public-API impact
- [x] Production-code diff is under ~400 lines (tests excluded) — ~30 lines in `scripts/precision-refs-continuous.py`, 2 in `scripts/dump-dist-cases-json.js`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqmVKBeRvZF13RHrsmbRGf)_