### PR TITLE
Add hand-computed R-hat reference test for gelmanRubin

### DIFF
--- a/test/mc/gelman-rubin.js
+++ b/test/mc/gelman-rubin.js
@@ -70,6 +70,36 @@ describe('mc.gelmanRubin', () => {
     })
   })
 
+  describe('hand-computed reference', () => {
+    it('should match exact hand-computed R-hat values for a small deterministic two-chain dataset', () => {
+      // chain1 = [1, 2, 3], chain2 = [4, 5, 6] (1D, m = 2 chains).
+      //
+      // Prefix length n = 2 (chain1 = [1, 2], chain2 = [4, 5]):
+      // exact rational: means = [1.5, 4.5], grandMean = 3
+      // exact rational: within-chain variance (n-1 = 1 divisor) is (0.5^2 + 0.5^2) / 1 = 0.5
+      //   for each chain -> W = (0.5 + 0.5) / 2 = 0.5
+      // exact rational: B = n * sum((mean_k - grandMean)^2) / (m - 1)
+      //   = 2 * ((1.5 - 3)^2 + (4.5 - 3)^2) / 1 = 2 * 4.5 = 9
+      // exact rational: R-hat^2 = ((n-1)*W + B) / (n*W) = (0.5 + 9) / 1 = 9.5, so R-hat = sqrt(9.5)
+      // mpmath mp.dps=50: sqrt(mpf('9.5')) -> 3.0822070014844882251250961907271221126178120117223
+      //
+      // Full length n = 3 (chain1 = [1, 2, 3], chain2 = [4, 5, 6]):
+      // exact rational: means = [2, 5], grandMean = 3.5
+      // exact rational: within-chain variance (n-1 = 2 divisor) is ((1-2)^2+(2-2)^2+(3-2)^2) / 2 = 1
+      //   for each chain -> W = (1 + 1) / 2 = 1
+      // exact rational: B = n * sum((mean_k - grandMean)^2) / (m - 1)
+      //   = 3 * ((2 - 3.5)^2 + (5 - 3.5)^2) / 1 = 3 * 4.5 = 13.5
+      // exact rational: R-hat^2 = ((n-1)*W + B) / (n*W) = (2 + 13.5) / 3 = 31/6, so R-hat = sqrt(31/6)
+      // mpmath mp.dps=50: sqrt(mpf(31) / mpf(6)) -> 2.2730302828309759821264329253215987058500140741315
+      const chain1 = [[1], [2], [3]]
+      const chain2 = [[4], [5], [6]]
+      const result = gelmanRubin([chain1, chain2])
+      assert.strictEqual(result[0].length, 2)
+      assert.closeTo(result[0][0], 3.082207001484488, 1e-14)
+      assert.closeTo(result[0][1], 2.273030282830976, 1e-14)
+    })
+  })
+
   describe('seeded RWM chains', () => {
     const logDensity = x => -0.5 * x[0] ** 2
 


### PR DESCRIPTION
## Summary

Adds an exact, hand-computed R-hat reference test for `gelmanRubin` on a small, fixed, deterministic two-chain dataset (`chain1 = [1, 2, 3]`, `chain2 = [4, 5, 6]`), mirroring the existing hand-worked `ac()`/`ess()` tests in `test/mc/mcmc.js`. The rational intermediate quantities (means, within-chain variance, between-chain variance) are documented as `// exact rational:` in the test comment; the final irrational R-hat values are sourced from `mpmath mp.dps=50` per the repo's reference-value convention. Test-only change — no production code touched.

Closes #1224

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (skip for pure refactors/docs/tests) — skipped, test-only change
- [x] Production-code diff is under ~400 lines (tests excluded) — 0 lines of production code changed

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJCCah7QecuEpj4w9d5LFc)_