### PR TITLE
Process and distribution fit tests migrated to params() accessor

### DIFF
--- a/test/dist-base-fit-1.js
+++ b/test/dist-base-fit-1.js
@@ -226,7 +226,8 @@ describe('dist', () => {
         // Component label-switching makes (weight, rate) pairs non-identifiable; use the mixture
         // mean E[X] = Σ w_i / λ_i — a sufficient statistic invariant under that permutation.
         const sampleMean = data.reduce((s, x) => s + x, 0) / data.length
-        const fittedMean = result.params().weights.reduce((s, w, i) => s + w / result.params().rates[i], 0)
+        const { weights, rates } = result.params()
+        const fittedMean = weights.reduce((s, w, i) => s + w / rates[i], 0)
         assert(Math.abs(fittedMean - sampleMean) < 0.2)
       })
 

--- a/test/dist-base-fit-1.js
+++ b/test/dist-base-fit-1.js
@@ -82,7 +82,7 @@ describe('dist', () => {
         assert(pdfCalls > data.length, `fit() made only ${pdfCalls} _pdf calls, expected the optimizer to run`)
         assert(pdfCalls < 200000, `fit() made ${pdfCalls} _pdf calls, expected well under 200000`)
         assert(result instanceof dist.DoublyNoncentralF)
-        assert(Number.isFinite(result.p.d1) && Number.isFinite(result.p.d2))
+        assert(Number.isFinite(result.params().d1) && Number.isFinite(result.params().d2))
         // Confirms the bounded search still improves on the initial guess rather than merely
         // terminating early with an unoptimized fit.
         const init = new dist.DoublyNoncentralF(...dist.DoublyNoncentralF._fitInit(data))
@@ -142,7 +142,7 @@ describe('dist', () => {
       it('Pareto.fit should recover xmin close to min(data)', () => {
         const data = [1.5, 2.0, 3.1, 1.8, 2.5]
         const result = dist.Pareto.fit(data)
-        assert(Math.abs(result.p.xmin - 1.5) < 1e-3)
+        assert(Math.abs(result.params().xmin - 1.5) < 1e-3)
       })
 
       it('Pareto.fit should recover alpha close to closed-form MLE', () => {
@@ -150,7 +150,7 @@ describe('dist', () => {
         const xmin = Math.min(...data)
         const alphaExpected = data.length / data.reduce((s, x) => s + Math.log(x / xmin), 0)
         const result = dist.Pareto.fit(data)
-        assert(Math.abs(result.p.alpha - alphaExpected) < 0.05)
+        assert(Math.abs(result.params().alpha - alphaExpected) < 0.05)
       })
 
       it('InvalidDiscrete.fit should return an InvalidDiscrete instance', () => {
@@ -226,7 +226,7 @@ describe('dist', () => {
         // Component label-switching makes (weight, rate) pairs non-identifiable; use the mixture
         // mean E[X] = Σ w_i / λ_i — a sufficient statistic invariant under that permutation.
         const sampleMean = data.reduce((s, x) => s + x, 0) / data.length
-        const fittedMean = result.p.weights.reduce((s, w, i) => s + w / result.p.rates[i], 0)
+        const fittedMean = result.params().weights.reduce((s, w, i) => s + w / result.params().rates[i], 0)
         assert(Math.abs(fittedMean - sampleMean) < 0.2)
       })
 
@@ -245,22 +245,22 @@ describe('dist', () => {
         const data = new dist.BorelTanner(0.5, 3).seed(42).sample(200)
         const result = dist.BorelTanner.fit(data)
         assert(result instanceof dist.BorelTanner)
-        assert(result.p.mu >= 0 && result.p.mu < 1 && result.p.n > 0)
-        assert(Number.isFinite(result.pdf(result.p.n)) && result.pdf(result.p.n) > 0)
+        assert(result.params().mu >= 0 && result.params().mu < 1 && result.params().n > 0)
+        assert(Number.isFinite(result.pdf(result.params().n)) && result.pdf(result.params().n) > 0)
       })
 
       it('Borel._fitInit degenerate: constant data (mean = 1) clamps mu to 0', () => {
         // mean > 1 branch false: data all equal 1 → mean = 1 → mu = 0
         const result = dist.Borel.fit([1, 1, 1, 1, 1])
         assert(result instanceof dist.Borel)
-        assert(result.p.mu === 0)
+        assert(result.params().mu === 0)
       })
 
       it('BorelTanner._fitInit degenerate: mean ≤ n clamps mu to 0', () => {
         // mean > n branch false: all values equal n (= minimum) → mean = n → mu = 0
         const result = dist.BorelTanner.fit([3, 3, 3, 3, 3])
         assert(result instanceof dist.BorelTanner)
-        assert(result.p.mu === 0 && result.p.n === 3)
+        assert(result.params().mu === 0 && result.params().n === 3)
       })
 
       it('PolyaAeppli._fitInit fallback: variance ≤ mean seeds theta=0.5', () => {
@@ -274,7 +274,7 @@ describe('dist', () => {
         const data = new dist.Erlang(3, 1).seed(20).sample(200)
         const result = dist.Erlang.fit(data)
         assert(result instanceof dist.Erlang)
-        assert.strictEqual(result.p.k, 3)
+        assert.strictEqual(result.params().k, 3)
       })
 
       it('Beta.fit should not converge to near-singular alpha or beta', () => {
@@ -284,16 +284,16 @@ describe('dist', () => {
         const data = new dist.Beta(0.5, 0.5).seed(42).sample(200)
         const result = dist.Beta.fit(data)
         assert(result instanceof dist.Beta)
-        assert(result.p.alpha > 0.3 && result.p.alpha < 1.5, `alpha ${result.p.alpha} out of expected range`)
-        assert(result.p.beta > 0.3 && result.p.beta < 1.5, `beta ${result.p.beta} out of expected range`)
+        assert(result.params().alpha > 0.3 && result.params().alpha < 1.5, `alpha ${result.params().alpha} out of expected range`)
+        assert(result.params().beta > 0.3 && result.params().beta < 1.5, `beta ${result.params().beta} out of expected range`)
       })
 
       it('BetaPrime.fit should not converge to near-singular alpha or beta', () => {
         const data = new dist.BetaPrime(1.5, 2.0).seed(42).sample(200)
         const result = dist.BetaPrime.fit(data)
         assert(result instanceof dist.BetaPrime)
-        assert(result.p.alpha > 0.5 && result.p.alpha < 8, `alpha ${result.p.alpha} out of expected range`)
-        assert(result.p.beta > 0.5 && result.p.beta < 8, `beta ${result.p.beta} out of expected range`)
+        assert(result.params().alpha > 0.5 && result.params().alpha < 8, `alpha ${result.params().alpha} out of expected range`)
+        assert(result.params().beta > 0.5 && result.params().beta < 8, `beta ${result.params().beta} out of expected range`)
       })
 
       it('PERT._fitPenalty should return 0', () => {
@@ -306,11 +306,11 @@ describe('dist', () => {
         assert(result instanceof dist.BetaRectangular)
         // alpha/beta > 0.5 ensures the optimizer did not converge to the near-singularity at 0.
         // Without the _fitPenalty log-barrier the optimizer can return alpha/beta < 0.01.
-        assert(result.p.alpha > 0.5 && result.p.alpha < 10, `alpha ${result.p.alpha} out of range`)
-        assert(result.p.beta > 0.5 && result.p.beta < 10, `beta ${result.p.beta} out of range`)
-        assert(result.p.theta > 0.1 && result.p.theta <= 1)
-        assert(Math.abs(result.p.a - 0) < 0.3)
-        assert(Math.abs(result.p.b - 4) < 0.3)
+        assert(result.params().alpha > 0.5 && result.params().alpha < 10, `alpha ${result.params().alpha} out of range`)
+        assert(result.params().beta > 0.5 && result.params().beta < 10, `beta ${result.params().beta} out of range`)
+        assert(result.params().theta > 0.1 && result.params().theta <= 1)
+        assert(Math.abs(result.params().a - 0) < 0.3)
+        assert(Math.abs(result.params().b - 4) < 0.3)
       })
 
       it('BetaRectangular.k should reflect its 5 free parameters, not the 2 inherited from Beta', () => {
@@ -334,8 +334,8 @@ describe('dist', () => {
         const data = new dist.BetaRectangular(0.8, 0.8, 0.6, 0, 10).seed(7).sample(300)
         const result = dist.BetaRectangular.fit(data)
         assert(result instanceof dist.BetaRectangular)
-        assert(result.p.alpha > 0.3, `alpha ${result.p.alpha} is near-singular`)
-        assert(result.p.beta > 0.3, `beta ${result.p.beta} is near-singular`)
+        assert(result.params().alpha > 0.3, `alpha ${result.params().alpha} is near-singular`)
+        assert(result.params().beta > 0.3, `beta ${result.params().beta} is near-singular`)
       })
 
       it('Weibull._fitInit should handle constant data', () => {

--- a/test/dist-base-fit-2.js
+++ b/test/dist-base-fit-2.js
@@ -67,7 +67,7 @@ describe('dist', () => {
         const data = new dist.F(10, 20).seed(42).sample(200)
         const result = dist.F.fit(data)
         assert(result instanceof dist.F)
-        assert(result.p.d1 > 0 && result.p.d2 > 0)
+        assert(result.params().d1 > 0 && result.params().d2 > 0)
         assert(Number.isFinite(result.pdf(1)) && result.pdf(1) > 0)
       })
 
@@ -77,7 +77,7 @@ describe('dist', () => {
         const result = dist.F.fit(data)
         assert(result instanceof dist.F)
         // Profile MLE has strictly higher lnL than the moment-seed answer
-        assert(new dist.F(result.p.d1, result.p.d2).lnL(data) > new dist.F(4, 14).lnL(data))
+        assert(new dist.F(result.params().d1, result.params().d2).lnL(data) > new dist.F(4, 14).lnL(data))
       })
 
       it('FisherZ._fitPenalty should return 0', () => {
@@ -88,7 +88,7 @@ describe('dist', () => {
         const data = new dist.FisherZ(10, 20).seed(42).sample(200)
         const result = dist.FisherZ.fit(data)
         assert(result instanceof dist.FisherZ)
-        assert(result.p.d1 > 0 && result.p.d2 > 0)
+        assert(result.params().d1 > 0 && result.params().d2 > 0)
         assert(Number.isFinite(result.pdf(0)) && result.pdf(0) > 0)
       })
 
@@ -119,7 +119,7 @@ describe('dist', () => {
         const result = dist.Degenerate.fit([5, 5, 5])
         assert(result instanceof dist.Degenerate)
         // constant data ⇒ exact point-mass location, no MLE drift
-        assert(Math.abs(result.p.x0 - 5) < 1e-9)
+        assert(Math.abs(result.params().x0 - 5) < 1e-9)
       })
 
       it('Soliton._fitInit should lower-bound N by the largest observation', () => {
@@ -169,29 +169,29 @@ describe('dist', () => {
         const data = new dist.BoundedPareto(2, 20, 3).seed(42).sample(200)
         const result = dist.BoundedPareto.fit(data)
         assert(result instanceof dist.BoundedPareto)
-        assert(Math.abs(result.p.L - 2) < 0.5)
+        assert(Math.abs(result.params().L - 2) < 0.5)
         // MLE for H converges to max(data) since likelihood decreases for any H > max(data)
-        assert(result.p.H >= Math.max(...data))
-        assert(Math.abs(result.p.alpha - 3) < 0.8)
+        assert(result.params().H >= Math.max(...data))
+        assert(Math.abs(result.params().alpha - 3) < 0.8)
       })
 
       it('Champernowne.fit should recover alpha and x0 and return a valid lambda', () => {
         const data = new dist.Champernowne(1, 0, 2).seed(42).sample(200)
         const result = dist.Champernowne.fit(data)
         assert(result instanceof dist.Champernowne)
-        assert(Math.abs(result.p.alpha - 1) < 0.4)
+        assert(Math.abs(result.params().alpha - 1) < 0.4)
         // lambda is poorly identified near 0 from n=200; check valid range instead
-        assert(result.p.lambda >= 0 && result.p.lambda < 1)
-        assert(Math.abs(result.p.x0 - 2) < 0.5)
+        assert(result.params().lambda >= 0 && result.params().lambda < 1)
+        assert(Math.abs(result.params().x0 - 2) < 0.5)
       })
 
       it('ExponentiallyModifiedGaussian.fit should recover mu, sigma, and lambda close to planted values', () => {
         const data = new dist.ExponentiallyModifiedGaussian(1, 2, 0.5).seed(42).sample(500)
         const result = dist.ExponentiallyModifiedGaussian.fit(data)
         assert(result instanceof dist.ExponentiallyModifiedGaussian)
-        assert(Math.abs(result.p.mu - 1) < 1.5)
-        assert(Math.abs(result.p.sigma - 2) < 1)
-        assert(Math.abs(result.p.lambda - 0.5) < 0.4)
+        assert(Math.abs(result.params().mu - 1) < 1.5)
+        assert(Math.abs(result.params().sigma - 2) < 1)
+        assert(Math.abs(result.params().lambda - 0.5) < 0.4)
       })
 
       it('ExponentiallyModifiedGaussian._fitInit should return the 1e-6-clamped params for constant data', () => {
@@ -237,16 +237,16 @@ describe('dist', () => {
         const data = new dist.NoncentralT(5, 1).seed(42).sample(300)
         const result = dist.NoncentralT.fit(data)
         assert(result instanceof dist.NoncentralT)
-        assert(Math.abs(result.p.nu - 5) <= 1)
-        assert(Math.abs(result.p.mu - 1) < 0.3)
+        assert(Math.abs(result.params().nu - 5) <= 1)
+        assert(Math.abs(result.params().mu - 1) < 0.3)
       })
 
       it('DoublyNoncentralChi2.fit should recover total df and noncentrality close to planted values', () => {
         const data = new dist.DoublyNoncentralChi2(2, 3, 1, 2).seed(42).sample(500)
         const result = dist.DoublyNoncentralChi2.fit(data)
         assert(result instanceof dist.DoublyNoncentralChi2)
-        assert(Math.abs((result.p.k1 + result.p.k2) - 5) <= 2)
-        assert(Math.abs((result.p.lambda1 + result.p.lambda2) - 3) <= 2)
+        assert(Math.abs((result.params().k1 + result.params().k2) - 5) <= 2)
+        assert(Math.abs((result.params().lambda1 + result.params().lambda2) - 3) <= 2)
       })
 
       it('DoublyNoncentralChi2.fit should enforce k1>=1 and k2>=1 when collapsed fit returns k=1', () => {
@@ -254,8 +254,8 @@ describe('dist', () => {
         const data = new dist.NoncentralChi2(1, 0).seed(42).sample(500)
         const result = dist.DoublyNoncentralChi2.fit(data)
         assert(result instanceof dist.DoublyNoncentralChi2)
-        assert(result.p.k1 >= 1)
-        assert(result.p.k2 >= 1)
+        assert(result.params().k1 >= 1)
+        assert(result.params().k2 >= 1)
       })
 
       it('DoublyNoncentralT moments should be identical across independent instances', () => {
@@ -277,8 +277,8 @@ describe('dist', () => {
         // exercises the closed-form moment formulas the fit is meant to recover.
         assert(Math.abs(result.mean() - 5) < 1)
         assert(Math.abs(result.variance() - 1 * Math.pow(5, 1.5)) < 3)
-        assert(result.p.p > 1 && result.p.p < 2)
-        assert(Math.abs(result.p.p - 1.5) < 0.3)
+        assert(result.params().p > 1 && result.params().p < 2)
+        assert(Math.abs(result.params().p - 1.5) < 0.3)
         assert(Number.isFinite(result.pdf(1)) && result.pdf(1) > 0)
       })
 

--- a/test/dist-base-fit-2.js
+++ b/test/dist-base-fit-2.js
@@ -77,7 +77,8 @@ describe('dist', () => {
         const result = dist.F.fit(data)
         assert(result instanceof dist.F)
         // Profile MLE has strictly higher lnL than the moment-seed answer
-        assert(new dist.F(result.params().d1, result.params().d2).lnL(data) > new dist.F(4, 14).lnL(data))
+        const { d1, d2 } = result.params()
+        assert(new dist.F(d1, d2).lnL(data) > new dist.F(4, 14).lnL(data))
       })
 
       it('FisherZ._fitPenalty should return 0', () => {

--- a/test/dist-base-fit-3.js
+++ b/test/dist-base-fit-3.js
@@ -213,10 +213,10 @@ describe('dist', () => {
         const data = new dist.TruncatedNormal(2, 1, 0, 4).seed(42).sample(300)
         const result = dist.TruncatedNormal.fit(data)
         assert(result instanceof dist.TruncatedNormal)
-        assert(Math.abs(result.p.mu - 2) < 0.4)
-        assert(Math.abs(result.p.sigma - 1) < 0.4)
-        assert(result.p.a < 0.5)
-        assert(result.p.b > 3.5)
+        assert(Math.abs(result.params().mu - 2) < 0.4)
+        assert(Math.abs(result.params().sigma - 1) < 0.4)
+        assert(result.params().a < 0.5)
+        assert(result.params().b > 3.5)
       })
 
       it('TruncatedExponential._fitInit should set a=min, b=max, lambda from MOM', () => {
@@ -239,9 +239,9 @@ describe('dist', () => {
         const data = new dist.TruncatedExponential(1, 0, 5).seed(42).sample(300)
         const result = dist.TruncatedExponential.fit(data)
         assert(result instanceof dist.TruncatedExponential)
-        assert(result.p.lambda > 0)
-        assert(result.p.a >= 0)
-        assert(result.p.b > result.p.a)
+        assert(result.params().lambda > 0)
+        assert(result.params().a >= 0)
+        assert(result.params().b > result.params().a)
         assert(Number.isFinite(result.pdf(1)) && result.pdf(1) > 0)
       })
 

--- a/test/dist-base-fit-gate.js
+++ b/test/dist-base-fit-gate.js
@@ -61,8 +61,8 @@ describe('fit() precision and robustness gate', () => {
       const muRef = data.reduce((s, x) => s + x, 0) / n
       const sigmaRef = Math.sqrt(data.reduce((s, x) => s + (x - muRef) ** 2, 0) / n)
       const fitted = dist.Normal.fit(data)
-      assert.approximately(fitted.p.mu / muRef, 1, 1e-14)
-      assert.approximately(fitted.p.sigma / sigmaRef, 1, 1e-14)
+      assert.approximately(fitted.params().mu / muRef, 1, 1e-14)
+      assert.approximately(fitted.params().sigma / sigmaRef, 1, 1e-14)
     })
 
     it('Pareto recovers x̂min = min and α̂ = n/Σln(x/xmin) to 1e-14 relative error', () => {
@@ -70,15 +70,15 @@ describe('fit() precision and robustness gate', () => {
       const xmin = Math.min(...data)
       const alphaRef = data.length / data.reduce((s, x) => s + Math.log(x / xmin), 0)
       const fitted = dist.Pareto.fit(data)
-      assert.strictEqual(fitted.p.xmin, xmin)
-      assert.approximately(fitted.p.alpha / alphaRef, 1, 1e-14)
+      assert.strictEqual(fitted.params().xmin, xmin)
+      assert.approximately(fitted.params().alpha / alphaRef, 1, 1e-14)
     })
 
     it('Uniform recovers the exact [min, max] support (not a padded interval)', () => {
       const data = [2.3, 5.1, 1.7, 4.4, 3.0]
       const fitted = dist.Uniform.fit(data)
-      assert.strictEqual(fitted.p.xmin, Math.min(...data))
-      assert.strictEqual(fitted.p.xmax, Math.max(...data))
+      assert.strictEqual(fitted.params().xmin, Math.min(...data))
+      assert.strictEqual(fitted.params().xmax, Math.max(...data))
     })
 
     it('InverseGaussian recovers the exact MLE λ̂ = n/Σ(1/xᵢ − 1/x̄) to 1e-14 relative error', () => {
@@ -87,8 +87,8 @@ describe('fit() precision and robustness gate', () => {
       const mean = data.reduce((s, x) => s + x, 0) / n
       const lambdaRef = n / data.reduce((s, x) => s + (1 / x - 1 / mean), 0)
       const fitted = dist.InverseGaussian.fit(data)
-      assert.approximately(fitted.p.mu / mean, 1, 1e-14)
-      assert.approximately(fitted.p.lambda / lambdaRef, 1, 1e-14)
+      assert.approximately(fitted.params().mu / mean, 1, 1e-14)
+      assert.approximately(fitted.params().lambda / lambdaRef, 1, 1e-14)
     })
   })
 
@@ -115,8 +115,8 @@ describe('fit() precision and robustness gate', () => {
       const trueModel = new dist.Bates(4, 1, 5).seed(20260601)
       const data = trueModel.sample(300)
       const fitted = dist.Bates.fit(data)
-      assert.isTrue(fitted.p.a < fitted.p.b)
-      assert.isTrue(Number.isInteger(fitted.p.n) && fitted.p.n >= 1)
+      assert.isTrue(fitted.params().a < fitted.params().b)
+      assert.isTrue(Number.isInteger(fitted.params().n) && fitted.params().n >= 1)
       const fittedLnL = fitted.lnL(data)
       assert.isTrue(Number.isFinite(fittedLnL))
       assert.isAtLeast(fittedLnL, trueModel.lnL(data) - 1e-6 * (Math.abs(trueModel.lnL(data)) + 1))
@@ -129,8 +129,8 @@ describe('fit() precision and robustness gate', () => {
       assert.isTrue(Number.isFinite(L0))
       // A genuine optimum: no small coordinate perturbation increases the log-likelihood.
       for (const [da, db] of [[1e-3, 0], [-1e-3, 0], [0, 1e-3], [0, -1e-3]]) {
-        const a = fitted.p.alpha * (1 + da)
-        const b = fitted.p.beta * (1 + db)
+        const a = fitted.params().alpha * (1 + da)
+        const b = fitted.params().beta * (1 + db)
         assert.isAtMost(new dist.Gamma(a, b).lnL(data), L0 + 1e-9)
       }
     })

--- a/test/dist-base-fit-gate.js
+++ b/test/dist-base-fit-gate.js
@@ -51,7 +51,7 @@ describe('fit() precision and robustness gate', () => {
       const data = [0.7, 1.3, 2.1, 0.9, 3.4, 1.1, 0.5, 2.8]
       // Reference computed independently of fit()'s n/Σx ordering.
       const reference = 1 / (data.reduce((s, x) => s + x, 0) / data.length)
-      const fitted = dist.Exponential.fit(data).p.lambda
+      const fitted = dist.Exponential.fit(data).params().lambda
       assert.approximately(fitted / reference, 1, 1e-14)
     })
 

--- a/test/process.js
+++ b/test/process.js
@@ -615,8 +615,8 @@ describe('process.BrownianMotion', () => {
         bm.seed(seed)
         const fitted = BrownianMotion.fit(bm.path(n), dt)
         assert.instanceOf(fitted, BrownianMotion)
-        assert.closeTo(fitted.p.mu, mu, tolMu, `seed ${seed}`)
-        assert.closeTo(fitted.p.sigma, sigma, tolSigma, `seed ${seed}`)
+        assert.closeTo(fitted.params().mu, mu, tolMu, `seed ${seed}`)
+        assert.closeTo(fitted.params().sigma, sigma, tolSigma, `seed ${seed}`)
       }
     })
 
@@ -624,7 +624,7 @@ describe('process.BrownianMotion', () => {
       const bm = new BrownianMotion(0.1, 1, 1)
       bm.seed(1)
       const fitted = BrownianMotion.fit(bm.path(5000))
-      assert.strictEqual(fitted.p.dt, 1)
+      assert.strictEqual(fitted.params().dt, 1)
     })
 
     it('should throw when path has fewer than 3 states', () => {
@@ -893,8 +893,8 @@ describe('process.GeometricBrownianMotion', () => {
         gbm.seed(seed)
         const fitted = GeometricBrownianMotion.fit(gbm.path(n), dt)
         assert.instanceOf(fitted, GeometricBrownianMotion)
-        assert.closeTo(fitted.p.sigma, sigma, tolSigma, `seed ${seed}`)
-        assert.closeTo(fitted.p.mu, mu, tolMu, `seed ${seed}`)
+        assert.closeTo(fitted.params().sigma, sigma, tolSigma, `seed ${seed}`)
+        assert.closeTo(fitted.params().mu, mu, tolMu, `seed ${seed}`)
       }
     })
 
@@ -902,7 +902,7 @@ describe('process.GeometricBrownianMotion', () => {
       const gbm = new GeometricBrownianMotion(0.05, 0.2, 1)
       gbm.seed(1)
       const fitted = GeometricBrownianMotion.fit(gbm.path(5000))
-      assert.strictEqual(fitted.p.dt, 1)
+      assert.strictEqual(fitted.params().dt, 1)
     })
 
     it('should throw when path has fewer than 3 states', () => {
@@ -1135,9 +1135,9 @@ describe('process.OrnsteinUhlenbeck', () => {
         ou.seed(seed)
         const fitted = OrnsteinUhlenbeck.fit(ou.path(n), dt)
         assert.instanceOf(fitted, OrnsteinUhlenbeck)
-        assert.closeTo(fitted.p.theta, theta, tolTheta, `seed ${seed}: theta`)
-        assert.closeTo(fitted.p.mu, mu, tolMu, `seed ${seed}: mu`)
-        assert.closeTo(fitted.p.sigma, sigma, tolSigma, `seed ${seed}: sigma`)
+        assert.closeTo(fitted.params().theta, theta, tolTheta, `seed ${seed}: theta`)
+        assert.closeTo(fitted.params().mu, mu, tolMu, `seed ${seed}: mu`)
+        assert.closeTo(fitted.params().sigma, sigma, tolSigma, `seed ${seed}: sigma`)
       }
     })
 
@@ -1145,7 +1145,7 @@ describe('process.OrnsteinUhlenbeck', () => {
       const ou = new OrnsteinUhlenbeck(0.5, 1, 1, 1)
       ou.seed(1)
       const fitted = OrnsteinUhlenbeck.fit(ou.path(20000))
-      assert.strictEqual(fitted.p.dt, 1)
+      assert.strictEqual(fitted.params().dt, 1)
     })
 
     it('should throw when path has fewer than 4 states', () => {
@@ -1485,7 +1485,7 @@ describe('process.BrownianBridge', () => {
         bb.seed(seed)
         const fitted = BrownianBridge.fit(bb.path(N), T, dt)
         assert.instanceOf(fitted, BrownianBridge)
-        assert.closeTo(fitted.p.sigma, sigma, tolSigma, `seed ${seed}`)
+        assert.closeTo(fitted.params().sigma, sigma, tolSigma, `seed ${seed}`)
       }
     })
 
@@ -1493,7 +1493,7 @@ describe('process.BrownianBridge', () => {
       const bb = new BrownianBridge(1, 10, 0.1)
       bb.seed(1)
       const fitted = BrownianBridge.fit(bb.path(100), 10)
-      assert.strictEqual(fitted.p.dt, 0.1)
+      assert.strictEqual(fitted.params().dt, 0.1)
     })
 
     it('should throw when T is not > 0', () => {
@@ -1516,7 +1516,7 @@ describe('process.BrownianBridge', () => {
       bb.seed(1)
       const fitted = BrownianBridge.fit(bb.path(2), T, dt)
       assert.instanceOf(fitted, BrownianBridge)
-      assert.isAbove(fitted.p.sigma, 0)
+      assert.isAbove(fitted.params().sigma, 0)
     })
 
     it('should throw when path is not an array', () => {
@@ -1829,8 +1829,8 @@ describe('process.AR1', () => {
         ar1.seed(seed)
         const fitted = AR1.fit(ar1.path(n))
         assert.instanceOf(fitted, AR1)
-        assert.closeTo(fitted.p.phi, phi, tolPhi, `seed ${seed}: phi`)
-        assert.closeTo(fitted.p.sigma, sigma, tolSigma, `seed ${seed}: sigma`)
+        assert.closeTo(fitted.params().phi, phi, tolPhi, `seed ${seed}: phi`)
+        assert.closeTo(fitted.params().sigma, sigma, tolSigma, `seed ${seed}: sigma`)
       }
     })
 
@@ -1847,8 +1847,8 @@ describe('process.AR1', () => {
       // residuals are not all 0 and sigma2 = ss/(n-2) is strictly positive.
       const fitted = AR1.fit([0, 1, 2, 2])
       assert.instanceOf(fitted, AR1)
-      assert.isTrue(Number.isFinite(fitted.p.phi))
-      assert.isAbove(fitted.p.sigma, 0)
+      assert.isTrue(Number.isFinite(fitted.params().phi))
+      assert.isAbove(fitted.params().sigma, 0)
     })
 
     it('should throw when a perfectly collinear path drives sigma to 0', () => {
@@ -2043,7 +2043,7 @@ describe('process.Poisson', () => {
         pp.seed(seed)
         const fitted = ProcessPoisson.fit(pp.path(n), dt)
         assert.instanceOf(fitted, ProcessPoisson)
-        assert.closeTo(fitted.p.lambda, lambda, tol, `seed ${seed}: lambda`)
+        assert.closeTo(fitted.params().lambda, lambda, tol, `seed ${seed}: lambda`)
       }
     })
 
@@ -2051,7 +2051,7 @@ describe('process.Poisson', () => {
       const pp = new ProcessPoisson(2, 1)
       pp.seed(1)
       const fitted = ProcessPoisson.fit(pp.path(20000))
-      assert.strictEqual(fitted.p.dt, 1)
+      assert.strictEqual(fitted.params().dt, 1)
     })
 
     it('should throw when path has fewer than 2 states', () => {
@@ -2348,9 +2348,9 @@ describe('process.CompoundPoisson', () => {
         cpp.seed(seed)
         const fitted = CompoundPoisson.fit(cpp.path(n), dt, Normal)
         assert.instanceOf(fitted, CompoundPoisson)
-        assert.closeTo(fitted.p.lambda, lambda, tolLambda, `seed ${seed}: lambda`)
-        assert.instanceOf(fitted.p.jumpDist, Normal)
-        const { mu: fittedMuJ, sigma: fittedSigmaJ } = fitted.p.jumpDist.params()
+        assert.closeTo(fitted.params().lambda, lambda, tolLambda, `seed ${seed}: lambda`)
+        assert.instanceOf(fitted.params().jumpDist, Normal)
+        const { mu: fittedMuJ, sigma: fittedSigmaJ } = fitted.params().jumpDist.params()
         assert.closeTo(fittedMuJ, muJ, tolMuJ, `seed ${seed}: muJ`)
         assert.closeTo(fittedSigmaJ, sigmaJ, tolSigmaJ, `seed ${seed}: sigmaJ`)
       }
@@ -2360,7 +2360,7 @@ describe('process.CompoundPoisson', () => {
       const cpp = new CompoundPoisson(new Normal(0, 1), 2, 1)
       cpp.seed(1)
       const fitted = CompoundPoisson.fit(cpp.path(20000), undefined, Normal)
-      assert.strictEqual(fitted.p.dt, 1)
+      assert.strictEqual(fitted.params().dt, 1)
     })
 
     it('should throw when path has fewer than 2 states', () => {
@@ -2701,9 +2701,9 @@ describe('process.CoxIngersollRoss', () => {
         cir.seed(seed)
         const fitted = CoxIngersollRoss.fit(cir.path(n), dt)
         assert.instanceOf(fitted, CoxIngersollRoss)
-        assert.closeTo(fitted.p.kappa, kappa, tolKappa, `seed ${seed}: kappa`)
-        assert.closeTo(fitted.p.theta, theta, tolTheta, `seed ${seed}: theta`)
-        assert.closeTo(fitted.p.sigma, sigma, tolSigma, `seed ${seed}: sigma`)
+        assert.closeTo(fitted.params().kappa, kappa, tolKappa, `seed ${seed}: kappa`)
+        assert.closeTo(fitted.params().theta, theta, tolTheta, `seed ${seed}: theta`)
+        assert.closeTo(fitted.params().sigma, sigma, tolSigma, `seed ${seed}: sigma`)
       }
     })
 
@@ -2711,7 +2711,7 @@ describe('process.CoxIngersollRoss', () => {
       const cir = new CoxIngersollRoss(2, 3, 1, 0.01)
       cir.seed(1)
       const fitted = CoxIngersollRoss.fit(cir.path(20000))
-      assert.strictEqual(fitted.p.dt, 1)
+      assert.strictEqual(fitted.params().dt, 1)
     })
 
     it('should throw when path has fewer than 4 states', () => {
@@ -2990,8 +2990,8 @@ describe('process.RandomWalk', () => {
       marginal.seed(42)
       const fitted = ShiftedBinomial.fit(marginal.sample(2000))
       assert.instanceOf(fitted, ShiftedBinomial)
-      assert.strictEqual(fitted.p.n, 20)
-      assert.closeTo(fitted.p.p, 0.7, 0.05)
+      assert.strictEqual(fitted.params().n, 20)
+      assert.closeTo(fitted.params().p, 0.7, 0.05)
     })
 
     // ShiftedBinomial is private (decisions/0045) and only ever surfaces as the return value
@@ -3048,7 +3048,7 @@ describe('process.RandomWalk', () => {
         rw.seed(seed)
         const fitted = RandomWalk.fit(rw.path(n))
         assert.instanceOf(fitted, RandomWalk)
-        assert.closeTo(fitted.p.p, p, tolP, `seed ${seed}`)
+        assert.closeTo(fitted.params().p, p, tolP, `seed ${seed}`)
       }
     })
 
@@ -3078,9 +3078,12 @@ describe('process.RandomWalk', () => {
       const fitted = RandomWalk.fit([0, 1, 0])
       assert.instanceOf(fitted, RandomWalk)
       // exact rational: p_hat is the fraction of +1 steps, and [0, 1, 0] has increments
-      // [+1, -1], so p_hat = 1/2. Stays inline rather than moving to process-cases.js because
-      // fit() is a static factory, not an instance method the case file's shape can express.
-      assert.strictEqual(fitted.p.p, 0.5)
+      // [+1, -1], so p_hat = 1/2 → mean(t) = t*(2*0.5-1) = 0 for any t, and
+      // variance(1) = 4*0.5*(1-0.5)*1 = 1. Stays inline rather than moving to process-cases.js
+      // because fit() is a static factory, not an instance method the case file's shape can
+      // express.
+      assert.strictEqual(fitted.mean(4), 0)
+      assert.strictEqual(fitted.variance(1), 1)
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #1290

- Replaced every `fitted.p.<key>` / `result.p.<key>` read (internal storage) with `.params().<key>` (the public accessor) across `test/process.js`'s `.fit()` blocks and every other test file that read `.p.` off a fitted `Distribution`/`Process` instance (`test/dist-base-fit-1.js`, `-fit-2.js`, `-fit-3.js`, `-fit-gate.js`).
- Strengthened the `RandomWalk` 3-state `.fit()` test from asserting the internal `fitted.p.p === 0.5` to two public-API behavioral assertions (`fitted.mean(4) === 0`, `fitted.variance(1) === 1`) derived from `RandomWalk`'s closed-form formulas — same discriminating power, no internal-state read.
- Hoisted two redundant `.params()` allocations (a shallow-copy `{ ...this.p }` call) found by `/review`'s performance pass: one inside a `.reduce()` callback, one duplicated in a single assertion.

## Design decisions

_No ADR needed — this is a pure test-only mechanical migration onto an accessor (`params()`) that already exists per [ADR-0047](decisions/0047-params-shallow-copy.md); no new design decision was introduced._

## Non-trivial changes

_No non-trivial changes — this PR is purely mechanical._

## Comprehension checklist

- [x] I can explain what this code does without reading line-by-line
- [x] I understand *why* this approach was chosen over alternatives
- [x] WHY comments are present where the logic is non-obvious (updated the `RandomWalk` test comment to justify the new `mean`/`variance` assertions)
- [x] Tests verify observable behavior, not internal state
- [x] A developer encountering this code in 6 months could understand it

<details>
<summary>Trivial changes</summary>

- **`test/process.js`**: `fitted.p.<key>` → `fitted.params().<key>` across BrownianMotion, GeometricBrownianMotion, OrnsteinUhlenbeck, BrownianBridge, AR1, Poisson, CompoundPoisson, CoxIngersollRoss, and RandomWalk `.fit()` blocks; RandomWalk 3-state test strengthened to behavioral assertions.
- **`test/dist-base-fit-1.js`, `-fit-2.js`, `-fit-3.js`**: `result.p.<key>` → `result.params().<key>` throughout the `.fit()`/`_fitInit` precision/robustness test blocks. Two lines (`d.p.F`, `d.p.p` in `-fit-2.js`, testing "BaldingNichols constructor should expose F and p on this.p") were deliberately left unchanged — that test asserts the internal storage convention itself, not a fitted instance's public params.
- **`test/dist-base-fit-gate.js`**: same `.p.<key>` → `.params().<key>` migration for `Distribution.fit()` precision-gate assertions.
- **`test/dist-base-fit-1.js`**: hoisted a `result.params()` call out of a `.reduce()` callback (was reallocating a shallow copy per array element).
- **`test/dist-base-fit-2.js`**: hoisted a duplicated `result.params()` call in a single assertion into one destructure.

</details>

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green — 9764 passing, coverage thresholds met)
- [x] `npm run typecheck` passes
- [x] Tests updated for changed behavior (test-only migration; `RandomWalk` test strengthened)
- [ ] New distribution items — N/A, no new distribution
- [ ] `CHANGELOG.md` updated — skipped; pure test-only change (per CLAUDE.md's per-PR changelog rule, "test-only changes... do not need a changelog entry")
- [x] Production-code diff under ~400 lines — N/A, zero `src/` diff

**Code health note**: `test/process.js` scores 9.09 (pre-existing "420 functions in a single module" god-file smell, unrelated to this diff). Splitting it is a major cross-file refactor out of scope for this test-only PR; all other touched files (`test/dist-base-fit-1.js`, `-fit-2.js`, `-fit-3.js`, `-fit-gate.js`) are at a perfect 10.0.

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEvsMNCyhuaTWpVzjMALZ2)_