### PR TITLE
Release v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-08-09
+
 ### Added
 
 - `ran.dist.Distribution.prototype.copy()`: returns a fully independent copy of a distribution instance, including its current PRNG state — a thin named wrapper around the existing `this.constructor.load(this.save())` round-trip, added so cloning a `Distribution` instance doesn't require knowing that trick. Used internally by `params()`'s new Distribution-instance-valued-field cloning (see `### Fixed`), and useful standalone — e.g. running two MCMC chains seeded from the same fitted distribution without them sharing PRNG state. See [ADR-0051](decisions/0051-params-distribution-instance-field-clone.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ranjs",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ranjs",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranjs",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Library for generating various random variables.",
   "keywords": [
     "random",


### PR DESCRIPTION
Bumps `package.json`/`package-lock.json` to `1.32.0` and consolidates the `## [Unreleased]` section of `CHANGELOG.md` into `## [1.32.0] - 2026-08-09`.

Includes:
- 25 commits since v1.31.0 (2026-07-20), spanning new distributions (`Tweedie`, `ExponentiallyModifiedGaussian`, `WrappedCauchy`), new goodness-of-fit tests (`cramerVonMises`, `kolmogorovSmirnov`, `andersonDarling`), `ran.process.Process` API expansion (`fit()`, `lnL()`, `marginal()`, `params()`), `ran.dist.guess()`, a process precision gate, a `VonMises` location-parameter change (with deprecation cycle for the old single-arg constructor), numerous performance caches, and a long tail of numerical-precision fixes across Bessel/Marcum-Q/incomplete-gamma special functions and several noncentral distributions.

*Automated release PR — do not add commits to this branch.*

---
_Generated by [Claude Code](https://claude.ai/code/session_012KdCG2g53rv23pNYr6KKiC)_