### PR TITLE
Update stale VonMises(11) besselI-precision comment

### DIFF
--- a/test/dist-base-special-cases.js
+++ b/test/dist-base-special-cases.js
@@ -389,16 +389,16 @@ describe('dist', () => {
       assert.approximately(d.cdf(-0.9), 0.005128950622327126, 1e-12)
     })
 
-    // Same mpmath source as above (kappa = 11). Tolerance is 1e-8, not machine precision: besselI's
-    // own approximation carries a pre-existing ~1e-10 relative error at kappa gtrsim 11 (unrelated
-    // to this fix -- verified by comparing ranjs' besselI(0, 11) directly against mpmath), which
-    // this loose bound still comfortably distinguishes from the truncation bug's ~1e-1 to 1e-2-scale
-    // errors (e.g. cdf(-pi/4) was -0.0201 pre-fix, not merely imprecise).
-    it('cdf should match mpmath at kappa = 11 within the pre-existing besselI precision floor', () => {
+    // mpmath mp.dps=50: quad(t => exp(11*cos(t))/(2*pi*besseli(0,11)), [-pi, x])
+    // #1185 fixed _besselIBackward's n=0 margin degeneration for x in (10, 14], which covers
+    // kappa=11: besselI(0, 11) now matches mpmath to ~2.5e-16 relative error (re-verified
+    // directly against mpmath), not the ~1e-10 this test used to attribute to a "pre-existing"
+    // floor. Tolerance tightened to match the kappa = 9 case.
+    it('cdf should match mpmath at kappa = 11', () => {
       const d = new dist.VonMises(0, 11)
-      assert.approximately(d.cdf(-Math.PI / 4), 0.006110362138173876, 1e-8)
-      assert.approximately(d.cdf(-1), 0.0008536976551769042, 1e-8)
-      assert.approximately(d.cdf(-0.9), 0.002206454459280005, 1e-8)
+      assert.approximately(d.cdf(-Math.PI / 4), 0.006110362138173876, 1e-12)
+      assert.approximately(d.cdf(-1), 0.0008536976551769042, 1e-12)
+      assert.approximately(d.cdf(-0.9), 0.002206454459280005, 1e-12)
     })
 
     // Concrete repro from the bug report: q() root-finds on cdf(x) - p, so a corrupted cdf() at an


### PR DESCRIPTION
Closes #1196

## Summary
- Re-measured `besselI(0, 11)` against mpmath at `mp.dps=50`: relative error is now ~2.5e-16 (machine precision), confirming issue #1185's `_besselIBackward` fix (n=0 margin degeneration for x in (10, 14]) already covers `kappa=11`.
- Re-measured `VonMises(0, 11).cdf(...)` at the three tested points: absolute error is now ~6e-17 to 8e-17, the same order as the `kappa = 9` case.
- Tightened the `kappa = 11` cdf test's tolerance from `1e-8` to `1e-12` (matching the sibling `kappa = 9` test) and replaced the stale comment — which attributed the old loose tolerance to an "unrelated" pre-existing besselI error — with an explanation naming #1185 as the actual (now-fixed) cause, plus the explicit mpmath computation the repo's testing conventions require.

## Non-trivial changes
_No non-trivial changes — this PR is purely mechanical (test comment + tolerance value, no production code touched)._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/dist-base-special-cases.js`**: Tightened `VonMises(0, 11).cdf(...)` assertion tolerance from `1e-8` to `1e-12` and rewrote the accompanying comment to reflect the current, post-#1185 precision floor instead of the stale one.

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_0177tzojMbvgqLkUGbJaNPor)_