### PR TITLE
Stale VonMises(11) besselI-precision comment fixed

### DIFF
--- a/test/dist-cases-continuous.js
+++ b/test/dist-cases-continuous.js
@@ -5995,15 +5995,21 @@ export default [{
       { x: -0.9, pdf: 0.03914013027583153, cdf: 0.005128950622327126 }
     ]
   }, {
-    // No refVals here: besselI(0, 11) itself carries a pre-existing ~1e-10 relative error
-    // (unrelated to this fix -- a besselI accuracy limit at kappa gtrsim 11, out of scope for
-    // this bug) that would fail the harness's tight 1e-14 refValTol regardless of correctness.
-    // Coverage for kappa=11 (cdf in [0,1]/monotonic/roundtrip/symmetric, all of which the
-    // premature-truncation bug violated) comes from the generic checks below plus the explicit,
-    // appropriately-toleranced mpmath comparison in dist-base-special-cases.js.
+    // Regression for issue: premature Fourier-series truncation at x = k*pi/4 (same as kappa=9
+    // above). besselI(0, 11)'s former ~1e-10 relative error (the "cold start" gap in
+    // _besselIBackward's run-up margin for x in (10, 14]) was fixed by #1185, so refVals here now
+    // hold to the harness's tight 1e-14 refValTol like any other case.
     name: 'large kappa at x = k*pi/4 (premature series truncation regression)',
     params: () => [0, 11],
-    symmetry: 0
+    symmetry: 0,
+    // mpmath mp.dps=50: exp(kappa*cos(x))/(2*pi*besseli(0,kappa)), quad(pdf, -pi, x)  (kappa=11)
+    refVals: [
+      { x: -Math.PI / 2, pdf: 0.00002183647881905232, cdf: 0.000002003172107986403 },
+      { x: -Math.PI / 4, pdf: 0.05214358825274366, cdf: 0.006110362138173876 },
+      { x: -Math.PI / 8, pdf: 0.5659475976651105, cdf: 0.10055267458189562 },
+      { x: -1, pdf: 0.008324075654520296, cdf: 0.0008536976551769042 },
+      { x: -0.9, pdf: 0.02035926892537725, cdf: 0.0022064544592800056 }
+    ]
   }, {
     // mu != 0: f(x; mu, kappa) = f(x-mu; 0, kappa) is an exact translation identity, so shifting
     // the already scipy-sourced kappa=2 refVals/quantileVals below by mu=1.5 (x -> x+1.5, pdf/cdf


### PR DESCRIPTION
Closes #1198

## Summary
- The `VonMises(0, 11)` test case in `test/dist-cases-continuous.js` withheld `refVals` with a comment claiming `besselI(0, 11)` still carried a ~1e-10 relative error — a claim that predates issue #1185, which fixed exactly that `_besselIBackward` run-up-margin gap for `x` in `(10, 14]` (covering `kappa=11`).
- Verified empirically against mpmath at `mp.dps=50`: `besselI(0, 11)`'s relative error is now ~2.5e-16 (not ~1e-10), and `VonMises(0, 11).pdf(x)`/`.cdf(x)` match mpmath to within 1e-16–1e-20 absolute error at the five regression x-points — comfortably inside the harness's tight 1e-14 `refValTol` floor.
- Replaced the stale comment and added the previously-withheld `refVals` block, matching the sibling `kappa=9` case's format and mpmath-sourced comment convention exactly.

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical (test-data restoration, no production code touched)._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-cases-continuous.js`**: stale comment replaced, `refVals` (pdf/cdf at 5 x-points) added to the `VonMises(0, 11)` premature-truncation regression case.

</details>

**Code health note**: `test/dist-cases-continuous.js` scores 9.68 (unchanged by this PR) due to a pre-existing "Lines of Declarations in a Single File" smell (~5336 lines) — a whole-file structural issue from its role as a shared distribution test-case data file, not something this 13-line targeted edit introduces or can reasonably fix within this hotfix's scope.

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_0139B4bUUGiBEghN6sPvUoeD)_