### PR TITLE
Add erfc/incomplete-beta boundary-crossover precision tests

### DIFF
--- a/scripts/precision-refs-continuous.py
+++ b/scripts/precision-refs-continuous.py
@@ -1457,7 +1457,10 @@ PARAM_SETS = {
     'Bates': [[10, 5, 25], [3, 0, 1], [5, -2, 2]],
     'Benini': [[2, 2, 2], [0.5, 0.5, 1], [1, 3, 2]],
     'BenktanderII': [[2, 0.9995], [2, 1], [2, 0.5]],
-    'Beta': [[2, 2], [0.5, 0.5], [3, 5]],
+    # [4, 3]: x straddles regularizedBetaIncomplete's direct/complementary continued-fraction
+    # dispatch at x=(a+1)/(a+b+2)=5/9 (src/special/beta-incomplete.js) -- unprobed before
+    # this (issue #1178).
+    'Beta': [[2, 2], [0.5, 0.5], [3, 5], [4, 3]],
     'BetaPrime': [[2, 2], [0.5, 4], [3, 3]],
     'BetaRectangular': [[2, 2, 0.5, 5, 25], [0.5, 0.5, 0.9, 5, 25], [3, 2, 0.3, 0, 10]],
     'BirnbaumSaunders': [[0, 2, 2], [0, 0.5, 0.5], [1, 1, 1]],
@@ -1481,7 +1484,10 @@ PARAM_SETS = {
     'ExponentialLogarithmic': [[0.5, 2], [0.9, 0.5], [0.3, 1]],
     'ExponentiallyModifiedGaussian': [[0, 1, 1], [1, 0.3, 5], [-1, 2, 0.2]],
     'ExponentiatedWeibull': [[2, 2, 2], [0.5, 0.5, 0.5], [1, 2, 3]],
-    'F': [[5, 5], [2, 20], [10, 4]],
+    # [6, 8]: x straddles regularizedBetaIncomplete's direct/complementary continued-fraction
+    # dispatch, here at internal beta-argument z=d1*x/(d1*x+d2)=(a+1)/(a+b+2)=4/9 -- unprobed
+    # before this (issue #1178).
+    'F': [[5, 5], [2, 20], [10, 4], [6, 8]],
     'FisherZ': [[5, 5], [1, 1], [8, 4]],
     'Frechet': [[2, 2, 0], [0.5, 1, 0], [3, 2, 1]],
     'Gamma': [[2, 2], [0.5, 0.5], [3, 1]],
@@ -1507,7 +1513,9 @@ PARAM_SETS = {
     ],
     'InverseChi2': [[6], [2], [4]],
     'InverseGamma': [[2, 2], [0.5, 0.5], [3, 1]],
-    'InverseGaussian': [[2, 2], [1, 0.5], [3, 1]],
+    # [2, 3]: x straddles _cdf's erfc(-a) series/continued-fraction dispatch at -a=1
+    # (src/special/error.js's erfc: x<=1 series, x>1 CF) -- unprobed before this (issue #1178).
+    'InverseGaussian': [[2, 2], [1, 0.5], [3, 1], [2, 3]],
     'InvertedWeibull': [[2], [0.5], [3]],
     'IrwinHall': [[10], [3], [5]],
     'JohnsonSU': [[0, 2, 2, 0], [1, 0.5, 0.5, 1], [-1, 1.5, 2, 0]],
@@ -1515,7 +1523,10 @@ PARAM_SETS = {
     'Kolmogorov': [[]],
     'Kumaraswamy': [[2, 2], [0.5, 0.5], [3, 1]],
     'Laplace': [[0, 2], [3, 0.5], [-1, 1]],
-    'Levy': [[0, 2], [1, 0.5], [-1, 1]],
+    # [2, 3]: x straddles _cdf's erfc series/continued-fraction dispatch at z=1
+    # (src/special/error.js) -- Normal/LogNormal's far-tail crossover coverage (issue #808)
+    # never probed this close to z=1 for Levy; unprobed before this (issue #1178).
+    'Levy': [[0, 2], [1, 0.5], [-1, 1], [2, 3]],
     'Lindley': [[2], [0.5], [1]],
     'LogCauchy': [[0, 2], [1, 0.5], [-1, 1]],
     'LogGamma': [[2, 2, 2], [0.5, 0.5, 1], [3, 1, 0]],
@@ -1533,7 +1544,10 @@ PARAM_SETS = {
     'Moyal': [[0, 2], [3, 0.5], [-1, 1]],
     'Muth': [[0.5], [0.1], [1]],
     'Nakagami': [[2.5, 2], [0.5, 0.5], [1, 3]],
-    'NoncentralBeta': [[2, 2, 2], [0.5, 5, 10], [0.1, 2, 10]],
+    # [2, 3, 4]: x straddles _cdf's regularizedBetaIncomplete(iAlpha0, beta, x) direct/
+    # complementary continued-fraction dispatch at x=(iAlpha0+1)/(iAlpha0+beta+2)=5/9, where
+    # iAlpha0=alpha+round(lambda/2)=4 -- unprobed before this (issue #1178).
+    'NoncentralBeta': [[2, 2, 2], [0.5, 5, 10], [0.1, 2, 10], [2, 3, 4]],
     # [5, 0.5]: besselISpherical(1, lambda*x) argument spans ~0.65-1.56, straddling the
     # |x|=1 Taylor/closed-form dispatch (order = floor((k-3)/2) = 1 at the lowest odd k>=5).
     # [2, 3.5]: besselI(0, lambda*x) argument spans into (10, 14], straddling
@@ -1546,7 +1560,11 @@ PARAM_SETS = {
     # _besselIBackward's n=0 warm-up margin gap (issue #1185; previously withheld here
     # during #1143's boundary-grid work, see the comment above PARAM_SETS).
     'NoncentralChi2': [[11, 2], [5, 3], [2, 1], [5, 58], [5, 62], [5, 0.5], [2, 8]],
-    'NoncentralF': [[5, 5, 2], [2, 10, 0.5], [4, 6, 3]],
+    # [6, 8, 4]: x straddles the underlying NoncentralBeta._cdf's regularizedBetaIncomplete
+    # direct/complementary dispatch, here at internal beta-argument
+    # z=d1*x/(d1*x+d2)=(iAlpha0+1)/(iAlpha0+beta+2)=6/11, where iAlpha0=alpha+round(lambda/2)=5
+    # -- unprobed before this (issue #1178).
+    'NoncentralF': [[5, 5, 2], [2, 10, 0.5], [4, 6, 3], [6, 8, 4]],
     'NoncentralT': [[5, 1], [5, 0], [8, 2]],
     'Normal': [[0, 2], [3, 0.5], [-1, 1]],
     'Pareto': [[2, 2], [1, 0.5], [3, 1]],
@@ -1622,6 +1640,47 @@ DNCF_XVALS = {
     (4, 6, 2, 1): [mpf('0.5'), mpf('1'), mpf('1.5'), mpf('2.5'), mpf('4')],
 }
 
+# erfc-family and incomplete-beta-family boundary-crossover probes (issue #1178, continuation
+# of #1143). P_GRID's probability-driven inversion cannot pin the internal special-function
+# argument to a specific value, so these fixed x-values were solved (in plain float64, then
+# evaluated here at mp.dps=50) to place the internal argument at 1%/0.1%/exactly the crossover
+# on each side, mirroring #1143's marcumQ boundary-grid intent but for erfc (x<=1 series/CF,
+# src/special/error.js) and regularizedBetaIncomplete (x<(a+1)/(a+b+2) direct/complementary CF,
+# src/special/beta-incomplete.js).
+LEVY_XVALS = {
+    # z = sqrt(0.5*c/(x-mu)) crosses erfc's x<=1 dispatch at z=1 <=> x=mu+0.5*c=3.5.
+    (2, 3): [mpf('3.5304560759106214'), mpf('3.503004506007509'), mpf('3.5'),
+             mpf('3.4970044940074914'), mpf('3.4704440741103815')],
+}
+INVERSE_GAUSSIAN_XVALS = {
+    # erfc(-a) crosses its x<=1 dispatch at -a=1 <=> a=-1, where
+    # a = (sqrt(lambda*x)/mu - sqrt(lambda/x)) / sqrt(2).
+    (2, 3): [mpf('0.6600414797517227'), mpf('0.6660004164792253'), mpf('0.6666666666666665'),
+             mpf('0.6673337501875585'), mpf('0.6733751880868137')],
+}
+BETA_XVALS = {
+    # x crosses regularizedBetaIncomplete's dispatch directly at x=(alpha+1)/(alpha+beta+2)=5/9.
+    (4, 3): [mpf('0.55'), mpf('0.555'), mpf('0.5555555555555556'),
+             mpf('0.5561111111111111'), mpf('0.5611111111111111')],
+}
+F_XVALS = {
+    # internal beta-argument z=d1*x/(d1*x+d2) crosses the dispatch at z=(alpha+1)/(alpha+beta+2)=4/9.
+    (6, 8): [mpf('1.0476190476190474'), mpf('1.0647482014388487'), mpf('1.0666666666666667'),
+             mpf('1.0685882038964503'), mpf('1.086021505376344')],
+}
+NONCENTRAL_BETA_XVALS = {
+    # x crosses regularizedBetaIncomplete(iAlpha0, beta, x)'s dispatch directly at
+    # x=(iAlpha0+1)/(iAlpha0+beta+2)=5/9, where iAlpha0=alpha+round(lambda/2)=4.
+    (2, 3, 4): [mpf('0.55'), mpf('0.555'), mpf('0.5555555555555556'),
+                mpf('0.5561111111111111'), mpf('0.5611111111111111')],
+}
+NONCENTRAL_F_XVALS = {
+    # internal beta-argument z=d1*x/(d1*x+d2) crosses the underlying NoncentralBeta dispatch at
+    # z=(iAlpha0+1)/(iAlpha0+beta+2)=6/11, where iAlpha0=alpha+round(lambda/2)=5.
+    (6, 8, 4): [mpf('1.5652173913043472'), mpf('1.596484218937275'), mpf('1.5999999999999996'),
+                mpf('1.6035242290748895'), mpf('1.6356275303643726')],
+}
+
 # Quadrature-based CDFs (Davis, noncentral-t, SkewNormal, VonMises): inverting by bisection
 # would re-run the integral 70x per point, so we probe at fixed interior values instead.
 NCT_XVALS = {
@@ -1648,6 +1707,12 @@ MANUAL_XVALS = {
     'NoncentralT': NCT_XVALS,
     'SkewNormal': SKEWNORMAL_XVALS,
     'VonMises': VONMISES_XVALS,
+    'Levy': LEVY_XVALS,
+    'InverseGaussian': INVERSE_GAUSSIAN_XVALS,
+    'Beta': BETA_XVALS,
+    'F': F_XVALS,
+    'NoncentralBeta': NONCENTRAL_BETA_XVALS,
+    'NoncentralF': NONCENTRAL_F_XVALS,
 }
 
 # Far-tail x-values for Normal and LogNormal (issue #808): x = mu - k*sigma at k=5,7.
@@ -1801,7 +1866,10 @@ def invcdf(name, p, pv):
 
 
 def xvalues(name, p):
-    if name in MANUAL_XVALS:
+    # Some distributions only have manual overrides for the boundary-crossover set added
+    # in #1178, alongside other param sets that still use the standard P_GRID inversion below
+    # -- fall through instead of unconditionally indexing when the specific tuple isn't listed.
+    if name in MANUAL_XVALS and tuple(p) in MANUAL_XVALS[name]:
         return MANUAL_XVALS[name][tuple(p)]
     if name == 'TukeyLambda':
         # exact closed-form quantile avoids root-finding inside bisection at the support edge

--- a/test/precision-continuous.js
+++ b/test/precision-continuous.js
@@ -382,6 +382,21 @@ const REFS = [
       { x: 0.596179727848044, pdf: 0.9924215278592065, cdf: 0.9 }
     ]
   },
+  // Beta[4, 3]: x straddles regularizedBetaIncomplete's direct/complementary continued-fraction
+  // dispatch at x=(alpha+1)/(alpha+beta+2)=5/9 (issue #1178)
+  {
+    name: 'Beta',
+    params: [4, 3],
+    tol: 1e-14,
+    qtol: 1e-14,
+    points: [
+      { x: 0.55, pdf: 2.02145625, cdf: 0.4415176562500001 },
+      { x: 0.555, pdf: 2.0311884658125, cdf: 0.45164966682515634 },
+      { x: 0.5555555555555556, pdf: 2.0322105370116343, cdf: 0.4527783893226154 },
+      { x: 0.5561111111111111, pdf: 2.033220668982755, cdf: 0.45390767632197815 },
+      { x: 0.5611111111111111, pdf: 2.0417709892419853, cdf: 0.46409556245689787 }
+    ]
+  },
   {
     name: 'BetaPrime',
     params: [2, 2],
@@ -1356,6 +1371,21 @@ const REFS = [
       { x: 3.919875603731213, pdf: 0.04036748484151186, cdf: 0.9 }
     ]
   },
+  // F[6, 8]: internal beta-argument z=d1*x/(d1*x+d2) straddles regularizedBetaIncomplete's
+  // direct/complementary continued-fraction dispatch at z=(alpha+1)/(alpha+beta+2)=4/9 (issue #1178)
+  {
+    name: 'F',
+    params: [6, 8],
+    tol: 1e-14,
+    qtol: 1e-14,
+    points: [
+      { x: 1.0476190476190474, pdf: 0.47979752325120006, cdf: 0.5381720678399999 },
+      { x: 1.0647482014388487, pdf: 0.4713596600178616, cdf: 0.5463182259195494 },
+      { x: 1.0666666666666667, pdf: 0.4704191057897302, cdf: 0.5472216106773847 },
+      { x: 1.0685882038964503, pdf: 0.46947798705698607, cdf: 0.5481246341537657 },
+      { x: 1.086021505376344, pdf: 0.4609842211770551, cdf: 0.5562350295181603 }
+    ]
+  },
   // FisherZ[5, 5]: q() has no closed form (numerical root-finding), so the round-trip is accurate to a few ULPs beyond 1e-14
   {
     name: 'FisherZ',
@@ -2139,6 +2169,21 @@ const REFS = [
       { x: 7.265187538585993, pdf: 0.017726594661409047, cdf: 0.9 }
     ]
   },
+  // InverseGaussian[2, 3]: x straddles _cdf's erfc(-a) series/continued-fraction dispatch at
+  // -a=1 (issue #1178)
+  {
+    name: 'InverseGaussian',
+    params: [2, 3],
+    tol: 1e-14,
+    qtol: 1e-14,
+    points: [
+      { x: 0.6600414797517227, pdf: 0.4646115995885947, cdf: 0.12254090504329164 },
+      { x: 0.6660004164792253, pdf: 0.46676194070821664, cdf: 0.12531595461348216 },
+      { x: 0.6666666666666665, pdf: 0.466995934598169, cdf: 0.1256270128644982 },
+      { x: 0.6673337501875585, pdf: 0.46722893612230915, cdf: 0.1259386159439316 },
+      { x: 0.6733751880868137, pdf: 0.46928103845924357, cdf: 0.1287676018137991 }
+    ]
+  },
   {
     name: 'InvertedWeibull',
     params: [2],
@@ -2427,6 +2472,21 @@ const REFS = [
       { x: 1.5355512546538017, pdf: 0.08112606983314283, cdf: 0.53 },
       { x: 6.782542897236661, pdf: 0.01723161347571413, cdf: 0.72 },
       { x: 62.32811767701674, pdf: 0.0007853916387698619, cdf: 0.9 }
+    ]
+  },
+  // Levy[2, 3]: x straddles _cdf's erfc series/continued-fraction dispatch at
+  // z=sqrt(0.5*c/(x-mu))=1 (issue #1178)
+  {
+    name: 'Levy',
+    params: [2, 3],
+    tol: 1e-14,
+    qtol: 1e-14,
+    points: [
+      { x: 3.5304560759106214, pdf: 0.13695798779782292, cdf: 0.1614919304446302 },
+      { x: 3.503004506007509, pdf: 0.13823052008751838, cdf: 0.15771472979350307 },
+      { x: 3.5, pdf: 0.1383691658068649, cdf: 0.15729920705028513 },
+      { x: 3.4970044940074914, pdf: 0.1385072580501478, cdf: 0.15688451452192373 },
+      { x: 3.4704440741103815, pdf: 0.13972500214520003, cdf: 0.15318950377172333 }
     ]
   },
   {
@@ -3168,6 +3228,22 @@ const REFS = [
       { x: 0.912096673134829, pdf: 1.9038127634365016, cdf: 0.9 }
     ]
   },
+  // NoncentralBeta[2, 3, 4]: x straddles regularizedBetaIncomplete(iAlpha0, beta, x)'s direct/
+  // complementary continued-fraction dispatch at x=(iAlpha0+1)/(iAlpha0+beta+2)=5/9, where
+  // iAlpha0=alpha+round(lambda/2)=4 (issue #1178)
+  {
+    name: 'NoncentralBeta',
+    params: [2, 3, 4],
+    tol: 1e-14,
+    qtol: 1e-14,
+    points: [
+      { x: 0.55, pdf: 1.7988380086325535, cdf: 0.4665231967893618 },
+      { x: 0.555, pdf: 1.8078525222376394, cdf: 0.4755401763558644 },
+      { x: 0.5555555555555556, pdf: 1.8088164107690712, cdf: 0.4765448069676411 },
+      { x: 0.5561111111111111, pdf: 1.8097726716830562, cdf: 0.4775499709553081 },
+      { x: 0.5611111111111111, pdf: 1.818032059759644, cdf: 0.48661974439675726 }
+    ]
+  },
   // NoncentralChi[5, 2]: series/transform accumulates a few ULPs beyond 1e-14
   {
     name: 'NoncentralChi',
@@ -3381,6 +3457,22 @@ const REFS = [
       { x: 1.8283547451496789, pdf: 0.23963434190768756, cdf: 0.53 },
       { x: 2.889723635149361, pdf: 0.12939440016942425, cdf: 0.72 },
       { x: 5.465891080861805, pdf: 0.0344547085561269, cdf: 0.9 }
+    ]
+  },
+  // NoncentralF[6, 8, 4]: internal beta-argument z=d1*x/(d1*x+d2) straddles the underlying
+  // NoncentralBeta dispatch at z=(iAlpha0+1)/(iAlpha0+beta+2)=6/11, where
+  // iAlpha0=alpha+round(lambda/2)=5 (issue #1178)
+  {
+    name: 'NoncentralF',
+    params: [6, 8, 4],
+    tol: 1e-14,
+    qtol: 1e-14,
+    points: [
+      { x: 1.5652173913043472, pdf: 0.33506779419030264, cdf: 0.4714445902137505 },
+      { x: 1.596484218937275, pdf: 0.32930643378405494, cdf: 0.48183110641636145 },
+      { x: 1.5999999999999996, pdf: 0.32865688620541067, cdf: 0.4829877339899027 },
+      { x: 1.6035242290748895, pdf: 0.32800550202064943, cdf: 0.48414484840865185 },
+      { x: 1.6356275303643726, pdf: 0.32206234246460486, cdf: 0.49457954853049313 }
     ]
   },
   // NoncentralT[5, 1]: pdf/cdf are noncentral-t (Poisson) mixtures; accumulated rounding caps accuracy near 1e-13


### PR DESCRIPTION
Closes #1178

## Summary
- Adds boundary-adjacent precision-test parameter sets for the two special-function families #1178 identified as uncovered by #1143's first PR: the `erfc` series/continued-fraction crossover (`src/special/error.js`, `x<=1` dispatch) for **Levy** and **InverseGaussian**, and the `regularizedBetaIncomplete` direct/complementary continued-fraction crossover (`src/special/beta-incomplete.js`, `x<(a+1)/(a+b+2)` dispatch) for **Beta**, **F**, **NoncentralBeta**, and **NoncentralF**.
- For each of the six distributions, one new parameter set is added to `PARAM_SETS` in `scripts/precision-refs-continuous.py`, with 5 explicit x-values (via new `LEVY_XVALS`/`INVERSE_GAUSSIAN_XVALS`/`BETA_XVALS`/`F_XVALS`/`NONCENTRAL_BETA_XVALS`/`NONCENTRAL_F_XVALS` dicts, registered in `MANUAL_XVALS`) chosen to straddle the relevant threshold at ~0.1%/1% offsets on each side, since the standard `P_GRID` probability-based inversion can't pin the internal special-function argument to a specific value. All reference `pdf`/`cdf` values in `test/precision-continuous.js` are computed at `mp.dps=50` and independently cross-checked against the live `ranjs` implementation (all six groups pass at the file's default `tol: 1e-14, qtol: 1e-14`, verified via a full `npm test` run, not an isolated one).
- `DoublyNoncentralBeta`/`DoublyNoncentralF` boundary work is explicitly **deferred**, per #1178's own sequencing note pending #1149 (the `DoublyNoncentralBeta[2,2,1200,1200]` stall/non-termination question).

This is a test-only change — no `src/` files are touched, so per CLAUDE.md's changelog rule no `CHANGELOG.md` entry was added.

## Non-trivial changes
- **`scripts/precision-refs-continuous.py`**: `xvalues()`'s `MANUAL_XVALS` lookup was loosened from an unconditional `MANUAL_XVALS[name][tuple(p)]` index to `if name in MANUAL_XVALS and tuple(p) in MANUAL_XVALS[name]`, so a distribution can now mix standard `P_GRID`-driven parameter sets with a manually-pinned boundary-crossover set in the same `PARAM_SETS` entry (needed because these six distributions each already had 3 P_GRID-driven sets before this PR). `/review`'s impact pass flagged that this silently drops a fail-fast `KeyError` for distributions with full manual coverage if a future param set is added without a matching manual-x-values entry — filed as **#1200** (trivial, documentation-only) rather than fixed inline, since today's coverage is unaffected (verified: all pre-existing fully-manual dicts still cover every tuple in their `PARAM_SETS` entries).
- **`scripts/precision-refs-continuous.py` / `test/precision-continuous.js`**: each new parameter set's boundary math was independently derived per distribution (e.g. `NoncentralBeta`'s and `NoncentralF`'s underlying dispatch threshold uses `iAlpha0 = alpha + round(lambda/2)`, not the raw `alpha`, since `_cdf` calls `regularizedBetaIncomplete(iAlpha0, beta, x)`) — see the inline comments above each `PARAM_SETS` entry and `*_XVALS` dict for the exact formula and source-file citation.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/precision-continuous.js`**: 6 new generated `REFS` groups (`Beta[4,3]`, `F[6,8]`, `InverseGaussian[2,3]`, `Levy[2,3]`, `NoncentralBeta[2,3,4]`, `NoncentralF[6,8,4]`), each with 5 mpmath-derived `{ x, pdf, cdf }` points at `mp.dps=50`.

</details>

**Note**: `npm run standard`, `npm run jsdoclint`, `npm test` (8337 passing, coverage thresholds met), and `npm run build && npm run typecheck` all pass locally. The CodeScene MCP server (used for the per-file code-health check) was not connected in this session, so that automated check could not be run — the only changed `.js` file (`test/precision-continuous.js`) is a generated data file with no logic beyond literal object arrays, matching every other entry already in the file.

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01QY1z4fmcGsFsuyJWjioU1d)_