### PR TITLE
DoublyNoncentralF.fit regression test timeout increased

### DIFF
--- a/test/dist-base-fit-1.js
+++ b/test/dist-base-fit-1.js
@@ -41,7 +41,7 @@ describe('dist', () => {
       })
 
       it('DoublyNoncentralF.fit should complete quickly on data shaped like the reported regression (#1063)', function () {
-        this.timeout(40000)
+        this.timeout(60000)
         // Exact reproduction from the issue report: Rice(5, 1)-sampled data (which does not
         // genuinely belong to this family) previously drove DoublyNoncentralF.fit() to ~30s
         // because the log-likelihood surface carries a long, near-flat ridge between d2 and
@@ -53,14 +53,15 @@ describe('dist', () => {
         // time alone varies more than 5x under mocha's --parallel workers contending for CPU
         // (matching the exact flakiness this codebase's own solutions doc already documented
         // for full-pool guess() timing assertions — see
-        // solutions/testing/2026-07-21-1055-guess-default-pool-latent-fit-cliff.md). Timeout
-        // raised from 20000 to 40000 alongside #1075: fixing that issue's NaN-at-large-lambda
-        // bug requires _pdf/_cdf's Poisson-mixing sum to combine its Beta-function/power-of-x
-        // terms via log()/exp() per term instead of plain multiplication (the isolated-linear
-        // form is what overflows/underflows), a real but bounded ~1.5x per-call cost that this
-        // already-slow sandboxed environment's ~13s baseline for the *unfixed* code left little
-        // margin against (measured ~19.6s post-fix, isolated) — the pdfCalls bounds above remain
-        // the deterministic guard against the original runaway-Powell-search regression.
+        // solutions/testing/2026-07-21-1055-guess-default-pool-latent-fit-cliff.md, which
+        // measured >60s for the same seeded Rice(5, 1) data inside the full suite). Timeout
+        // raised from 20000 to 40000 alongside #1075 (see that commit for the NaN-at-large-lambda
+        // fix's ~1.5x per-call cost), then to 60000 for #1249: 40000 still left too little
+        // headroom over full-suite CPU/GC contention (isolated run measured 18.6s, ~2x margin,
+        // yet still timed out once under contention); 60000 matches the margin already used by
+        // guess.js's own #1063-driven timeouts for the identical underlying latency. The pdfCalls
+        // bounds above remain the deterministic guard against the original runaway-Powell-search
+        // regression — this timeout only bounds wall-clock, not correctness.
         const data = new dist.Rice(5, 1).seed(5).sample(500)
 
         let pdfCalls = 0


### PR DESCRIPTION
Closes #1249

## Summary
- Bumped the `DoublyNoncentralF.fit` regression test's mocha `this.timeout()` from 40000ms to 60000ms in `test/dist-base-fit-1.js`, to give it enough headroom under full-suite CPU/GC contention.
- Expanded the in-test WHY comment to document the timeout history (20000→40000→60000) and the rationale for each change, cross-referencing `test/guess.js`'s existing 60000ms timeouts for the same underlying `DoublyNoncentralF` latency (#1063).

## Root cause
The test's own regression guard (the `pdfCalls` bounds) is deterministic and load-independent — only the wall-clock mocha timeout was too tight. An isolated run measured ~18.6s against a 40000ms timeout (~2x margin), but that margin was evidently insufficient under full-suite worker contention, matching the exact flakiness already documented in `solutions/testing/2026-07-21-1055-guess-default-pool-latent-fit-cliff.md` for the same seeded `Rice(5, 1)` data. `test/guess.js` already uses a 60000ms timeout for tests hitting this identical latency, so this PR brings `test/dist-base-fit-1.js` in line with that existing convention rather than introducing a new one.

## Verification
- `npm run standard`: clean
- `npm run jsdoclint`: clean
- `npm test` run 3 consecutive times (per the issue's acceptance criteria): each run passed cleanly with 0 failures and no timeouts
- `npm run build && npm run typecheck`: clean
- Code Health score for `test/dist-base-fit-1.js`: 10.0

## Non-trivial changes
_No non-trivial changes — this PR is purely a test-infrastructure timeout adjustment plus a comment update. No production code (`src/`) is touched._

## Comprehension checklist
- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

## Checklist
- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [x] `CHANGELOG.md` updated under `## [Unreleased]` — skipped: this is a test-only change (per CLAUDE.md's per-PR changelog rule)
- [x] Production-code diff is under ~400 lines (tests excluded) — 0 lines of production code changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cw5hNYUy22MUyN3zAFd93y)_