### PR TITLE
Add VonMises(11) boundary-grid precision-gate coverage

### DIFF
--- a/scripts/precision-refs-continuous.py
+++ b/scripts/precision-refs-continuous.py
@@ -1447,7 +1447,9 @@ P_GRID = [mpf('0.1'), mpf('0.3'), mpf('0.53'), mpf('0.72'), mpf('0.9')]
 # (e.g. VonMises(9).cdf(-pi/4) = -0.0074) for sufficiently concentrated kappa, which corrupts
 # the general quantile root-finder for arbitrary p -- filed and fixed separately (see
 # solutions/correctness/2026-07-26-1339-vonmises-cdf-oscillating-term-premature-convergence.md).
-# No VonMises boundary set is added here; out of scope for #1185.
+# Both fixes have since landed, so the VonMises[11] set below (in PARAM_SETS/VONMISES_XVALS)
+# is now included -- its three k*pi/4 x-values directly regression-test the oscillating-term
+# envelope fix, and kappa=11 keeps it inside the besselI(0,x) dispatch band #1185 fixed.
 PARAM_SETS = {
     'Alpha': [[2, 2], [0.5, 0.5], [3, 1]],
     'Anglit': [[0, 2], [3, 0.5], [-1, 4]],
@@ -1576,7 +1578,7 @@ PARAM_SETS = {
     'Uniform': [[5, 25], [0, 1], [-2, 2]],
     'UniformProduct': [[6], [2], [4]],
     'UniformRatio': [[]],
-    'VonMises': [[2], [0.5], [1]],
+    'VonMises': [[2], [0.5], [1], [11]],
     'Weibull': [[2, 2], [0.5, 0.5], [1, 3]],
     'Wigner': [[2], [0.5], [1]],
 }
@@ -1638,6 +1640,14 @@ VONMISES_XVALS = {
     (2,): [mpf('-2'), mpf('-0.8'), mpf('0.4'), mpf('1.2'), mpf('2.5')],
     (0.5,): [mpf('-2.5'), mpf('-1'), mpf('0.4'), mpf('1.4'), mpf('2.5')],
     (1,): [mpf('-2.5'), mpf('-1'), mpf('0.4'), mpf('1.4'), mpf('2.5')],
+    # kappa=11 straddles besselI(0,x)'s Miller-recurrence dispatch band (10, 14] (bessel.js)
+    # and includes three k*pi/4 phase points (-pi/4, pi/4, pi/2) where _cdf's Fourier-series
+    # envelope convergence check (see src/dist/von-mises.js) was previously fooled by sin(i*x)
+    # coincidentally vanishing at those exact phases -- see the withheld-set note above. The
+    # remaining two points, -1 and 0.15, are generic interior probes (one moderate-tail, one
+    # near-mode) added to round the group out to this file's standard 5-points-per-group shape,
+    # matching how other groups here combine targeted boundary probes with generic coverage.
+    (11,): [mpf('-1'), -pi / 4, mpf('0.15'), pi / 4, pi / 2],
 }
 # Davis is inverted by bisection like the rest (its quadrature CDF is slow but tolerable for
 # one distribution) so its probes span the full support {0.1..0.9} rather than fixed points.
@@ -1861,6 +1871,7 @@ PDFCDF_TOL = {
     ('NoncentralChi2', '[5, 58]'): '5e-13',
     ('NoncentralChi2', '[5, 62]'): '5e-13',
     ('R', '[0.5]'): '1e-13',
+    ('VonMises', '[11]'): '1e-13',
 }
 # Per-(name, json-params) quantile round-trip tolerance (default 1e-14; per-group empirical:
 # closed-form/Halley quantiles stay at 1e-14, root-finding/approximate ones are looser).
@@ -1899,6 +1910,7 @@ Q_TOL = {
     ('UniformProduct', '[4]'): '5e-13',
     ('UniformProduct', '[6]'): '1e-11',
     ('LogGamma', '[0.5, 0.5, 1]'): '2e-14',
+    ('VonMises', '[11]'): '1e-11',
 }
 # Per-(name, json-params) one-line justification comment emitted above a loosened group.
 _N_SERIES = 'series/transform accumulates a few ULPs beyond 1e-14'
@@ -1958,6 +1970,7 @@ NOTES = {
     ('UniformProduct', '[2]'): 'q() has no closed form (numerical root-finding); round-trip measured at 1.1e-14 on Node 20 (V8/libm rounding differs across Node versions) — gate at 1e-13 (#759)',
     ('UniformProduct', '[4]'): 'q() has no closed form (numerical root-finding); round-trip measured at 1.4e-13 in JIT-order-dependent full-suite runs — gate at 5e-13 (#759)',
     ('UniformProduct', '[6]'): _N_ROOT,
+    ('VonMises', '[11]'): 'series/transform accumulates a few ULPs beyond 1e-14; q() has no closed form (numerical root-finding), which loosens the round-trip further',
 }
 
 
@@ -1981,6 +1994,9 @@ def compute_cache(only=None):
                 for g in json.load(fh):
                     prev_by_name.setdefault(g['name'], []).append(g)
         else:
+            # --only scopes cache REUSE, not computation -- with no prior cache this recomputes
+            # every distribution, including the ~65-minute DoublyNoncentralBeta[1200,1200] set.
+            # See solutions/tooling/2026-07-26-2200-precision-refs-only-flag-cache-scope-not-compute-scope.md
             print(f'  --only given but no cache at {CACHE} yet; computing everything', flush=True)
 
     cache = []

--- a/solutions/tooling/2026-07-26-2200-precision-refs-only-flag-cache-scope-not-compute-scope.md
+++ b/solutions/tooling/2026-07-26-2200-precision-refs-only-flag-cache-scope-not-compute-scope.md
@@ -1,0 +1,40 @@
+---
+date: 2026-07-26T22:00:00Z
+category: "tooling"
+problem: "scripts/precision-refs-continuous.py's --only <name> flag looks like it scopes computation to one distribution, but with no pre-existing cache it silently recomputes all 121 continuous distributions instead"
+status: complete
+related_issue: "1143"
+related_plan: "thoughts/plans/2026-07-26-2100-vonmises-precision-boundary-grid.md"
+tags: [precision-refs, mpmath, tooling, cache, cost-avoidance, generator-script]
+---
+
+# Solution: `--only` in `precision-refs-continuous.py` scopes cache reuse, not computation
+
+**Date**: 2026-07-26
+**Category**: tooling
+**Related Issue**: #1143
+
+## Problem
+
+Adding a single new precision-gate parameter set (`VonMises` `kappa=11`) to `test/precision-continuous.js` normally means regenerating that file from `scripts/precision-refs-continuous.py` via the documented command `python3 scripts/precision-refs-continuous.py --emit --only VonMises`. In a fresh environment — no pre-existing `/tmp/precision-continuous-cache.json`, `mpmath` not yet installed — that command does not do what its name implies: `--only` does not scope *computation* to the named distribution, it scopes *cache reuse*. With no cache present it silently falls back to recomputing all 121 continuous distributions from mpmath at `mp.dps=50`, including the `DoublyNoncentralBeta[1200,1200]` set independently documented (issues #1149/#1194) as costing ~65 minutes by itself — a wildly disproportionate cost for adding one distribution's one parameter set.
+
+## Root Cause
+
+`compute_cache(only=None)` (`scripts/precision-refs-continuous.py`) reuses cached groups for every distribution *not* named in `--only`, computing fresh values for everything else. That's correct when a cache from a prior full run already exists, but the script itself detects and warns about the degenerate case — `--only given but no cache at {CACHE} yet; computing everything` — meaning the cost-avoidance only works if someone already paid the full computation cost once before. A contributor who reads the flag's name (and the file's header comment) rather than its runtime warning would reasonably expect `--only VonMises` to be cheap regardless of environment state. It is not, in a cache-less sandbox, CI runner, or fresh clone — exactly the state of this session's environment.
+
+## Fix
+
+Rather than running the full generator pipeline, the new reference values were computed with a small, uncommitted script that imports `scripts/precision-refs-continuous.py` as a Python module (`importlib.util`, safe because the script's top-level execution is guarded by `if __name__ == '__main__':`) and calls its existing `pdf('VonMises', [11], x)` / `cdf('VonMises', [11], x)` functions directly for just the 5 chosen x-values, rounding with the same `num(...)` float64 conversion `compute_cache` uses, then hand-splicing the resulting group into `test/precision-continuous.js` to match `render()`'s exact emitted format. This reuses the identical formula code the full pipeline would use, without paying for the other 120 distributions. This is not a new pattern — it follows an existing precedent already documented in the same file: the `DoublyNoncentralBeta[1200,1200]` "large-lambda anchor" comment records that entry was generated the same way, for the same reason.
+
+## Prevention Strategy
+
+Before running `--emit --only <name>` (or `--only <name>` for `--render`) in `scripts/precision-refs-continuous.py`, check whether `/tmp/precision-continuous-cache.json` already exists. If it does not (fresh clone, fresh CI sandbox, or `mpmath` freshly installed with no prior run), do not run the flag expecting it to be cheap — either accept the full-suite recomputation cost deliberately, or use the "import as module, call `pdf()`/`cdf()` directly for just the new group" pattern this session and the `DoublyNoncentralBeta` precedent both used. This is worth surfacing explicitly rather than relying on every future contributor rediscovering the runtime warning message on their own.
+
+## Related Solutions
+
+- `solutions/testing/2026-07-24-1141-precision-refs-self-check-never-ran.md` — a different tooling gotcha in the same generator script (a dormant self-check that silently never ran); both cases show this script's safety/cost-control mechanisms can look complete while having a gap nobody had walked into yet.
+- `solutions/correctness/2026-07-26-1339-vonmises-cdf-oscillating-term-premature-convergence.md` — the bug that caused the VonMises boundary set to be withheld in the first place; this solution documents the tooling side of finally adding that withheld set back.
+
+## Key Insight
+
+In `scripts/precision-refs-continuous.py`, `--only <name>` scopes *cache reuse*, not *computation* — with no pre-existing cache it silently recomputes all 121 distributions (including a ~65-minute `DoublyNoncentralBeta[1200,1200]` set) instead of just the named one, so in a cache-less environment the safe way to add or update a single distribution's reference values is to import the script as a module and call its `pdf()`/`cdf()` functions directly for just the new group, as already precedented by the `DoublyNoncentralBeta[1200,1200]` comment in the same file.

--- a/test/precision-continuous.js
+++ b/test/precision-continuous.js
@@ -4530,6 +4530,20 @@ const REFS = [
       { x: 2.5, pdf: 0.05641980438908635, cdf: 0.9682095163056197 }
     ]
   },
+  // VonMises[11]: series/transform accumulates a few ULPs beyond 1e-14; q() has no closed form (numerical root-finding), which loosens the round-trip further
+  {
+    name: 'VonMises',
+    params: [11],
+    tol: 1e-13,
+    qtol: 1e-11,
+    points: [
+      { x: -1.0, pdf: 0.008324075654520296, cdf: 0.0008536976551769042 },
+      { x: -0.7853981633974483, pdf: 0.05214358825274366, cdf: 0.006110362138173876 },
+      { x: 0.15, pdf: 1.15552317984488, cdf: 0.6883262995038191 },
+      { x: 0.7853981633974483, pdf: 0.05214358825274366, cdf: 0.9938896378618262 },
+      { x: 1.5707963267948966, pdf: 2.1836478819052325e-05, cdf: 0.999997996827892 }
+    ]
+  },
   {
     name: 'Weibull',
     params: [2, 2],


### PR DESCRIPTION
## Summary

Adds the previously-withheld `VonMises(kappa=11)` boundary-grid parameter set to the precision-gate test suite, closing the one remaining slice of #1143 not already handled by prior merged work or claimed by an open sibling issue.

Part of #1143 (not closing it — see rationale below)

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 8319 passing)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior (new `VonMises[11]` precision-gate group)
- [x] `CHANGELOG.md` updated under `## [Unreleased]` — **skipped**: test-only change, no user-visible behavior
- [x] Production-code diff is under ~400 lines (tests excluded) — **0 lines**, no `src/` files touched

## Why "Part of #1143" instead of "Closes #1143"

#1143 is a broad tracking issue ("expand precision tests across all distribution families") that was already decomposed, before this PR, into six open sibling issues (#1178, #1186–#1190) plus several already-merged slices (Rice/NoncentralChi/NoncentralChi2 marcumQ+besselI boundary sets, Tweedie's dynamic series cap, besselISpherical, Poisson's gammaLowerIncomplete). This PR closes the one remaining slice research found neither done nor claimed: `scripts/precision-refs-continuous.py` carried an explicit comment saying VonMises's boundary set was deliberately withheld ("out of scope for #1185") because probing that parameter regime had surfaced a real `_cdf` bug — since fixed. #1143 itself should stay open until the sibling issues also land.

## Non-trivial changes

_No non-trivial changes — no `src/` production code was touched. This PR is test-fixture/precision-gate data only._

<details>
<summary>Trivial changes</summary>

- **`scripts/precision-refs-continuous.py`**: added `[11]` to `PARAM_SETS['VonMises']`; added a `(11,)` entry to `VONMISES_XVALS` with 5 x-values (3 are exact `k·π/4` phase points regression-testing a previously-fixed oscillating-term convergence bug); added matching `PDFCDF_TOL`/`Q_TOL`/`NOTES` overrides; updated the now-stale deferral comment; added a WHY-comment pointer to a new solution doc at the `--only`-without-cache fallback warning.
- **`test/precision-continuous.js`**: added one new `VonMises` `REFS` group (`params: [11]`, `tol: 1e-13`, `qtol: 1e-11`, 5 points), generated from mpmath at `mp.dps=50` via a standalone script that imports the generator's own `pdf()`/`cdf()` functions directly (no pre-existing cache existed in this environment, and the standard `--emit --only` flow would have silently recomputed all 121 continuous distributions — see the new solution doc).
- **`solutions/tooling/2026-07-26-2200-precision-refs-only-flag-cache-scope-not-compute-scope.md`**: new solution doc documenting that `--only <name>` scopes cache reuse, not computation, and the workaround used here.

</details>

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

## Code health

`test/precision-continuous.js` scores 9.68/10.0 (Green Code) both before and after this diff — the one flagged smell ("Lines of Declarations in a Single File", 4555 lines) is inherent to the file's generated-data-array shape (it was already 4655 lines before this PR added 14) and out of scope for a structural rewrite of a generator-owned fixture file.

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZofHpkVSBr4df21bzjURL)_