### PR TITLE
Add deterministic leapfrog single-step tests for HMC/NUTS

### DIFF
--- a/test/mc/hmc.js
+++ b/test/mc/hmc.js
@@ -235,6 +235,35 @@ describe('mc.HMC', () => {
     })
   })
 
+  describe('._leapfrog() deterministic single-step correctness', () => {
+    // Standard Normal target (U(x) = x^2/2, gradLnp(x) = -x) with a non-identity diagonal
+    // metric (variance = 4, so M^-1 = 4, not the identity): with an identity metric, a
+    // regression that dots raw momentum instead of the metric-scaled velocity would produce
+    // the same numbers, defeating the point of this test. See decisions/0034-nuts-euclidean-
+    // metric-adaptation.md, which names exactly that regression as a blind spot statistical
+    // KS-based sampler tests cannot catch on well-scaled targets.
+    const metricVariance4 = { internal: { metric: { type: 'diag', variance: [4] } } }
+
+    it('should match a hand-derived single leapfrog step (x0=1, r0=1, eps=0.1, variance=4)', () => {
+      const hmc = new HMC({ logDensity: logDensity1D, gradLogDensity: gradLogDensity1D, config: { dim: 1, pathLength: 1 }, initialState: metricVariance4 })
+      const { x, r } = hmc._leapfrog([1], [1], 0.1)
+      // exact rational: rHalf = 1 - 0.5*0.1*1 = 19/20; vMid = 4*19/20 = 19/5;
+      // x1 = 1 + 0.1*19/5 = 69/50 = 1.38; r1 = 19/20 - 0.5*0.1*(69/50) = 881/1000 = 0.881
+      assert.closeTo(x[0], 1.38, 1e-12)
+      assert.closeTo(r[0], 0.881, 1e-12)
+    })
+
+    it('should chain two leapfrog steps correctly (pathLength=2)', () => {
+      const hmc = new HMC({ logDensity: logDensity1D, gradLogDensity: gradLogDensity1D, config: { dim: 1, pathLength: 2 }, initialState: metricVariance4 })
+      const { x, r } = hmc._leapfrog([1], [1], 0.1)
+      // exact rational, continuing from the single-step case above (x1=1.38, r1=0.881):
+      // rHalf2 = 0.881 - 0.5*0.1*1.38 = 0.812; vMid2 = 4*0.812 = 3.248;
+      // x2 = 1.38 + 0.1*3.248 = 1.7048; r2 = 0.812 - 0.5*0.1*1.7048 = 0.72676
+      assert.closeTo(x[0], 1.7048, 1e-12)
+      assert.closeTo(r[0], 0.72676, 1e-12)
+    })
+  })
+
   describe('gradLogDensity array-reuse contract', () => {
     it('should pass the same array object to gradLogDensity on every leapfrog step of one .iterate() call, mutated in place', () => {
       // Pins #948's array-reuse optimization (issue #996) as observed through the public

--- a/test/mc/nuts.js
+++ b/test/mc/nuts.js
@@ -208,6 +208,40 @@ describe('mc.NUTS', () => {
     })
   })
 
+  describe('._leapfrog() deterministic single-step correctness', () => {
+    // Standard Normal target (U(x) = x^2/2, gradLnp(x) = -x) with a non-identity diagonal
+    // metric (variance = 4, so M^-1 = 4, not the identity): with an identity metric, a
+    // regression that dots raw momentum instead of the metric-scaled velocity would produce
+    // the same numbers, defeating the point of this test. See decisions/0034-nuts-euclidean-
+    // metric-adaptation.md, which names exactly that regression as a blind spot statistical
+    // KS-based sampler tests cannot catch on well-scaled targets.
+    const metricVariance4 = { internal: { metric: { type: 'diag', variance: [4] } } }
+
+    it('should match a hand-derived single leapfrog step and return the metric-scaled velocity', () => {
+      const nuts = new NUTS({ logDensity: logDensity1D, gradLogDensity: gradLogDensity1D, config: { dim: 1 }, initialState: metricVariance4 })
+      const { x, r, vel } = nuts._leapfrog([1], [1], 0.1)
+      // exact rational: rHalf = 1 - 0.5*0.1*1 = 19/20; vMid = 4*19/20 = 19/5;
+      // x1 = 1 + 0.1*19/5 = 69/50 = 1.38; r1 = 19/20 - 0.5*0.1*(69/50) = 881/1000 = 0.881;
+      // vel = 4*r1 = 3524/1000 = 3.524
+      assert.closeTo(x[0], 1.38, 1e-12)
+      assert.closeTo(r[0], 0.881, 1e-12)
+      assert.closeTo(vel[0], 3.524, 1e-12)
+    })
+
+    it('should chain two leapfrog steps correctly when fed its own output', () => {
+      const nuts = new NUTS({ logDensity: logDensity1D, gradLogDensity: gradLogDensity1D, config: { dim: 1 }, initialState: metricVariance4 })
+      const step1 = nuts._leapfrog([1], [1], 0.1)
+      const step2 = nuts._leapfrog(step1.x, step1.r, 0.1)
+      // exact rational, continuing from the single-step case above (x1=1.38, r1=0.881):
+      // rHalf2 = 0.881 - 0.5*0.1*1.38 = 0.812; vMid2 = 4*0.812 = 3.248;
+      // x2 = 1.38 + 0.1*3.248 = 1.7048; r2 = 0.812 - 0.5*0.1*1.7048 = 0.72676;
+      // vel2 = 4*r2 = 2.90704
+      assert.closeTo(step2.x[0], 1.7048, 1e-12)
+      assert.closeTo(step2.r[0], 0.72676, 1e-12)
+      assert.closeTo(step2.vel[0], 2.90704, 1e-12)
+    })
+  })
+
   describe('._iter() rejection', () => {
     it('should return accepted: false and leave position unchanged when the target is degenerate', () => {
       // logDensity = -Infinity everywhere: every leapfrog point fails the slice/divergence


### PR DESCRIPTION
Closes #1222

## Summary
- Added a hand-derived, deterministic single/two-step correctness test for the leapfrog integrator to `test/mc/hmc.js` and `test/mc/nuts.js`, independent of the existing `ksTest`-based statistical recovery tests.
- Uses a standard Normal target (`U(x) = x^2/2`, `gradLnp(x) = -x`) under a deliberately **non-identity** diagonal metric (`variance = [4]`), so the test actually exercises the metric-scaled-velocity multiplication in `applyInverseMetric` rather than being vacuously satisfied by the identity case.
- Expected values are hand-derived exact rationals (documented inline, e.g. `x1 = 1 + 0.1*19/5 = 69/50 = 1.38`), not sourced from ranjs's own integrator, per the repo's reference-value provenance convention.

## Scope note
The issue's "Scope" section names `src/mc/_leapfrog.js` as a shared module, but no such file exists in the current codebase — `HMC` and `NUTS` each implement their own independent inline `_leapfrog` private method (`src/mc/hmc.js:317`, `src/mc/nuts.js:454`), a deliberate split documented in `decisions/0034-nuts-euclidean-metric-adaptation.md` and `decisions/0036-shared-metric-module.md` (only the metric machinery was extracted to a shared module; the leapfrog step itself stayed per-sampler). This PR tests both samplers' `_leapfrog` methods directly instead.

`MALA` (also named in the issue body) has no leapfrog step — it uses a single Langevin drift step (`src/mc/mala.js:104`) — so no test changes were needed there.

## Non-trivial changes
- **`test/mc/hmc.js`**: New `describe('._leapfrog() deterministic single-step correctness', ...)` block. One test pins a single leapfrog step (`pathLength: 1`); a second pins two chained steps (`pathLength: 2`) to also cover the internal loop, both against hand-derived exact-rational expected values under a non-identity metric.
- **`test/mc/nuts.js`**: Same pattern, plus asserting the returned `vel` (`= M⁻¹r`) field on both the single-step and the manually-chained two-step case, since NUTS's `_leapfrog` returns velocity for the no-U-turn check and a prior code review caught the initial version only checking `vel` on the first step.

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_012uVDecvHmDiWuZCt4GUMRL)_