### PR TITLE
Fix flaky cramerVonMises test with instance seeding

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -102,14 +102,18 @@ describe('test', () => {
       seed(0)
       const mu = float(0, 5)
       const sigma = float(1, 10)
-      assert(test.cramerVonMises((new Normal(mu, sigma)).sample(SAMPLE_SIZE), x => (new Normal(mu, sigma)).cdf(x)).passed)
+      // seed(0) above only reseeds the module-level generator behind float()/int() (src/core/index.js);
+      // Normal owns its own Xoshiro128p instance (src/dist/_distribution.js) that self-seeds from
+      // Math.random() unless .seed() is called on it directly, so .sample() must be seeded here too or
+      // the drawn sample - and thus the CvM statistic - is different on every run.
+      assert(test.cramerVonMises((new Normal(mu, sigma)).seed(0).sample(SAMPLE_SIZE), x => (new Normal(mu, sigma)).cdf(x)).passed)
     })
 
     it('should reject for samples drawn from a different distribution', () => {
       seed(0)
       const mu = float(0, 5)
       const sigma = float(1, 10)
-      assert(!test.cramerVonMises((new Normal(mu + 10, sigma)).sample(SAMPLE_SIZE), x => (new Normal(mu, sigma)).cdf(x)).passed)
+      assert(!test.cramerVonMises((new Normal(mu + 10, sigma)).seed(0).sample(SAMPLE_SIZE), x => (new Normal(mu, sigma)).cdf(x)).passed)
     })
 
     // Reference stat/pValue below are cross-checked against scipy 1.17.1:


### PR DESCRIPTION
Closes #1182

## Summary
- Fixed the flaky `cramerVonMises` test in `test/test.js` by seeding the `Normal` distribution instances directly before calling `.sample()`.
- Root cause differs from the issue's original hypothesis: `seed(0)` only reseeds the module-level generator behind `float()`/`int()` (`src/core/index.js`). Each `Distribution` instance owns its own `Xoshiro128p` PRNG (`src/dist/_distribution.js:39`) that self-seeds from `Math.random()` at construction unless `.seed()` is called on it directly (`src/core/xoshiro.js:12`). The test never seeded the `Normal` instance used for `.sample()`, so the drawn sample — and thus the CvM statistic — was genuinely random on every run, not merely marginal near α = 0.05.
- Verified locally: before the fix, repeated runs of the same seeded test produced p-values ranging from ~0.0006 to ~0.82 (i.e. flipping pass/fail arbitrarily). After adding `.seed(0)` to the `Normal` instances (matching the pattern already used elsewhere in the same file, e.g. line 216), the sample and resulting p-value (≈0.113) are now identical across repeated runs.

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical (adds `.seed(0)` calls to two existing test call sites plus a WHY comment)._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/test.js`**: Added `.seed(0)` to the `Normal` instances in the two `cramerVonMises` "should pass"/"should reject" tests, plus a WHY comment explaining the two-PRNG root cause.

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9avBfkMi4t8N8fjvNFs9M)_