### PR TITLE
Extract process test reference values into a structured case file

### DIFF
--- a/solutions/testing/2026-08-01-1617-inline-provenance-comments-drift-from-their-literals.md
+++ b/solutions/testing/2026-08-01-1617-inline-provenance-comments-drift-from-their-literals.md
@@ -1,0 +1,156 @@
+---
+date: 2026-08-01T16:17:45Z
+category: "testing"
+problem: "A reference value's provenance comment described a computation that produces a different number than the literal it sat above, undetected for as long as the value lived inline"
+status: complete
+related_issue: "#1221"
+related_plan: "thoughts/plans/2026-08-01-1535-process-test-reference-value-extraction.md"
+tags: [testing, reference-values, provenance, mpmath, stochastic-processes, test-organization, refactor, dead-documentation]
+---
+
+# Solution: Inline provenance comments drift from their literals because nothing ever executes them
+
+**Date**: 2026-08-01T16:17:45Z
+**Category**: testing
+**Related Issue**: #1221
+
+## Problem
+
+`test/process.js` carried 72 externally-sourced numeric reference values, each with a provenance
+comment directly above its assertion, in the house style:
+
+```js
+const gbm = new GeometricBrownianMotion(0, 0.5, 1)
+// scipy: stats.lognorm.pdf(0.8, s=0.5*sqrt(0.5), scale=exp(-0.0625*0.5)) = 1.2721398281078873
+assert.closeTo(gbm.pdf(0.8, 0.5), 1.2721398281078873, 1e-10)
+```
+
+The comment is wrong. `scale=exp(-0.0625*0.5)` is `exp(-0.03125)`, and evaluating scipy's
+`lognorm.pdf` with it gives **1.2172975135116265** — not the asserted 1.2721398281078873. The
+correct log-mean is `(mu - sigma^2/2)*t = (0 - 0.125)*0.5 = -0.0625`, so the scale is `exp(-0.0625)`.
+The literal was right all along; only the stated derivation was wrong.
+
+Three further defects of the same family were in the file:
+
+- Six values cited `// Python3 math:` as their source. That is float64 stdlib arithmetic, not one of
+  the three tools `CLAUDE.md` sanctions (mpmath at `mp.dps=50`, scipy, R) — so they carried no
+  independent verification at all.
+- Five values (`test/process.js:537, 1056, 2148, 2677, 3396`) had **no provenance comment**.
+- Two values labelled `mpmath mp.dps=50` stored literals truncated to 13-15 significant digits
+  (`2.59399415029016` where the correctly-rounded float64 is `2.593994150290162`), so the comment
+  claimed 50-digit provenance for a number that did not match it.
+
+Every one of these had been green in CI since the day it was written.
+
+## Root Cause
+
+**A provenance comment is dead documentation: nothing executes it, nothing compares it against the
+literal it describes, and the test passes identically whether it is right, wrong, or absent.**
+
+The assertion `assert.closeTo(gbm.pdf(0.8, 0.5), 1.2721398281078873, 1e-10)` exercises exactly one
+claim — that ranjs computes 1.2721398281078873. The comment asserts a *second*, entirely unchecked
+claim: that scipy, given a specific parameterization, produces that same number. Only the first is
+ever tested. The second can rot freely.
+
+This is structurally the same failure as
+`solutions/testing/2026-07-24-1141-precision-refs-self-check-never-ran.md`, where a `self_check()`
+that had never actually executed was indistinguishable from a working one by reading the code. Here
+the never-executed artifact is the comment rather than a function, but the mechanism is identical:
+**an unexecuted claim looks exactly like a verified one.**
+
+Two properties of the old layout made it worse:
+
+1. **Scattered across 3399 lines.** With provenance interleaved among constructor validation, NaN
+   boundary checks, symmetry identities, and CLT recovery tests, there was no vantage point from
+   which all 72 values could be read together and audited. Nobody could see that six of them cited a
+   tool the conventions forbid.
+2. **Comments are unstructured.** `// Python3 math:` and `// scipy:` and `// exact rational:` are
+   free text. Nothing could enumerate them, count them, or assert that each one names a sanctioned
+   tool.
+
+## Fix
+
+Extracted all 71 instance-method reference values into `test/process-cases.js` as structured
+records, consumed by an inline loop in `test/process.js`:
+
+```js
+{
+  should: 'return log-normal density for mu=0, sigma=0.5, t=0.5, x=0.8',
+  params: () => [0, 0.5, 1],
+  method: 'pdf',
+  args: [0.8, 0.5],
+  expected: 1.2721398281078873,
+  tol: 1e-10,
+  source: 'scipy: stats.lognorm.pdf(0.8, s=0.5*sqrt(0.5), scale=exp((0-0.5^2/2)*0.5)=exp(-0.0625)) = 1.2721398281078873'
+}
+```
+
+The decisive step was **not** the restructuring — it was writing a throwaway mpmath script that
+re-derived all 72 values from each process's textbook marginal/transition law (Gaussian for
+BM/OU/BB/AR1, log-normal for GBM, Poisson for the counting process, Gamma for CIR's `x0 = 0`
+marginal, shifted binomial for RandomWalk) and diffed them against the asserted literals. That
+confirmed all 72 literals correct to within tolerance, which is what made it safe to conclude the
+GBM discrepancy was a *comment* bug rather than a value bug.
+
+Turning provenance from a comment into a `source` **field** bought three things a comment cannot:
+
+- It is passed as `assert.closeTo`'s message argument, so provenance appears in the failure output
+  rather than only to a reader of the source.
+- It is enumerable: `cases.forEach(g => g.refs.forEach(r => ...))` can assert every entry has one,
+  and grep for banned tool names across a structured field rather than free text.
+- Reviewing all 71 side by side is what surfaced the `Python3 math` cluster in the first place.
+
+Deliberately **not** built: a shared runner module mirroring `test/dist-runner.js`. That runner
+exists because four `dist-shard-*.js` files consume it to spread 145+ distributions across
+`mocha --parallel` workers. With one consumer and 71 values, a runner is an abstraction boundary
+with no reuse — every other structured case file in `test/` (`precision-continuous.js`,
+`precision-discrete.js`, `precision-special.js`, `precision-summary-stats.js`) pairs a plain array
+with an inline `forEach`. The rationale is recorded in the new file's header, where a maintainer
+considering a runner would actually look.
+
+## Prevention Strategy
+
+1. **Treat a provenance comment as an unverified claim, because it is one.** When a reference value
+   and its stated derivation disagree, the value is usually right (it was checked against the tool
+   once, at authoring time) and the comment is usually wrong (it was typed by hand). Re-derive
+   before assuming the implementation is broken.
+2. **Before restructuring reference values, re-derive all of them independently.** The mpmath sweep
+   cost ~150 lines of throwaway script and is what converted "the comment looks odd" into "the
+   comment is provably wrong and the value is provably right." Restructuring without it would have
+   faithfully carried the bad comment forward.
+3. **Prefer a structured `source` field over a free-text comment** for any new batch of reference
+   values. It makes provenance enumerable, greppable by tool name, and visible in failure output.
+4. **When extracting values, run old and new assertions side by side first, then delete.** A
+   transcription typo (wrong param, wrong arg) fails loudly during the overlap. Deleting first and
+   extracting second lets a typo silently weaken a test — the same hazard as
+   `solutions/testing/2026-07-21-0835-paramcountcases-shared-sample-vacuous-pass.md`.
+5. **Audit provenance in bulk, not one assertion at a time.** All four defect families here were
+   invisible when reading any single assertion and obvious when reading all 72 together. Periodically
+   grep the suite for tool names outside {mpmath, scipy, R} and for literals whose digit count
+   undershoots float64 while claiming `mp.dps=50` (tracked as #1288).
+6. **Prove a test-only refactor is coverage-neutral by diffing the nyc table**, not by trusting that
+   relocation is safe. `nyc` measures `src/**` only, so an identical `src/process` table before and
+   after is direct evidence no branch lost its only exerciser.
+
+## Related Solutions
+
+- `solutions/testing/2026-07-24-1141-precision-refs-self-check-never-ran.md` — a safety net that
+  never executed was indistinguishable from a working one; same "unexecuted claim looks verified"
+  mechanism, applied to a function rather than a comment.
+- `solutions/testing/2026-05-23-1010-circular-quantile-refvals-provenance-audit.md` — 20
+  `quantileVals` sourced from the ranjs bundle itself; established the rule that every reference must
+  name a source outside the codebase, which is what flagged the `Python3 math` citations here.
+- `solutions/testing/2026-05-22-1708-refvals-self-validation-cancellation-boundary.md` — near a
+  cancellation boundary a reference must not use the same reformulation it guards; why AR1's three
+  near-unit-root guards were re-derived from the *untransformed* expression at 50 digits and kept
+  their `1e-15`/`1e-12` tolerances.
+- `solutions/testing/2026-07-29-2007-normal-far-tail-refvals-absolute-tolerance-blind-spot.md` — a
+  value duplicated across files went stale in one copy; motivated removing the duplicate here rather
+  than leaving the literal in two places.
+
+## Key Insight
+
+A provenance comment is never executed, so a wrong one is indistinguishable from a right one until
+someone re-derives the value by hand — which is why provenance belongs in a structured field that
+can be enumerated and checked in bulk, and why any reference-value refactor must independently
+re-derive every value *before* moving it, not after.

--- a/test/process-cases.js
+++ b/test/process-cases.js
@@ -1,0 +1,768 @@
+import AR1 from '../src/process/ar1'
+import BrownianBridge from '../src/process/brownian-bridge'
+import BrownianMotion from '../src/process/brownian-motion'
+import CompoundPoisson from '../src/process/compound-poisson'
+import CoxIngersollRoss from '../src/process/cox-ingersoll-ross'
+import GeometricBrownianMotion from '../src/process/geometric-brownian-motion'
+import OrnsteinUhlenbeck from '../src/process/ornstein-uhlenbeck'
+import ProcessPoisson from '../src/process/poisson'
+import RandomWalk from '../src/process/random-walk'
+import { Normal } from '../src/dist'
+
+// Externally-sourced reference values for the analytical methods of ran.process (issue #1221).
+//
+// WHY THERE IS NO SHARED RUNNER MODULE HERE: test/dist-runner.js exists because four shard files
+// (dist-shard-0.js .. dist-shard-3.js) each consume it to spread 145+ distributions across
+// mocha --parallel workers. There is one process test file, no sharding need at 9 processes, and
+// so a registerProcessRefTests() module would be an abstraction boundary with exactly one caller.
+// Every other structured case file in test/ — precision-continuous.js, precision-discrete.js,
+// precision-special.js, precision-summary-stats.js — instead pairs a plain array with an inline
+// forEach consumer, and that is the precedent followed here. The data lives in its own file only
+// because test/process.js is already ~3400 lines of behavioural tests; the precision-*.js files can
+// embed their arrays because the array IS their whole purpose. Reconsider a runner only if a second
+// consumer (e.g. process shard files, or a process precision gate) ever actually appears.
+//
+// Entry shape:
+//   should      prose completing "should ..." — the mocha test title, carried over verbatim from
+//               the hand-written block this entry replaced, so a failure still names the
+//               mathematical property that broke rather than a stringified call
+//   params      thunk returning the constructor arguments (thunked, as in dist-cases-*.js, so no
+//               instance — in particular no jump distribution and its PRNG — is built at import)
+//   method      instance method to call
+//   args        arguments to that method
+//   chain       optional: method to call on `method`'s return value (only marginal(t).pdf(x))
+//   chainArgs   optional: arguments to `chain`
+//   expected    the reference value
+//   tol         absolute tolerance for assert.closeTo
+//   source      provenance, naming the external tool (mpmath at mp.dps=50 / scipy / R) or the exact
+//               rational identity. Passed as assert.closeTo's message so provenance is visible in
+//               the failure output, not only to a reader of this file.
+//
+// solutions/testing/2026-08-01-1617-inline-provenance-comments-drift-from-their-literals.md — a
+// provenance comment is never executed, so a wrong one reads exactly like a verified one; keeping
+// provenance in a `source` field makes it enumerable and surfaces it in failure output.
+//
+// Every value below was independently re-verified against mpmath at mp.dps=50, using each process's
+// textbook marginal/transition law (Gaussian for BM/OU/BB/AR1, log-normal for GBM, Poisson for the
+// counting process, Gamma for CIR's x0 = 0 marginal, shifted binomial for RandomWalk) — never by
+// running ran.process itself, which would make these assertions tautological.
+export default [
+  {
+    name: 'BrownianMotion',
+    ctor: BrownianMotion,
+    refs: [
+      {
+        should: 'return mu*t for zero initial state',
+        params: () => [0.5, 1, 1],
+        method: 'mean',
+        args: [2],
+        expected: 1.0,
+        tol: 1e-10,
+        source: 'exact rational: mu*t = 0.5*2 = 1'
+      },
+      {
+        should: 'return sigma^2 * t',
+        params: () => [0, 2, 1],
+        method: 'variance',
+        args: [3],
+        expected: 12,
+        tol: 1e-10,
+        source: 'exact rational: sigma^2*t = 2^2*3 = 12'
+      },
+      {
+        should: 'return Normal(0,1) density at x=0, t=1 for mu=0, sigma=1',
+        params: () => [0, 1, 1],
+        method: 'pdf',
+        args: [0, 1],
+        expected: 0.3989422804014327,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(0, loc=0, scale=1) = 0.3989422804014327'
+      },
+      {
+        should: 'return Normal(mu*t, sigma^2*t) density for general parameters',
+        params: () => [0.5, 2, 1],
+        method: 'pdf',
+        args: [1, 2],
+        expected: 0.1410473958869391,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(1, loc=0.5*2, scale=sqrt(4*2)) = 0.1410473958869391'
+      },
+      {
+        should: 'match Normal distribution with correct parameters',
+        params: () => [-0.2, 1.5, 1],
+        method: 'pdf',
+        args: [0, 3],
+        expected: 0.1495123243667221,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(0, loc=-0.2*3, scale=sqrt(1.5^2*3)) = 0.1495123243667221'
+      },
+      {
+        should: 'return sigma^2 * min(s, t)',
+        params: () => [0, 2, 1],
+        method: 'covariogram',
+        args: [2, 3],
+        expected: 8,
+        tol: 1e-10,
+        source: 'exact rational: sigma^2*min(s,t) = 2^2*min(2,3) = 4*2 = 8'
+      },
+      {
+        should: 'match the transition log-likelihood of a fixed path',
+        params: () => [0.3, 1.2, 0.5],
+        method: 'lnL',
+        args: [[0, 0.4, 1.1, 0.7]],
+        expected: -2.7276011658226307,
+        tol: 1e-9,
+        source: 'mpmath mp.dps=50: sum of Normal(x_i + mu*dt, sigma^2*dt).logpdf(x_{i+1}) over the 3 steps -> -2.7276011658226308065169617691597986337297768997831'
+      }
+    ]
+  },
+  {
+    name: 'GeometricBrownianMotion',
+    ctor: GeometricBrownianMotion,
+    refs: [
+      {
+        should: 'return exp(mu*t)',
+        params: () => [0.1, 0.2, 1],
+        method: 'mean',
+        args: [3],
+        expected: 1.3498588075760032,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: exp(0.1*3) = exp(0.3) -> 1.3498588075760032'
+      },
+      {
+        should: 'return exp(2*mu*t)*(exp(sigma^2*t)-1)',
+        params: () => [0.05, 0.3, 1],
+        method: 'variance',
+        args: [1],
+        expected: 0.10407867958160391,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: exp(0.1)*(exp(0.09)-1) -> 0.10407867958160391'
+      },
+      {
+        should: 'return log-normal density for mu=0.1, sigma=0.3, t=1, x=1',
+        params: () => [0.1, 0.3, 1],
+        method: 'pdf',
+        args: [1.0, 1],
+        expected: 1.3076461848524421,
+        tol: 1e-10,
+        source: 'scipy: stats.lognorm.pdf(1, s=0.3*sqrt(1), scale=exp(log(1)+(0.1-0.09/2)*1)) = 1.3076461848524421'
+      },
+      {
+        should: 'return log-normal density for mu=0.05, sigma=0.2, t=2, x=1.5',
+        params: () => [0.05, 0.2, 1],
+        method: 'pdf',
+        args: [1.5, 2],
+        expected: 0.4459926977250626,
+        tol: 1e-10,
+        source: 'scipy: stats.lognorm.pdf(1.5, s=0.2*sqrt(2), scale=exp((0.05-0.02)*2)) = 0.4459926977250626'
+      },
+      {
+        should: 'return log-normal density for mu=0, sigma=0.5, t=0.5, x=0.8',
+        params: () => [0, 0.5, 1],
+        method: 'pdf',
+        args: [0.8, 0.5],
+        expected: 1.2721398281078873,
+        tol: 1e-10,
+        // The inline comment this replaced wrote the scale as exp(-0.0625*0.5), which evaluates to
+        // 1.2172975135116265 — not the asserted value. The log-mean is (mu - sigma^2/2)*t =
+        // (0 - 0.125)*0.5 = -0.0625, so the scale is exp(-0.0625). The literal was always correct;
+        // only the stated derivation was wrong (#1221).
+        source: 'scipy: stats.lognorm.pdf(0.8, s=0.5*sqrt(0.5), scale=exp((0-0.5^2/2)*0.5)=exp(-0.0625)) = 1.2721398281078873'
+      },
+      {
+        should: 'return exp(mu*(s+t)) * (exp(sigma^2*min(s,t)) - 1)',
+        params: () => [0.05, 0.2, 1],
+        method: 'covariogram',
+        args: [1, 3],
+        expected: 0.049846392161234841,
+        tol: 1e-10,
+        source: 'scipy: exp(0.05*(1+3)) * (exp(0.2**2*min(1,3)) - 1) -> 0.049846392161234841'
+      },
+      {
+        should: 'match the transition log-likelihood of a fixed path',
+        params: () => [0.1, 0.25, 0.5],
+        method: 'lnL',
+        args: [[1.0, 1.2, 0.9, 1.5]],
+        expected: -3.682464110185123,
+        tol: 1e-9,
+        source: 'mpmath mp.dps=50: sum of [Normal(drift, noise^2).logpdf(log(x_{i+1}/x_i)) - log(x_{i+1})] over the 3 steps, where drift = (mu-0.5*sigma^2)*dt, noise^2 = sigma^2*dt (the log-normal transition density\'s 1/x Jacobian) -> -3.6824641101851229894621067377482732895915091716478'
+      }
+    ]
+  },
+  {
+    name: 'OrnsteinUhlenbeck',
+    ctor: OrnsteinUhlenbeck,
+    refs: [
+      {
+        should: 'return mu*(1 - exp(-theta*t)) for zero initial state',
+        params: () => [2, 3, 1, 0.1],
+        method: 'mean',
+        args: [1],
+        expected: 2.593994150290162,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: 3*(1-exp(-2)) -> 2.593994150290162'
+      },
+      {
+        should: 'approach mu as t -> infinity',
+        params: () => [1, 4, 1, 0.1],
+        method: 'mean',
+        args: [1000],
+        expected: 4,
+        tol: 1e-6,
+        source: 'exact rational: mu*(1-exp(-theta*t)) -> mu as t -> inf; at theta*t = 1000, exp(-1000) underflows to 0 in float64, so the limit is exactly mu = 4'
+      },
+      {
+        should: 'return sigma^2*(1-exp(-2*theta*t))/(2*theta)',
+        params: () => [2, 0, 0.5, 0.1],
+        method: 'variance',
+        args: [1],
+        expected: 0.06135527256945411,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: sigma^2*(1-exp(-2*theta*t))/(2*theta) = 0.25*(1-exp(-4))/4 -> 0.06135527256945411'
+      },
+      {
+        should: 'approach stationary variance sigma^2/(2*theta) as t -> infinity',
+        params: () => [2, 0, 0.5, 0.1],
+        method: 'variance',
+        args: [1000],
+        expected: 0.0625,
+        tol: 1e-6,
+        source: 'exact rational: sigma^2/(2*theta) = 0.25/4 = 0.0625'
+      },
+      {
+        should: 'return Normal(mean(t), variance(t)) density for theta=1 mu=2 sigma=1 t=1 x=1',
+        params: () => [1, 2, 1, 0.1],
+        method: 'pdf',
+        args: [1, 1],
+        expected: 0.5596687594392821,
+        tol: 1e-10,
+        source: 'scipy: mu=2*(1-exp(-1)), var=(1-exp(-2))/2; stats.norm.pdf(1, mu, sqrt(var)) = 0.5596687594392821'
+      },
+      {
+        should: 'return correct density for theta=2 mu=0 sigma=0.5 t=0.5 x=0',
+        params: () => [2, 0, 0.5, 0.1],
+        method: 'pdf',
+        args: [0, 0.5],
+        expected: 1.7161142135258760,
+        tol: 1e-10,
+        source: 'scipy: mu=0, var=0.25*(1-exp(-2))/4; stats.norm.pdf(0, 0, sqrt(var)) = 1.7161142135258760'
+      },
+      {
+        should: 'return correct density for theta=0.5 mu=3 sigma=2 t=2 x=2',
+        params: () => [0.5, 3, 2, 0.1],
+        method: 'pdf',
+        args: [2, 2],
+        expected: 0.2141814469689605,
+        tol: 1e-10,
+        source: 'scipy: mu=3*(1-exp(-1)), var=4*(1-exp(-2))/1; stats.norm.pdf(2, mu, sqrt(var)) = 0.2141814469689605'
+      },
+      {
+        should: 'return (sigma^2/2theta)*(exp(-theta*|t-s|) - exp(-theta*(t+s)))',
+        params: () => [2, 0, 0.5, 0.1],
+        method: 'covariogram',
+        args: [1, 3],
+        expected: 0.0011237610163019791,
+        tol: 1e-10,
+        source: 'scipy: (0.5**2/(2*2)) * (exp(-2*abs(3-1)) - exp(-2*(3+1))) -> 0.0011237610163019791'
+      },
+      {
+        should: 'match the transition log-likelihood of a fixed path',
+        params: () => [0.8, 0.5, 0.6, 0.25],
+        method: 'lnL',
+        args: [[1.0, 0.9, 0.6, 0.8]],
+        expected: 0.47497249518150225,
+        tol: 1e-9,
+        source: 'mpmath mp.dps=50: sum of Normal(x_i*decay + mu*(1-decay), noise^2).logpdf(x_{i+1}) over the 3 steps, where decay = exp(-theta*dt), noise^2 = sigma^2*(1-decay^2)/(2*theta) — the ONE-STEP transition constants, distinct from mean(t)/variance(t)\'s elapsed-time decay exp(-theta*t) for arbitrary t -> 0.47497249518150224285604569178811850409220342308943'
+      }
+    ]
+  },
+  {
+    name: 'BrownianBridge',
+    ctor: BrownianBridge,
+    refs: [
+      {
+        should: 'return sigma^2 * t * (T-t) / T for 0 < t < T',
+        params: () => [2, 1, 0.1],
+        method: 'variance',
+        args: [0.5],
+        expected: 1,
+        tol: 1e-10,
+        source: 'exact rational: sigma^2*t*(T-t)/T = 4*0.5*0.5/1 = 1'
+      },
+      {
+        should: 'return sigma^2 * min(s,t) * (T - max(s,t)) / T for 0 <= s <= t <= T',
+        params: () => [2, 1, 0.1],
+        method: 'covariogram',
+        args: [0.25, 0.5],
+        expected: 0.5,
+        tol: 1e-10,
+        source: 'exact rational: sigma^2*s*(T-t)/T = 4*0.25*0.5/1 = 0.5'
+      },
+      {
+        should: 'return Normal(0, sigma^2*t*(T-t)/T) density at x=0 for sigma=1, T=2, t=1',
+        params: () => [1, 2, 0.1],
+        method: 'pdf',
+        args: [0, 1],
+        expected: 0.5641895835477563,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(0, 0, sqrt(1*1*1/2)) = 0.5641895835477563'
+      },
+      {
+        should: 'return correct density at x=1 for sigma=1, T=2, t=1',
+        params: () => [1, 2, 0.1],
+        method: 'pdf',
+        args: [1, 1],
+        expected: 0.20755374871029736,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(1, 0, sqrt(0.5)) = 0.20755374871029736'
+      },
+      {
+        should: 'return correct density at x=0 for sigma=2, T=4, t=2',
+        params: () => [2, 4, 0.1],
+        method: 'pdf',
+        args: [0, 2],
+        expected: 0.19947114020071635,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(0, 0, sqrt(4*2*2/4)) = stats.norm.pdf(0, 0, 2) = 0.19947114020071635'
+      }
+    ]
+  },
+  {
+    name: 'AR1',
+    ctor: AR1,
+    refs: [
+      {
+        should: 'return sigma^2 at t = 1',
+        params: () => [0.5, 2],
+        method: 'variance',
+        args: [1],
+        expected: 4,
+        tol: 1e-10,
+        source: 'exact rational: Var(X_1) = sigma^2 = 4'
+      },
+      {
+        should: 'return sigma^2*(1+phi^2) at t = 2',
+        params: () => [0.5, 2],
+        method: 'variance',
+        args: [2],
+        expected: 5,
+        tol: 1e-10,
+        source: 'exact rational: Var(X_2) = sigma^2*(1 + phi^2) = 4*(1+0.25) = 5'
+      },
+      {
+        should: 'approach stationary variance sigma^2/(1-phi^2) as t -> infinity',
+        params: () => [0.5, 1],
+        method: 'variance',
+        args: [1000],
+        expected: 4 / 3,
+        tol: 1e-6,
+        source: 'exact rational: sigma^2/(1-phi^2) = 1/(1-0.25) = 4/3'
+      },
+      {
+        should: 'grow monotonically for |phi| > 1',
+        params: () => [1.5, 1],
+        method: 'variance',
+        args: [3],
+        expected: 8.3125,
+        tol: 1e-10,
+        source: 'exact rational: Var(X_3) = sigma^2*(1 + phi^2 + phi^4) = 1 + 2.25 + 5.0625 = 8.3125'
+      },
+      // The next three are cancellation regression guards, not ordinary reference points: phi is
+      // chosen so phi^2 lands just outside the 1e-14 special-case band, where the pre-#1153 formula
+      // lost all significance. Their references are computed from the UNTRANSFORMED
+      // sigma^2*(1-phi2^t)/(1-phi2) at 50 digits — deliberately not from the expm1/log1p
+      // reformulation under test — and their tolerances are correspondingly tighter than the 1e-10
+      // used elsewhere. Do not relax them to the default.
+      {
+        should: 'not collapse to 0 via cancellation for near-unit-root phi and small fractional t',
+        params: () => [Math.sqrt(1 - 2e-14), 1],
+        method: 'variance',
+        args: [1e-6],
+        expected: 1.00000000000001e-6,
+        tol: 1e-15,
+        source: 'mpmath mp.dps=50, untransformed sigma^2*(1-phi2^t)/(1-phi2) with the actual double phi2 = 0.99999999999998 (immune to cancellation at 50 digits): 1.0000000000000099999900...e-6'
+      },
+      {
+        should: 'stay accurate for near-unit-root phi and moderate fractional t',
+        params: () => [Math.sqrt(1 - 1e-13), 1],
+        method: 'variance',
+        args: [0.01],
+        expected: 0.010000000000000495,
+        tol: 1e-12,
+        source: 'mpmath mp.dps=50, untransformed sigma^2*(1-phi2^t)/(1-phi2) with the actual double phi2 = 0.9999999999998999: 0.0100000000000004954950000000329...'
+      },
+      {
+        should: 'remain accurate for near-unit-root phi at integer t (regression guard)',
+        params: () => [Math.sqrt(1 - 1e-13), 1],
+        method: 'variance',
+        args: [10],
+        expected: 9.999999999995495,
+        tol: 1e-12,
+        source: 'mpmath mp.dps=50, untransformed sigma^2*(1-phi2^t)/(1-phi2) with the actual double phi2 = 0.9999999999998999: 9.9999999999954955000000012024...'
+      },
+      {
+        should: 'return Normal(0, sigma^2) density at t = 1',
+        params: () => [0.5, 1],
+        method: 'pdf',
+        args: [0, 1],
+        expected: 0.3989422804014327,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(0, 0, 1) = 0.3989422804014327'
+      },
+      {
+        should: 'return Normal(0, sigma^2*(1+phi^2)) density at t = 2',
+        params: () => [0.5, 1],
+        method: 'pdf',
+        args: [0, 2],
+        expected: 0.3568248232305543,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(0, 0, sqrt(1.25)) = 0.3568248232305543'
+      },
+      {
+        should: 'return Normal(0, sigma^2*(1+phi^2+phi^4)) density at t = 3',
+        params: () => [0.5, 1],
+        method: 'pdf',
+        args: [1, 3],
+        expected: 0.2379112029210874,
+        tol: 1e-10,
+        source: 'scipy: stats.norm.pdf(1, 0, sqrt(1.3125)) = 0.2379112029210874'
+      },
+      {
+        should: 'return phi * Var(X_2) for s=2, t=3',
+        params: () => [0.5, 1],
+        method: 'covariogram',
+        args: [2, 3],
+        expected: 0.625,
+        tol: 1e-10,
+        source: 'exact rational: Cov(X_2, X_3) = phi * Var(X_2) = 0.5 * (1 + 0.25) = 0.625'
+      },
+      {
+        should: 'return phi * Var(X_1) for s=1, t=2',
+        params: () => [0.5, 1],
+        method: 'covariogram',
+        args: [1, 2],
+        expected: 0.5,
+        tol: 1e-10,
+        source: 'exact rational: Cov(X_1, X_2) = phi^1 * Var(X_1) = 0.5 * 1 = 0.5'
+      },
+      {
+        should: 'return phi^2 * Var(X_1) for s=1, t=3',
+        params: () => [0.5, 1],
+        method: 'covariogram',
+        args: [1, 3],
+        expected: 0.25,
+        tol: 1e-10,
+        source: 'exact rational: Cov(X_1, X_3) = phi^2 * Var(X_1) = 0.25 * 1 = 0.25'
+      }
+    ]
+  },
+  {
+    name: 'Poisson',
+    ctor: ProcessPoisson,
+    refs: [
+      {
+        should: 'return lambda*t',
+        params: () => [2, 0.5],
+        method: 'mean',
+        args: [3],
+        expected: 6,
+        tol: 1e-10,
+        source: 'exact rational: lambda*t = 2*3 = 6'
+      },
+      {
+        should: 'return lambda*t',
+        params: () => [2, 0.5],
+        method: 'variance',
+        args: [3],
+        expected: 6,
+        tol: 1e-10,
+        source: 'exact rational: lambda*t = 2*3 = 6'
+      },
+      {
+        should: 'return Poisson(lambda*t) PMF for lambda=2 t=1 x=2',
+        params: () => [2, 1],
+        method: 'pdf',
+        args: [2, 1],
+        expected: 0.2706705664732255,
+        tol: 1e-10,
+        source: 'scipy: stats.poisson.pmf(2, 2) = 0.2706705664732255'
+      },
+      {
+        should: 'return Poisson(lambda*t) PMF for lambda=0.5 t=3 x=1',
+        params: () => [0.5, 1],
+        method: 'pdf',
+        args: [1, 3],
+        expected: 0.3346952402226447,
+        tol: 1e-10,
+        source: 'scipy: stats.poisson.pmf(1, 1.5) = 0.3346952402226447'
+      },
+      {
+        should: 'return Poisson(lambda*t) PMF for lambda=3 t=2 x=5',
+        params: () => [3, 1],
+        method: 'pdf',
+        args: [5, 2],
+        expected: 0.1606231410479798,
+        tol: 1e-10,
+        source: 'scipy: stats.poisson.pmf(5, 6) = 0.1606231410479798'
+      },
+      {
+        should: 'return lambda * min(s, t)',
+        params: () => [3, 0.5],
+        method: 'covariogram',
+        args: [2, 5],
+        expected: 6,
+        tol: 1e-10,
+        source: 'exact rational: lambda*min(s,t) = 3*min(2,5) = 3*2 = 6'
+      }
+    ]
+  },
+  {
+    // Only three entries, against 5-13 for every other process: a compound Poisson sum has no
+    // closed-form pdf/cdf/lnL for a general jump distribution, so only the first two moments and
+    // the covariogram are expressible as literals here. The density is covered instead by the
+    // hand-written .marginal() block in process.js, which checks the Gamma-jump case against a
+    // truncated Poisson-Gamma series. Thin by nature, not by oversight.
+    name: 'CompoundPoisson',
+    ctor: CompoundPoisson,
+    refs: [
+      {
+        should: 'return lambda*t*E[J]',
+        params: () => [new Normal(2, 1), 3, 1],
+        method: 'mean',
+        args: [5],
+        expected: 30,
+        tol: 1e-10,
+        source: 'exact rational: lambda*t*mu = 3*5*2 = 30'
+      },
+      {
+        should: 'return lambda*t*E[J^2]',
+        params: () => [new Normal(2, 1), 3, 1],
+        method: 'variance',
+        args: [4],
+        expected: 60,
+        tol: 1e-10,
+        source: 'exact rational: lambda*t*(sigma^2 + mu^2) = 3*4*(1+4) = 60'
+      },
+      {
+        should: 'return lambda*E[J^2]*min(s,t)',
+        params: () => [new Normal(2, 1), 3, 1],
+        method: 'covariogram',
+        args: [2, 5],
+        expected: 30,
+        tol: 1e-10,
+        source: 'exact rational: lambda*E[J^2]*min(s,t) = 3*(1+4)*2 = 30'
+      }
+    ]
+  },
+  {
+    name: 'CoxIngersollRoss',
+    ctor: CoxIngersollRoss,
+    refs: [
+      {
+        should: 'return theta*(1-exp(-kappa*t)) for zero initial state',
+        params: () => [2, 3, 1, 0.1],
+        method: 'mean',
+        args: [1],
+        expected: 2.593994150290162,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: 3*(1-exp(-2)) -> 2.5939941502901619243180015150825467897771053622713'
+      },
+      {
+        should: 'approach theta as t -> infinity',
+        params: () => [1, 4, 1, 0.1],
+        method: 'mean',
+        args: [1000],
+        expected: 4,
+        tol: 1e-6,
+        source: 'exact rational: theta*(1-exp(-kappa*t)) -> theta as t -> inf; at kappa*t = 1000, exp(-1000) underflows to 0 in float64, so the limit is exactly theta = 4'
+      },
+      {
+        should: 'return theta*sigma^2/(2*kappa)*(1-exp(-kappa*t))^2 for zero initial state',
+        params: () => [2, 3, 0.5, 0.1],
+        method: 'variance',
+        args: [1],
+        expected: 0.1401834510779079,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: 3*(0.25/(2*2))*(1-exp(-2))^2 -> 0.14018345107790789934482231837405108163687168295019'
+      },
+      {
+        should: 'approach stationary variance theta*sigma^2/(2*kappa) as t -> infinity',
+        params: () => [2, 3, 0.5, 0.1],
+        method: 'variance',
+        args: [1000],
+        expected: 0.1875,
+        tol: 1e-6,
+        source: 'exact rational: theta*sigma^2/(2*kappa) = 3*0.25/4 = 0.1875'
+      },
+      // The five CIR pdf/covariogram references below previously cited "Python3 math", which is
+      // float64 stdlib arithmetic and not one of the three tools CLAUDE.md sanctions. They are
+      // re-derived here from the same textbook laws at mp.dps=50 — X_t ~ Gamma(2*kappa*theta/sigma^2,
+      // scale = sigma^2*(1-exp(-kappa*t))/(2*kappa)) for x0 = 0, and Cov(X_s,X_t) = Var(X_min) *
+      // exp(-kappa*|t-s|) — and the asserted literals are now the correctly-rounded float64 values
+      // rather than the 13-significant-digit truncations previously stored (#1221).
+      {
+        should: 'return Gamma density for x=0.5, kappa=2, theta=3, sigma=1, t=0.5',
+        params: () => [2, 3, 1, 0.1],
+        method: 'pdf',
+        args: [0.5, 0.5],
+        expected: 0.0021308247498825613,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: Gamma(alpha=12, scale=(1-exp(-1))/4).pdf(0.5) -> 0.0021308247498825613865329058218278989295590699941829'
+      },
+      {
+        should: 'return Gamma density for x=2.0, kappa=2, theta=3, sigma=1, t=0.5',
+        params: () => [2, 3, 1, 0.1],
+        method: 'pdf',
+        args: [2.0, 0.5],
+        expected: 0.6744427823991435,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: Gamma(alpha=12, scale=(1-exp(-1))/4).pdf(2) -> 0.674442782399143409464902014509663705211162020868'
+      },
+      {
+        should: 'return Gamma density for x=1.5, kappa=2, theta=3, sigma=1, t=1',
+        params: () => [2, 3, 1, 0.1],
+        method: 'pdf',
+        args: [1.5, 1],
+        expected: 0.2017343219136092,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: Gamma(alpha=12, scale=(1-exp(-2))/4).pdf(1.5) -> 0.20173432191360919916867020119773819180627563066727'
+      },
+      {
+        should: 'return correct value for s=1, t=3, kappa=2, theta=3, sigma=1',
+        params: () => [2, 3, 1, 0.1],
+        method: 'covariogram',
+        args: [1, 3],
+        expected: 0.010270197872477982,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: theta*sigma^2/(2*kappa)*(1-exp(-2))^2*exp(-4) -> 0.010270197872477981464836806653041575586157506387096'
+      },
+      {
+        should: 'return correct value for s=0.5, t=2, kappa=2, theta=3, sigma=1',
+        params: () => [2, 3, 1, 0.1],
+        method: 'covariogram',
+        args: [0.5, 2],
+        expected: 0.014920303192110787,
+        tol: 1e-10,
+        source: 'mpmath mp.dps=50: theta*sigma^2/(2*kappa)*(1-exp(-1))^2*exp(-3) -> 0.01492030319211078711640681614504578734254378158162'
+      }
+    ]
+  },
+  {
+    name: 'RandomWalk',
+    ctor: RandomWalk,
+    refs: [
+      {
+        should: 'return t*(2p-1) for biased walk',
+        params: () => [0.7],
+        method: 'mean',
+        args: [5],
+        expected: 2,
+        tol: 1e-10,
+        source: 'exact rational: t*(2p-1) = 5*(2*0.7-1) = 5*0.4 = 2'
+      },
+      {
+        should: 'return negative mean for p < 0.5',
+        params: () => [0.3],
+        method: 'mean',
+        args: [4],
+        expected: -1.6,
+        tol: 1e-10,
+        source: 'exact rational: t*(2p-1) = 4*(0.6-1) = 4*(-0.4) = -1.6'
+      },
+      {
+        should: 'return 4p(1-p)*t for symmetric walk',
+        params: () => [0.5],
+        method: 'variance',
+        args: [10],
+        expected: 10,
+        tol: 1e-10,
+        source: 'exact rational: 4*0.5*0.5*10 = 10'
+      },
+      {
+        should: 'return 4p(1-p)*t for biased walk',
+        params: () => [0.7],
+        method: 'variance',
+        args: [5],
+        expected: 4.2,
+        tol: 1e-10,
+        source: 'exact rational: 4*0.7*0.3*5 = 4.2'
+      },
+      {
+        should: 'return exact binomial PMF for p=0.5, t=4, x=0',
+        params: () => [0.5],
+        method: 'pdf',
+        args: [0, 4],
+        expected: 0.375,
+        tol: 1e-10,
+        source: 'exact rational: C(4,2)*0.5^4 = 6/16 = 0.375'
+      },
+      {
+        should: 'return exact binomial PMF for p=0.5, t=4, x=2',
+        params: () => [0.5],
+        method: 'pdf',
+        args: [2, 4],
+        expected: 0.25,
+        tol: 1e-10,
+        source: 'exact rational: C(4,3)*0.5^4 = 4/16 = 0.25'
+      },
+      {
+        should: 'return exact binomial PMF for p=0.6, t=3, x=1',
+        params: () => [0.6],
+        method: 'pdf',
+        args: [1, 3],
+        expected: 0.432,
+        tol: 1e-10,
+        source: 'exact rational: C(3,2)*0.6^2*0.4 = 3*0.36*0.4 = 0.432'
+      },
+      {
+        should: 'return exact binomial PMF for p=0.7, t=5, x=3',
+        params: () => [0.7],
+        method: 'pdf',
+        args: [3, 5],
+        expected: 0.36015,
+        tol: 1e-10,
+        source: 'exact rational: C(5,4)*0.7^4*0.3 = 5*0.2401*0.3 = 0.36015'
+      },
+      {
+        should: 'return 4p(1-p)*min(s,t) for symmetric walk',
+        params: () => [0.5],
+        method: 'covariogram',
+        args: [3, 5],
+        expected: 3,
+        tol: 1e-10,
+        source: 'exact rational: 4*0.5*0.5*min(3,5) = 3'
+      },
+      {
+        should: 'return 4p(1-p)*min(s,t) for biased walk',
+        params: () => [0.7],
+        method: 'covariogram',
+        args: [2, 4],
+        expected: 1.68,
+        tol: 1e-10,
+        source: 'exact rational: 4*0.7*0.3*min(2,4) = 4*0.21*2 = 1.68'
+      },
+      {
+        should: 'return a nonzero marginal pdf at the upper support boundary',
+        params: () => [0.6],
+        method: 'marginal',
+        args: [4],
+        chain: 'pdf',
+        chainArgs: [4],
+        expected: 0.1296,
+        tol: 1e-10,
+        source: 'exact rational: pdf(n) is the all-+1-steps walk, probability p^n = 0.6^4 = 0.1296'
+      },
+      {
+        should: 'return a nonzero marginal pdf at the lower support boundary',
+        params: () => [0.6],
+        method: 'marginal',
+        args: [4],
+        chain: 'pdf',
+        chainArgs: [-4],
+        expected: 0.0256,
+        tol: 1e-10,
+        source: 'exact rational: pdf(-n) is the all--1-steps walk, probability (1-p)^n = 0.4^4 = 0.0256'
+      }
+    ]
+  }
+]

--- a/test/process.js
+++ b/test/process.js
@@ -18,6 +18,7 @@ import RandomWalk from '../src/process/random-walk'
 import ShiftedBinomial from '../src/dist/_shifted-binomial'
 import { Normal, LogNormal, Gamma, Poisson, Tweedie } from '../src/dist'
 import { chiTest } from './test-utils'
+import processCases from './process-cases'
 
 // Fixed seeds replace ksTest/chiTest significance-level checks: a random seed can produce
 // a false positive/negative at the chosen critical value on some runs, while a fixed seed
@@ -460,12 +461,6 @@ describe('process.BrownianMotion', () => {
   })
 
   describe('.mean()', () => {
-    it('should return mu*t for zero initial state', () => {
-      const bm = new BrownianMotion(0.5, 1, 1)
-      // exact rational: mu*t = 0.5*2 = 1
-      assert.closeTo(bm.mean(2), 1.0, 1e-10)
-    })
-
     it('should return 0 for zero drift at any t', () => {
       const bm = new BrownianMotion(0, 1, 1)
       assert.strictEqual(bm.mean(3), 0)
@@ -484,12 +479,6 @@ describe('process.BrownianMotion', () => {
   })
 
   describe('.variance()', () => {
-    it('should return sigma^2 * t', () => {
-      const bm = new BrownianMotion(0, 2, 1)
-      // exact rational: sigma^2*t = 2^2*3 = 12
-      assert.closeTo(bm.variance(3), 12, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const bm = new BrownianMotion(0, 1, 1)
       assert.strictEqual(bm.variance(0), 0)
@@ -511,32 +500,9 @@ describe('process.BrownianMotion', () => {
       const bm = new BrownianMotion(0, 1, 1)
       assert(Number.isNaN(bm.pdf(0, -1)))
     })
-
-    it('should return Normal(0,1) density at x=0, t=1 for mu=0, sigma=1', () => {
-      const bm = new BrownianMotion(0, 1, 1)
-      // scipy: stats.norm.pdf(0, loc=0, scale=1) = 0.3989422804014327
-      assert.closeTo(bm.pdf(0, 1), 0.3989422804014327, 1e-10)
-    })
-
-    it('should return Normal(mu*t, sigma^2*t) density for general parameters', () => {
-      const bm = new BrownianMotion(0.5, 2, 1)
-      // scipy: stats.norm.pdf(1, loc=0.5*2, scale=sqrt(4*2)) = 0.1410473958869391
-      assert.closeTo(bm.pdf(1, 2), 0.1410473958869391, 1e-10)
-    })
-
-    it('should match Normal distribution with correct parameters', () => {
-      const bm = new BrownianMotion(-0.2, 1.5, 1)
-      // scipy: stats.norm.pdf(0, loc=-0.2*3, scale=sqrt(1.5^2*3)) = 0.1495123243667221
-      assert.closeTo(bm.pdf(0, 3), 0.1495123243667221, 1e-10)
-    })
   })
 
   describe('.covariogram()', () => {
-    it('should return sigma^2 * min(s, t)', () => {
-      const bm = new BrownianMotion(0, 2, 1)
-      assert.closeTo(bm.covariogram(2, 3), 4 * 2, 1e-10)
-    })
-
     it('should be symmetric', () => {
       const bm = new BrownianMotion(0, 2, 1)
       assert.closeTo(bm.covariogram(1, 4), bm.covariogram(4, 1), 1e-10)
@@ -591,14 +557,6 @@ describe('process.BrownianMotion', () => {
   })
 
   describe('.lnL()', () => {
-    it('should match the transition log-likelihood of a fixed path', () => {
-      const bm = new BrownianMotion(0.3, 1.2, 0.5)
-      const path = [0, 0.4, 1.1, 0.7]
-      // mpmath mp.dps=50: sum of Normal(x_i + mu*dt, sigma^2*dt).logpdf(x_{i+1}) over the 3 steps
-      // → -2.7276011658226308065169617691597986337297768997831
-      assert.closeTo(bm.lnL(path), -2.7276011658226307, 1e-9)
-    })
-
     it('should have a mean per-step log-density matching the known transition law (CLT tolerance)', () => {
       const mu = 0.1
       const sigma = 1
@@ -756,12 +714,6 @@ describe('process.GeometricBrownianMotion', () => {
       assert.strictEqual(gbm.mean(0), 1)
     })
 
-    it('should return exp(mu*t)', () => {
-      const gbm = new GeometricBrownianMotion(0.1, 0.2, 1)
-      // mpmath mp.dps=50: exp(0.1*3) = exp(0.3) → 1.3498588075760032
-      assert.closeTo(gbm.mean(3), 1.3498588075760032, 1e-10)
-    })
-
     it('should return NaN for t < 0', () => {
       const gbm = new GeometricBrownianMotion(0, 1, 1)
       assert(Number.isNaN(gbm.mean(-1)))
@@ -779,12 +731,6 @@ describe('process.GeometricBrownianMotion', () => {
     it('should return 0 at t=0', () => {
       const gbm = new GeometricBrownianMotion(0.1, 0.2, 1)
       assert.strictEqual(gbm.variance(0), 0)
-    })
-
-    it('should return exp(2*mu*t)*(exp(sigma^2*t)-1)', () => {
-      const gbm = new GeometricBrownianMotion(0.05, 0.3, 1)
-      // mpmath mp.dps=50: exp(0.1)*(exp(0.09)-1) → 0.10407867958160391
-      assert.closeTo(gbm.variance(1), 0.10407867958160391, 1e-10)
     })
 
     it('should return NaN for t < 0', () => {
@@ -813,33 +759,9 @@ describe('process.GeometricBrownianMotion', () => {
       const gbm = new GeometricBrownianMotion(0, 1, 1)
       assert.strictEqual(gbm.pdf(-1, 1), 0)
     })
-
-    it('should return log-normal density for mu=0.1, sigma=0.3, t=1, x=1', () => {
-      const gbm = new GeometricBrownianMotion(0.1, 0.3, 1)
-      // scipy: stats.lognorm.pdf(1, s=0.3*sqrt(1), scale=exp(log(1)+(0.1-0.09/2)*1)) = 1.3076461848524421
-      assert.closeTo(gbm.pdf(1.0, 1), 1.3076461848524421, 1e-10)
-    })
-
-    it('should return log-normal density for mu=0.05, sigma=0.2, t=2, x=1.5', () => {
-      const gbm = new GeometricBrownianMotion(0.05, 0.2, 1)
-      // scipy: stats.lognorm.pdf(1.5, s=0.2*sqrt(2), scale=exp((0.05-0.02)*2)) = 0.4459926977250626
-      assert.closeTo(gbm.pdf(1.5, 2), 0.4459926977250626, 1e-10)
-    })
-
-    it('should return log-normal density for mu=0, sigma=0.5, t=0.5, x=0.8', () => {
-      const gbm = new GeometricBrownianMotion(0, 0.5, 1)
-      // scipy: stats.lognorm.pdf(0.8, s=0.5*sqrt(0.5), scale=exp(-0.0625*0.5)) = 1.2721398281078873
-      assert.closeTo(gbm.pdf(0.8, 0.5), 1.2721398281078873, 1e-10)
-    })
   })
 
   describe('.covariogram()', () => {
-    it('should return exp(mu*(s+t)) * (exp(sigma^2*min(s,t)) - 1)', () => {
-      const gbm = new GeometricBrownianMotion(0.05, 0.2, 1)
-      // scipy: exp(0.05*(1+3)) * (exp(0.2**2*min(1,3)) - 1) → 0.049846392161234841
-      assert.closeTo(gbm.covariogram(1, 3), 0.049846392161234841, 1e-10)
-    })
-
     it('should be symmetric', () => {
       const gbm = new GeometricBrownianMotion(0.05, 0.2, 1)
       assert.closeTo(gbm.covariogram(1, 4), gbm.covariogram(4, 1), 1e-10)
@@ -894,15 +816,6 @@ describe('process.GeometricBrownianMotion', () => {
   })
 
   describe('.lnL()', () => {
-    it('should match the transition log-likelihood of a fixed path', () => {
-      const gbm = new GeometricBrownianMotion(0.1, 0.25, 0.5)
-      const path = [1.0, 1.2, 0.9, 1.5]
-      // mpmath mp.dps=50: sum of [Normal(drift, noise^2).logpdf(log(x_{i+1}/x_i)) - log(x_{i+1})]
-      // over the 3 steps, where drift = (mu-0.5*sigma^2)*dt, noise^2 = sigma^2*dt (the log-normal
-      // transition density's 1/x Jacobian) → -3.6824641101851229894621067377482732895915091716478
-      assert.closeTo(gbm.lnL(path), -3.682464110185123, 1e-9)
-    })
-
     it('should return -Infinity, not throw, when the path visits a non-positive state', () => {
       const gbm = new GeometricBrownianMotion(0.1, 0.25, 0.5)
       assert.strictEqual(gbm.lnL([1, -1]), -Infinity)
@@ -1040,20 +953,9 @@ describe('process.OrnsteinUhlenbeck', () => {
   })
 
   describe('.mean()', () => {
-    it('should return mu*(1 - exp(-theta*t)) for zero initial state', () => {
-      const ou = new OrnsteinUhlenbeck(2, 3, 1, 0.1)
-      // mpmath mp.dps=50: 3*(1-exp(-2)) → 2.593994150290162
-      assert.closeTo(ou.mean(1), 2.593994150290162, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const ou = new OrnsteinUhlenbeck(1, 5, 1, 0.1)
       assert.strictEqual(ou.mean(0), 0)
-    })
-
-    it('should approach mu as t -> infinity', () => {
-      const ou = new OrnsteinUhlenbeck(1, 4, 1, 0.1)
-      assert.closeTo(ou.mean(1000), 4, 1e-6)
     })
 
     it('should return NaN for t < 0', () => {
@@ -1070,22 +972,9 @@ describe('process.OrnsteinUhlenbeck', () => {
   })
 
   describe('.variance()', () => {
-    it('should return sigma^2*(1-exp(-2*theta*t))/(2*theta)', () => {
-      const ou = new OrnsteinUhlenbeck(2, 0, 0.5, 0.1)
-      // mpmath mp.dps=50: sigma^2*(1-exp(-2*theta*t))/(2*theta) = 0.25*(1-exp(-4))/4 → 0.06135527256945411
-      assert.closeTo(ou.variance(1), 0.06135527256945411, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const ou = new OrnsteinUhlenbeck(1, 0, 1, 1)
       assert.strictEqual(ou.variance(0), 0)
-    })
-
-    it('should approach stationary variance sigma^2/(2*theta) as t -> infinity', () => {
-      const theta = 2; const sigma = 0.5
-      const ou = new OrnsteinUhlenbeck(theta, 0, sigma, 0.1)
-      // exact rational: sigma^2/(2*theta) = 0.25/4 = 0.0625
-      assert.closeTo(ou.variance(1000), 0.0625, 1e-6)
     })
 
     it('should return NaN for t < 0', () => {
@@ -1104,33 +993,9 @@ describe('process.OrnsteinUhlenbeck', () => {
       const ou = new OrnsteinUhlenbeck(1, 0, 1, 1)
       assert(Number.isNaN(ou.pdf(0, -1)))
     })
-
-    it('should return Normal(mean(t), variance(t)) density for theta=1 mu=2 sigma=1 t=1 x=1', () => {
-      const ou = new OrnsteinUhlenbeck(1, 2, 1, 0.1)
-      // scipy: mu=2*(1-exp(-1)), var=(1-exp(-2))/2; stats.norm.pdf(1, mu, sqrt(var)) = 0.5596687594392821
-      assert.closeTo(ou.pdf(1, 1), 0.5596687594392821, 1e-10)
-    })
-
-    it('should return correct density for theta=2 mu=0 sigma=0.5 t=0.5 x=0', () => {
-      const ou = new OrnsteinUhlenbeck(2, 0, 0.5, 0.1)
-      // scipy: mu=0, var=0.25*(1-exp(-2))/4; stats.norm.pdf(0, 0, sqrt(var)) = 1.7161142135258760
-      assert.closeTo(ou.pdf(0, 0.5), 1.7161142135258760, 1e-10)
-    })
-
-    it('should return correct density for theta=0.5 mu=3 sigma=2 t=2 x=2', () => {
-      const ou = new OrnsteinUhlenbeck(0.5, 3, 2, 0.1)
-      // scipy: mu=3*(1-exp(-1)), var=4*(1-exp(-2))/1; stats.norm.pdf(2, mu, sqrt(var)) = 0.2141814469689605
-      assert.closeTo(ou.pdf(2, 2), 0.2141814469689605, 1e-10)
-    })
   })
 
   describe('.covariogram()', () => {
-    it('should return (sigma^2/2theta)*(exp(-theta*|t-s|) - exp(-theta*(t+s)))', () => {
-      const ou = new OrnsteinUhlenbeck(2, 0, 0.5, 0.1)
-      // scipy: (0.5**2/(2*2)) * (exp(-2*abs(3-1)) - exp(-2*(3+1))) → 0.0011237610163019791
-      assert.closeTo(ou.covariogram(1, 3), 0.0011237610163019791, 1e-10)
-    })
-
     it('should be symmetric', () => {
       const ou = new OrnsteinUhlenbeck(2, 0, 0.5, 0.1)
       assert.closeTo(ou.covariogram(1, 3), ou.covariogram(3, 1), 1e-10)
@@ -1185,16 +1050,6 @@ describe('process.OrnsteinUhlenbeck', () => {
   })
 
   describe('.lnL()', () => {
-    it('should match the transition log-likelihood of a fixed path', () => {
-      const ou = new OrnsteinUhlenbeck(0.8, 0.5, 0.6, 0.25)
-      const path = [1.0, 0.9, 0.6, 0.8]
-      // mpmath mp.dps=50: sum of Normal(x_i*decay + mu*(1-decay), noise^2).logpdf(x_{i+1}) over
-      // the 3 steps, where decay = exp(-theta*dt), noise^2 = sigma^2*(1-decay^2)/(2*theta) —
-      // the ONE-STEP transition constants, distinct from mean(t)/variance(t)'s elapsed-time
-      // decay exp(-theta*t) for arbitrary t → 0.47497249518150224285604569178811850409220342308943
-      assert.closeTo(ou.lnL(path), 0.47497249518150225, 1e-9)
-    })
-
     it('should have a mean per-step log-density matching the known transition law (CLT tolerance)', () => {
       const theta = 0.5
       const mu = 3
@@ -1439,14 +1294,6 @@ describe('process.BrownianBridge', () => {
   })
 
   describe('.variance()', () => {
-    it('should return sigma^2 * t * (T-t) / T for 0 < t < T', () => {
-      const sigma = 2
-      const T = 1
-      const bb = new BrownianBridge(sigma, T, 0.1)
-      // exact rational: sigma^2*t*(T-t)/T = 4*0.5*0.5/1 = 1
-      assert.closeTo(bb.variance(0.5), 1, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const bb = new BrownianBridge(1, 1, 0.1)
       assert.strictEqual(bb.variance(0), 0)
@@ -1469,13 +1316,6 @@ describe('process.BrownianBridge', () => {
   })
 
   describe('.covariogram()', () => {
-    it('should return sigma^2 * min(s,t) * (T - max(s,t)) / T for 0 <= s <= t <= T', () => {
-      const sigma = 2; const T = 1
-      const bb = new BrownianBridge(sigma, T, 0.1)
-      // exact rational: sigma^2*s*(T-t)/T = 4*0.25*0.5/1 = 0.5
-      assert.closeTo(bb.covariogram(0.25, 0.5), 0.5, 1e-10)
-    })
-
     it('should be symmetric', () => {
       const bb = new BrownianBridge(1, 2, 0.1)
       assert.closeTo(bb.covariogram(0.5, 1.5), bb.covariogram(1.5, 0.5), 1e-10)
@@ -1549,27 +1389,9 @@ describe('process.BrownianBridge', () => {
       assert.strictEqual(bb.pdf(1, 3), 0)
     })
 
-    it('should return Normal(0, sigma^2*t*(T-t)/T) density at x=0 for sigma=1, T=2, t=1', () => {
-      const bb = new BrownianBridge(1, 2, 0.1)
-      // scipy: stats.norm.pdf(0, 0, sqrt(1*1*1/2)) = 0.5641895835477563
-      assert.closeTo(bb.pdf(0, 1), 0.5641895835477563, 1e-10)
-    })
-
-    it('should return correct density at x=1 for sigma=1, T=2, t=1', () => {
-      const bb = new BrownianBridge(1, 2, 0.1)
-      // scipy: stats.norm.pdf(1, 0, sqrt(0.5)) = 0.20755374871029736
-      assert.closeTo(bb.pdf(1, 1), 0.20755374871029736, 1e-10)
-    })
-
     it('should be symmetric around 0 (pdf(-x, t) = pdf(x, t))', () => {
       const bb = new BrownianBridge(1, 2, 0.1)
       assert.closeTo(bb.pdf(-1, 1), bb.pdf(1, 1), 1e-10)
-    })
-
-    it('should return correct density at x=0 for sigma=2, T=4, t=2', () => {
-      const bb = new BrownianBridge(2, 4, 0.1)
-      // scipy: stats.norm.pdf(0, 0, sqrt(4*2*2/4)) = stats.norm.pdf(0, 0, 2) = 0.19947114020071635
-      assert.closeTo(bb.pdf(0, 2), 0.19947114020071635, 1e-10)
     })
   })
 
@@ -1744,24 +1566,6 @@ describe('process.AR1', () => {
       assert.strictEqual(ar1.variance(0), 0)
     })
 
-    it('should return sigma^2 at t = 1', () => {
-      const ar1 = new AR1(0.5, 2)
-      // exact rational: Var(X_1) = sigma^2 = 4
-      assert.closeTo(ar1.variance(1), 4, 1e-10)
-    })
-
-    it('should return sigma^2*(1+phi^2) at t = 2', () => {
-      const ar1 = new AR1(0.5, 2)
-      // exact rational: Var(X_2) = sigma^2*(1 + phi^2) = 4*(1+0.25) = 5
-      assert.closeTo(ar1.variance(2), 5, 1e-10)
-    })
-
-    it('should approach stationary variance sigma^2/(1-phi^2) as t -> infinity', () => {
-      const ar1 = new AR1(0.5, 1)
-      // exact rational: sigma^2/(1-phi^2) = 1/(1-0.25) = 4/3
-      assert.closeTo(ar1.variance(1000), 4 / 3, 1e-6)
-    })
-
     it('should return NaN for t < 0', () => {
       const ar1 = new AR1(0.5, 1)
       assert(Number.isNaN(ar1.variance(-1)))
@@ -1769,8 +1573,6 @@ describe('process.AR1', () => {
 
     it('should grow monotonically for |phi| > 1', () => {
       const ar1 = new AR1(1.5, 1)
-      // exact rational: Var(X_3) = sigma^2*(1 + phi^2 + phi^4) = 1 + 2.25 + 5.0625 = 8.3125
-      assert.closeTo(ar1.variance(3), 8.3125, 1e-10)
       assert(ar1.variance(10) > ar1.variance(5))
       assert(ar1.variance(20) > ar1.variance(10))
     })
@@ -1779,26 +1581,7 @@ describe('process.AR1', () => {
       // phi2 = 1 - 2e-14 lies just outside the 1e-14 special-case band; at
       // t = 1e-6, 1 - phi2^t previously rounded to exactly 0 (100% error)
       const ar1 = new AR1(Math.sqrt(1 - 2e-14), 1)
-      // mpmath mp.dps=50, untransformed sigma^2*(1-phi2^t)/(1-phi2) with the actual double
-      // phi2 = 0.99999999999998 (immune to cancellation at 50 digits): 1.0000000000000099999900...e-6
-      assert.closeTo(ar1.variance(1e-6), 1.00000000000001e-6, 1e-15)
       assert.isAbove(ar1.variance(1e-6), 0)
-    })
-
-    it('should stay accurate for near-unit-root phi and moderate fractional t', () => {
-      // phi2 = 1 - 1e-13; at t = 0.01 the old formula returned 0.009977827050997782
-      // (0.22% error) instead of the true value
-      const ar1 = new AR1(Math.sqrt(1 - 1e-13), 1)
-      // mpmath mp.dps=50, untransformed sigma^2*(1-phi2^t)/(1-phi2) with the actual double
-      // phi2 = 0.9999999999998999: 0.0100000000000004954950000000329...
-      assert.closeTo(ar1.variance(0.01), 0.010000000000000495, 1e-12)
-    })
-
-    it('should remain accurate for near-unit-root phi at integer t (regression guard)', () => {
-      const ar1 = new AR1(Math.sqrt(1 - 1e-13), 1)
-      // mpmath mp.dps=50, untransformed sigma^2*(1-phi2^t)/(1-phi2) with the actual double
-      // phi2 = 0.9999999999998999: 9.9999999999954955000000012024...
-      assert.closeTo(ar1.variance(10), 9.999999999995495, 1e-12)
     })
   })
 
@@ -1813,22 +1596,8 @@ describe('process.AR1', () => {
       assert(Number.isNaN(ar1.pdf(0, -1)))
     })
 
-    it('should return Normal(0, sigma^2) density at t = 1', () => {
-      const ar1 = new AR1(0.5, 1)
-      // scipy: stats.norm.pdf(0, 0, 1) = 0.3989422804014327
-      assert.closeTo(ar1.pdf(0, 1), 0.3989422804014327, 1e-10)
-    })
-
-    it('should return Normal(0, sigma^2*(1+phi^2)) density at t = 2', () => {
-      const ar1 = new AR1(0.5, 1)
-      // scipy: stats.norm.pdf(0, 0, sqrt(1.25)) = 0.3568248232305543
-      assert.closeTo(ar1.pdf(0, 2), 0.3568248232305543, 1e-10)
-    })
-
     it('should be symmetric around 0', () => {
       const ar1 = new AR1(0.5, 1)
-      // scipy: stats.norm.pdf(1, 0, sqrt(1.3125)) = 0.2379112029210874
-      assert.closeTo(ar1.pdf(1, 3), 0.2379112029210874, 1e-10)
       assert.closeTo(ar1.pdf(-1, 3), ar1.pdf(1, 3), 1e-10)
     })
   })
@@ -1841,21 +1610,7 @@ describe('process.AR1', () => {
 
     it('should be symmetric: covariogram(s, t) = covariogram(t, s)', () => {
       const ar1 = new AR1(0.5, 1)
-      // exact rational: Cov(X_2, X_3) = phi * Var(X_2) = 0.5 * (1 + 0.25) = 0.625
-      assert.closeTo(ar1.covariogram(2, 3), 0.625, 1e-10)
       assert.closeTo(ar1.covariogram(2, 3), ar1.covariogram(3, 2), 1e-10)
-    })
-
-    it('should return phi * Var(X_1) for s=1, t=2', () => {
-      const ar1 = new AR1(0.5, 1)
-      // exact rational: Cov(X_1, X_2) = phi^1 * Var(X_1) = 0.5 * 1 = 0.5
-      assert.closeTo(ar1.covariogram(1, 2), 0.5, 1e-10)
-    })
-
-    it('should return phi^2 * Var(X_1) for s=1, t=3', () => {
-      const ar1 = new AR1(0.5, 1)
-      // exact rational: Cov(X_1, X_3) = phi^2 * Var(X_1) = 0.25 * 1 = 0.25
-      assert.closeTo(ar1.covariogram(1, 3), 0.25, 1e-10)
     })
 
     it('should return NaN for s < 0', () => {
@@ -2062,12 +1817,6 @@ describe('process.Poisson', () => {
   })
 
   describe('.mean()', () => {
-    it('should return lambda*t', () => {
-      const pp = new ProcessPoisson(2, 0.5)
-      // exact rational: lambda*t = 2*3 = 6
-      assert.closeTo(pp.mean(3), 6, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const pp = new ProcessPoisson(2, 0.5)
       assert.strictEqual(pp.mean(0), 0)
@@ -2080,12 +1829,6 @@ describe('process.Poisson', () => {
   })
 
   describe('.variance()', () => {
-    it('should return lambda*t', () => {
-      const pp = new ProcessPoisson(2, 0.5)
-      // exact rational: lambda*t = 2*3 = 6
-      assert.closeTo(pp.variance(3), 6, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const pp = new ProcessPoisson(2, 0.5)
       assert.strictEqual(pp.variance(0), 0)
@@ -2122,32 +1865,9 @@ describe('process.Poisson', () => {
       const pp = new ProcessPoisson(1, 1)
       assert.strictEqual(pp.pdf(1, 0), 0)
     })
-
-    it('should return Poisson(lambda*t) PMF for lambda=2 t=1 x=2', () => {
-      const pp = new ProcessPoisson(2, 1)
-      // scipy: stats.poisson.pmf(2, 2) = 0.2706705664732255
-      assert.closeTo(pp.pdf(2, 1), 0.2706705664732255, 1e-10)
-    })
-
-    it('should return Poisson(lambda*t) PMF for lambda=0.5 t=3 x=1', () => {
-      const pp = new ProcessPoisson(0.5, 1)
-      // scipy: stats.poisson.pmf(1, 1.5) = 0.3346952402226447
-      assert.closeTo(pp.pdf(1, 3), 0.3346952402226447, 1e-10)
-    })
-
-    it('should return Poisson(lambda*t) PMF for lambda=3 t=2 x=5', () => {
-      const pp = new ProcessPoisson(3, 1)
-      // scipy: stats.poisson.pmf(5, 6) = 0.1606231410479798
-      assert.closeTo(pp.pdf(5, 2), 0.1606231410479798, 1e-10)
-    })
   })
 
   describe('.covariogram()', () => {
-    it('should return lambda * min(s, t)', () => {
-      const pp = new ProcessPoisson(3, 0.5)
-      assert.closeTo(pp.covariogram(2, 5), 3 * 2, 1e-10)
-    })
-
     it('should be symmetric', () => {
       const pp = new ProcessPoisson(3, 0.5)
       assert.closeTo(pp.covariogram(2, 5), pp.covariogram(5, 2), 1e-10)
@@ -2339,12 +2059,6 @@ describe('process.CompoundPoisson', () => {
   })
 
   describe('.mean()', () => {
-    it('should return lambda*t*E[J]', () => {
-      const cpp = new CompoundPoisson(new Normal(2, 1), 3, 1)
-      // exact rational: lambda*t*mu = 3*5*2 = 30
-      assert.closeTo(cpp.mean(5), 30, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const cpp = new CompoundPoisson(new Normal(2, 1), 3, 1)
       assert.strictEqual(cpp.mean(0), 0)
@@ -2357,12 +2071,6 @@ describe('process.CompoundPoisson', () => {
   })
 
   describe('.variance()', () => {
-    it('should return lambda*t*E[J^2]', () => {
-      const cpp = new CompoundPoisson(new Normal(2, 1), 3, 1)
-      // exact rational: lambda*t*(sigma^2 + mu^2) = 3*4*(1+4) = 60
-      assert.closeTo(cpp.variance(4), 60, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const cpp = new CompoundPoisson(new Normal(1, 1), 2, 1)
       assert.strictEqual(cpp.variance(0), 0)
@@ -2375,12 +2083,6 @@ describe('process.CompoundPoisson', () => {
   })
 
   describe('.covariogram()', () => {
-    it('should return lambda*E[J^2]*min(s,t)', () => {
-      const cpp = new CompoundPoisson(new Normal(2, 1), 3, 1)
-      // exact rational: lambda*E[J^2]*min(s,t) = 3*(1+4)*2 = 30
-      assert.closeTo(cpp.covariogram(2, 5), 30, 1e-10)
-    })
-
     it('should be symmetric', () => {
       const cpp = new CompoundPoisson(new Normal(2, 1), 3, 1)
       assert.closeTo(cpp.covariogram(2, 5), cpp.covariogram(5, 2), 1e-10)
@@ -2661,20 +2363,9 @@ describe('process.CoxIngersollRoss', () => {
   })
 
   describe('.mean()', () => {
-    it('should return theta*(1-exp(-kappa*t)) for zero initial state', () => {
-      const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
-      // mpmath mp.dps=50: 3*(1-exp(-2)) → 2.59399415029016
-      assert.closeTo(cir.mean(1), 2.59399415029016, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
       assert.strictEqual(cir.mean(0), 0)
-    })
-
-    it('should approach theta as t -> infinity', () => {
-      const cir = new CoxIngersollRoss(1, 4, 1, 0.1)
-      assert.closeTo(cir.mean(1000), 4, 1e-6)
     })
 
     it('should return NaN for t < 0', () => {
@@ -2691,22 +2382,9 @@ describe('process.CoxIngersollRoss', () => {
   })
 
   describe('.variance()', () => {
-    it('should return theta*sigma^2/(2*kappa)*(1-exp(-kappa*t))^2 for zero initial state', () => {
-      const cir = new CoxIngersollRoss(2, 3, 0.5, 0.1)
-      // mpmath mp.dps=50: 3*(0.25/(2*2))*(1-exp(-2))^2 → 0.14018345107791
-      assert.closeTo(cir.variance(1), 0.14018345107791, 1e-10)
-    })
-
     it('should return 0 at t=0', () => {
       const cir = new CoxIngersollRoss(1, 1, 1, 1)
       assert.strictEqual(cir.variance(0), 0)
-    })
-
-    it('should approach stationary variance theta*sigma^2/(2*kappa) as t -> infinity', () => {
-      const kappa = 2; const theta = 3; const sigma = 0.5
-      const cir = new CoxIngersollRoss(kappa, theta, sigma, 0.1)
-      // exact rational: theta*sigma^2/(2*kappa) = 3*0.25/4 = 0.1875
-      assert.closeTo(cir.variance(1000), 0.1875, 1e-6)
     })
 
     it('should return NaN for t < 0', () => {
@@ -2776,24 +2454,6 @@ describe('process.CoxIngersollRoss', () => {
       assert.strictEqual(cir.pdf(0, 0.5), 0)
     })
 
-    it('should return Gamma density for x=0.5, kappa=2, theta=3, sigma=1, t=0.5', () => {
-      const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
-      // alpha=12, scale=0.5/2*(1-exp(-1)); Python3 math: gamma_pdf = 0.002130824749883
-      assert.closeTo(cir.pdf(0.5, 0.5), 0.002130824749883, 1e-10)
-    })
-
-    it('should return Gamma density for x=2.0, kappa=2, theta=3, sigma=1, t=0.5', () => {
-      const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
-      // alpha=12, scale=0.5/2*(1-exp(-1)); Python3 math: gamma_pdf = 0.674442782399143
-      assert.closeTo(cir.pdf(2.0, 0.5), 0.674442782399143, 1e-10)
-    })
-
-    it('should return Gamma density for x=1.5, kappa=2, theta=3, sigma=1, t=1', () => {
-      const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
-      // alpha=12, scale=0.5/2*(1-exp(-2)); Python3 math: gamma_pdf = 0.201734321913609
-      assert.closeTo(cir.pdf(1.5, 1), 0.201734321913609, 1e-10)
-    })
-
     it('should be stable after advancing the simulation', () => {
       const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
       const before = cir.pdf(1.0, 0.5)
@@ -2820,20 +2480,10 @@ describe('process.CoxIngersollRoss', () => {
 
     it('should equal variance at s = t', () => {
       const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
-      // Python3 math: cov(2,2) = variance(2) = 0.722778138637826
+      // mpmath mp.dps=50: theta*sigma^2/(2*kappa)*(1-exp(-kappa*t))^2 at t=2 ->
+      // 0.72277813863782561343853900993447378244661507377008. Documentation only — the assertion
+      // below is the structural cov(t,t) = variance(t) identity, not a reference-value check.
       assert.closeTo(cir.covariogram(2, 2), cir.variance(2), 1e-10)
-    })
-
-    it('should return correct value for s=1, t=3, kappa=2, theta=3, sigma=1', () => {
-      const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
-      // theta*sigma2OverKappa/2*(1-exp(-2))^2*exp(-4); Python3 math: 0.010270197872478
-      assert.closeTo(cir.covariogram(1, 3), 0.010270197872478, 1e-10)
-    })
-
-    it('should return correct value for s=0.5, t=2, kappa=2, theta=3, sigma=1', () => {
-      const cir = new CoxIngersollRoss(2, 3, 1, 0.1)
-      // Python3 math: 0.014920303192111
-      assert.closeTo(cir.covariogram(0.5, 2), 0.014920303192111, 1e-10)
     })
 
     it('should return 0 at s=0 or t=0', () => {
@@ -3027,21 +2677,9 @@ describe('process.RandomWalk', () => {
   })
 
   describe('.mean()', () => {
-    it('should return t*(2p-1) for biased walk', () => {
-      const rw = new RandomWalk(0.7)
-      // exact rational: t*(2p-1) = 5*(2*0.7-1) = 5*0.4 = 2
-      assert.closeTo(rw.mean(5), 2, 1e-10)
-    })
-
     it('should return 0 for symmetric walk (p=0.5)', () => {
       const rw = new RandomWalk(0.5)
       assert.strictEqual(rw.mean(10), 0)
-    })
-
-    it('should return negative mean for p < 0.5', () => {
-      const rw = new RandomWalk(0.3)
-      // exact rational: t*(2p-1) = 4*(0.6-1) = 4*(-0.4) = -1.6
-      assert.closeTo(rw.mean(4), -1.6, 1e-10)
     })
 
     it('should return 0 at t = 0', () => {
@@ -3056,18 +2694,6 @@ describe('process.RandomWalk', () => {
   })
 
   describe('.variance()', () => {
-    it('should return 4p(1-p)*t for symmetric walk', () => {
-      const rw = new RandomWalk(0.5)
-      // exact rational: 4*0.5*0.5*10 = 10
-      assert.closeTo(rw.variance(10), 10, 1e-10)
-    })
-
-    it('should return 4p(1-p)*t for biased walk', () => {
-      const rw = new RandomWalk(0.7)
-      // exact rational: 4*0.7*0.3*5 = 4.2
-      assert.closeTo(rw.variance(5), 4.2, 1e-10)
-    })
-
     it('should be reduced by bias (p != 0.5 has less variance than p = 0.5)', () => {
       const sym = new RandomWalk(0.5)
       const biased = new RandomWalk(0.3)
@@ -3122,30 +2748,6 @@ describe('process.RandomWalk', () => {
       assert.strictEqual(rw.pdf(1, 0), 0)
     })
 
-    it('should return exact binomial PMF for p=0.5, t=4, x=0', () => {
-      const rw = new RandomWalk(0.5)
-      // exact rational: C(4,2)*0.5^4 = 6/16 = 0.375
-      assert.closeTo(rw.pdf(0, 4), 0.375, 1e-10)
-    })
-
-    it('should return exact binomial PMF for p=0.5, t=4, x=2', () => {
-      const rw = new RandomWalk(0.5)
-      // exact rational: C(4,3)*0.5^4 = 4/16 = 0.25
-      assert.closeTo(rw.pdf(2, 4), 0.25, 1e-10)
-    })
-
-    it('should return exact binomial PMF for p=0.6, t=3, x=1', () => {
-      const rw = new RandomWalk(0.6)
-      // exact rational: C(3,2)*0.6^2*0.4 = 3*0.36*0.4 = 0.432
-      assert.closeTo(rw.pdf(1, 3), 0.432, 1e-10)
-    })
-
-    it('should return exact binomial PMF for p=0.7, t=5, x=3', () => {
-      const rw = new RandomWalk(0.7)
-      // exact rational: C(5,4)*0.7^4*0.3 = 5*0.2401*0.3 = 0.36015
-      assert.closeTo(rw.pdf(3, 5), 0.36015, 1e-10)
-    })
-
     it('should sum to 1 over all reachable states at t=6', () => {
       const rw = new RandomWalk(0.4)
       let total = 0
@@ -3156,18 +2758,6 @@ describe('process.RandomWalk', () => {
   })
 
   describe('.covariogram()', () => {
-    it('should return 4p(1-p)*min(s,t) for symmetric walk', () => {
-      const rw = new RandomWalk(0.5)
-      // exact rational: 4*0.5*0.5*min(3,5) = 3
-      assert.closeTo(rw.covariogram(3, 5), 3, 1e-10)
-    })
-
-    it('should return 4p(1-p)*min(s,t) for biased walk', () => {
-      const rw = new RandomWalk(0.7)
-      // exact rational: 4*0.7*0.3*min(2,4) = 4*0.21*2 = 1.68
-      assert.closeTo(rw.covariogram(2, 4), 1.68, 1e-10)
-    })
-
     it('should be symmetric', () => {
       const rw = new RandomWalk(0.7)
       assert.closeTo(rw.covariogram(2, 4), rw.covariogram(4, 2), 1e-10)
@@ -3239,17 +2829,6 @@ describe('process.RandomWalk', () => {
       const marginal = rw.marginal(4)
       assert.strictEqual(marginal.pdf(6), 0)
       assert.strictEqual(marginal.pdf(-6), 0)
-    })
-
-    it('should return a nonzero pdf at the exact support boundary', () => {
-      const p = 0.6
-      const n = 4
-      const rw = new RandomWalk(p)
-      const marginal = rw.marginal(n)
-      // exact rational: pdf(n) is the all-+1-steps walk, probability p^n
-      assert.closeTo(marginal.pdf(n), Math.pow(p, n), 1e-10)
-      // exact rational: pdf(-n) is the all--1-steps walk, probability (1-p)^n
-      assert.closeTo(marginal.pdf(-n), Math.pow(1 - p, n), 1e-10)
     })
 
     it('should invert cdf via quantile', () => {
@@ -3393,7 +2972,30 @@ describe('process.RandomWalk', () => {
     it('should succeed at 3 states (the minimum length where p_hat can land strictly inside (0,1))', () => {
       const fitted = RandomWalk.fit([0, 1, 0])
       assert.instanceOf(fitted, RandomWalk)
+      // exact rational: p_hat is the fraction of +1 steps, and [0, 1, 0] has increments
+      // [+1, -1], so p_hat = 1/2. Stays inline rather than moving to process-cases.js because
+      // fit() is a static factory, not an instance method the case file's shape can express.
       assert.strictEqual(fitted.p.p, 0.5)
+    })
+  })
+})
+
+// Externally-sourced reference values for the analytical methods, defined in ./process-cases.js.
+// Consumed by a plain inline loop rather than a shared runner module — see that file's header for
+// why a dist-runner.js-style abstraction is not proportionate at this scale (#1221).
+describe('process reference values', () => {
+  processCases.forEach(({ name, ctor: Ctor, refs }) => {
+    describe(name, () => {
+      refs.forEach(({ should, params, method, args, chain, chainArgs, expected, tol, source }) => {
+        // The method name is part of the title because `should` alone is not unique: Poisson's
+        // mean(t) and variance(t) are both "return lambda*t", and the per-method describe() blocks
+        // that used to disambiguate them are gone.
+        it(`${method}() should ${should}`, () => {
+          const proc = new Ctor(...params())
+          const value = proc[method](...args)
+          assert.closeTo(chain ? value[chain](...chainArgs) : value, expected, tol, source)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

Extracts the 71 externally-sourced reference values that were inlined across `test/process.js` (3399 lines) into a structured `test/process-cases.js`, consumed by an inline loop. Reviewing them side by side is what surfaced four defect families that were invisible one assertion at a time — including a provenance comment that described a computation producing a *different number* than the literal it sat above, green in CI since the day it was written.

Closes #1221

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 9642 passing, all four nyc thresholds met)
- [x] `npm run typecheck` passes
- [x] Tests added or updated for changed behavior
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — _N/A, no new distribution_
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — _N/A_
- [x] `CHANGELOG.md` updated under `## [Unreleased]` — _correctly skipped; `CLAUDE.md` exempts test-only changes_
- [x] Production-code diff is under ~400 lines (tests excluded) — **zero**; `git diff origin/main...HEAD -- src/` is empty

## Design decisions

**No shared runner module.** The issue explicitly asked to decide and document this. `test/dist-runner.js` exists because *four* `dist-shard-*.js` files consume it to spread 145+ distributions across `mocha --parallel` workers. There is one process test file, no sharding need, and 71 values — a runner would be an abstraction boundary with exactly one caller. Every other structured case file in `test/` (`precision-continuous.js`, `precision-discrete.js`, `precision-special.js`, `precision-summary-stats.js`) pairs a plain array with an inline `forEach`. The rationale, and the condition under which to revisit it, is recorded in the new file's header — where someone about to build a runner would actually look.

**No ADR**, deliberately. `CLAUDE.md` scopes ADRs to base-class public API, module export structure, cross-cutting conventions, and dependencies — explicitly *not* implementation-technique choices. None of the four existing `precision-*.js` case files has one. Reviewers who disagree should say so; this was a judgement call, not an oversight. Documented instead in `solutions/testing/2026-08-01-1617-inline-provenance-comments-drift-from-their-literals.md`.

## Non-trivial changes

Despite the zero-line production diff, these warrant a look:

- **`test/process-cases.js`** — GBM `pdf(0.8, 0.5)` provenance said `scale=exp(-0.0625*0.5)`, which evaluates to **1.2172975135116265**, not the asserted **1.2721398281078873**. The log-mean is `(mu - sigma^2/2)*t = (0 - 0.125)*0.5 = -0.0625`, so the scale is `exp(-0.0625)`. The literal was always correct; only the stated derivation was wrong. Inherited verbatim from the original inline comment.
- **`test/process-cases.js`** — six CIR values cited `// Python3 math:`, which is float64 stdlib arithmetic and not one of the three tools `CLAUDE.md` sanctions (mpmath at `mp.dps=50`, scipy, R), so they carried no independent verification. Re-derived from CIR's textbook `x0 = 0` Gamma marginal — `Gamma(2*kappa*theta/sigma^2, scale = sigma^2*(1-exp(-kappa*t))/(2*kappa))` — and from `Cov(X_s,X_t) = Var(X_min)*exp(-kappa*|t-s|)`. Five asserted literals moved from 13-significant-digit truncations to correctly-rounded float64; all remain far inside the unchanged `1e-10` tolerance.
- **`test/process-cases.js`** — five values had *no* provenance at all (former `test/process.js:537, 1056, 2148, 2677, 3396`); each gained one.
- **`test/process-cases.js`** — the three AR1 near-unit-root cancellation guards keep their tighter `1e-15`/`1e-12` tolerances and their derivation from the *untransformed* `sigma^2*(1-phi2^t)/(1-phi2)` at 50 digits, deliberately not from the `expm1`/`log1p` reformulation they guard.
- **`test/process.js`** — the generated title includes the method name because `should` alone is not unique: Poisson's `mean(t)` and `variance(t)` are both "return lambda*t", and the per-method `describe()` blocks that used to disambiguate them are gone.

**Verification.** All 72 values were independently re-derived at `mp.dps=50` from each process's textbook marginal/transition law — Gaussian for BM/OU/BB/AR1, log-normal for GBM, Poisson for the counting process, Gamma for CIR, shifted binomial for RandomWalk — *before* any were moved. 73 checks, 0 outside tolerance. That is what made it safe to conclude the GBM discrepancy was a comment bug rather than a value bug.

**Coverage neutrality is proven, not assumed.** `nyc` measures `src/**` only, and the `src/process` coverage table is byte-identical before and after, so no branch lost its only exerciser. Test count: 467 → 538 with both old and new assertions running in parallel (the equivalence proof) → 472 after removing the 66 now-duplicated blocks.

## Known limitation

`test/process.js` scores **9.09** on CodeScene, not 10.0. The sole smell is module size — this branch reduces it from 478 functions to 412, but clearing it entirely requires splitting the file per process, a separate refactor analogous to the `dist-base.js` split in #1072. Out of scope here. `test/process-cases.js` scores 10.0.

## Follow-ups filed

- #1288 — audit the suite for mpmath-labelled literals truncated below float64
- #1289 — `CompoundPoisson.marginal()` reference is computed with `ran.dist` code rather than an external tool
- #1290 — process `.fit()` tests assert on internal `.p` instead of the public `params()` accessor
- #1291 — document the data-file-plus-inline-loop test pattern in `CLAUDE.md`

## Comprehension checklist

- [ ] I can explain what this code does without reading line-by-line
- [ ] I understand *why* this approach was chosen over alternatives
- [ ] WHY comments are present where the logic is non-obvious
- [ ] Tests verify observable behavior, not internal state
- [ ] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/process.js`**: 66 fully-redundant `it(...)` blocks deleted and 4 partially edited (a reference assertion removed, the structural assertion beside it kept). File shrinks 3399 → 2996 lines.
- **`test/process.js`**: `RandomWalk.fit([0,1,0])` stays hand-written — it is a static factory, not `new Ctor(...)[method](...)` — and gained the provenance comment it was missing.
- **`test/process.js`**: the `CompoundPoisson.marginal()` block and the RandomWalk sum-to-1 loop stay hand-written; neither has a literal to extract (see #1289).
- **`solutions/testing/2026-08-01-1617-...md`**: new solution document recording the root cause and prevention strategy.

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_015M78q7JEKo1XYTy7kiRUad)_