### PR TITLE
CompoundPoisson.marginal() test reference sourced from mpmath

### DIFF
--- a/test/process.js
+++ b/test/process.js
@@ -2311,19 +2311,16 @@ describe('process.CompoundPoisson', () => {
       // pdf(x) = sum_{n=1}^{inf} Poisson(lambda*t).pdf(n) * Gamma(n*alpha, beta).pdf(x) and
       // cdf(x) = exp(-lambda*t)*(x>=0) + sum_{n=1}^{inf} Poisson(lambda*t).pdf(n) * Gamma(n*alpha, beta).cdf(x).
       // The series is truncated at N = 30, where the Poisson(3) tail 1 - cdf(30) is far below
-      // 1e-12, so truncation error is negligible next to the 1e-8 comparison tolerance.
-      const mu = marginal.mean()
-      const lambdaT = lambda * t
-      const poissonN = new Poisson(lambdaT)
-      const N = 30
-      let pdfRef = 0
-      let cdfRef = Math.exp(-lambdaT) * (mu >= 0 ? 1 : 0)
-      for (let n = 1; n <= N; n++) {
-        const weight = poissonN.pdf(n)
-        const gammaN = new Gamma(n * alpha, beta)
-        pdfRef += weight * gammaN.pdf(mu)
-        cdfRef += weight * gammaN.cdf(mu)
-      }
+      // 1e-12, so truncation error is negligible next to the comparison tolerance.
+      // mu = lambda*t*alpha/beta = 2*1.5*2/3 (exact rational) = 2.
+      const mu = 2
+      // mpmath mp.dps=50: sum_{n=1}^{30} Poisson(3).pmf(n) * Gamma(2n, scale=1/3).pdf(2), with
+      // Gamma.pdf/cdf and Poisson.pmf reimplemented from scratch via mpmath's own
+      // exp/log/loggamma/gammainc -> 0.26858960310934577112955117114307537913148585514259
+      const pdfRef = 0.26858960310934576
+      // mpmath mp.dps=50: exp(-3) + sum_{n=1}^{30} Poisson(3).pmf(n) * Gamma(2n, scale=1/3).cdf(2)
+      // -> 0.56348946343750803140234169015766437926068330168143
+      const cdfRef = 0.563489463437508
       assert.closeTo(marginal.pdf(mu), pdfRef, 1e-8)
       assert.closeTo(marginal.cdf(mu), cdfRef, 1e-8)
     })


### PR DESCRIPTION
## Summary

Replaces the `CompoundPoisson.marginal()` interior-point test's runtime-computed reference values (built from `ran.dist.Poisson`/`ran.dist.Gamma`) with literals independently derived via mpmath at `mp.dps=50`, per CLAUDE.md's Testing Conventions rule against self-referential `closeTo` references.

Closes #1289

## Non-trivial changes

- **`test/process.js`**: The `pdfRef`/`cdfRef` values in the `'should return a Tweedie marginal whose pdf/cdf match the exact Poisson-gamma mixture'` test were previously computed at runtime by summing `new Poisson(lambdaT).pdf(n) * new Gamma(n*alpha, beta).pdf/cdf(mu)` over 30 terms — using ranjs's own `Poisson`/`Gamma` classes as the "independent" reference, which could let a shared bug in ranjs's incomplete-gamma machinery cancel between expected and actual. Replaced with float64 literals computed by a standalone mpmath script that reimplements the Poisson pmf and Gamma pdf/cdf from mpmath's own `exp`/`log`/`loggamma`/`gammainc` (no ranjs dependency), with provenance comments quoting the 50-digit mpmath value each literal rounds from. `mu` (the evaluation point, `= lambda*t*alpha/beta = 2`) is now a hardcoded exact-rational literal instead of `marginal.mean()`, decoupling the probe location from the code under test.

## Code Health

- `test/process.js` scores 9.09 (Green), flagged only for "Number of Functions in a Single Module" (420 functions) — a pre-existing file-level smell on this ~2600-line test file, unrelated to this change (which reduces line count by 3). Splitting the file is a major cross-file refactor out of scope for this fix; out of scope per this issue's stated boundaries.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green, coverage thresholds met — 9752 passing)
- [x] `npm run typecheck` passes
- [x] Tests updated (reference-value provenance only; no new test cases)
- [ ] `CHANGELOG.md` updated — not needed, test-only change (CLAUDE.md: "test-only changes... do not need a changelog entry")
- [x] Production-code diff is under ~400 lines (tests excluded) — no `src/` diff at all

<details>
<summary>Trivial changes</summary>

- **`test/process.js`**: Comment wording tightened (removed a stale `1e-8` tolerance reference from a comment that now sits above literals rather than a runtime loop).

</details>

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_012pTiLCEvkn7AFJAmEk9szp)_