### PR TITLE
Automate release-summary prepend in GitHub release notes

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -128,6 +128,23 @@ Verify the file parses correctly (no duplicate headings, no orphaned bullets).
 
 ---
 
+### 6a. Draft the release summary
+
+Write a 2-5 sentence plain-prose paragraph (no markdown headers) covering the
+release's user-facing highlights: new distributions/features, notable
+behavior or API changes (call out anything mid-deprecation-cycle), and the
+general shape of the fix batch. Base it on the `## [VERSION]` section just
+written in step 6 — this is a compressed read of that section, not new
+research.
+
+This text is **not** written into `CHANGELOG.md`. It is passed as the
+`summary` input when triggering the release workflow (step 10), which
+prepends it above the CHANGELOG notes in the GitHub release — so every
+release carries a human-readable overview instead of a raw bullet dump, with
+no manual copy-paste step after the fact.
+
+---
+
 ### 7. Commit release branch
 
 Commit the step 5 + step 6 edits as a single commit `Release v{VERSION}` on
@@ -166,14 +183,15 @@ Once the PR is merged (the bumped `package.json` and consolidated `CHANGELOG.md`
 are now on `main`), trigger the workflow:
 
 - `mcp__github__actions_run_trigger` — `workflow_id` `release.yml`, `ref`
-  `main`, `inputs: { version: "VERSION" }`.
+  `main`, `inputs: { version: "VERSION", summary: "SUMMARY" }` (`SUMMARY` from
+  step 6a).
 
 The workflow then, on the runner, does everything MCP cannot:
 
 - creates and pushes the `v{VERSION}` tag,
 - runs lint/typecheck/tests and `npm publish --provenance`,
-- cuts the GitHub release with the consolidated `## [VERSION]` notes from
-  `CHANGELOG.md`,
+- cuts the GitHub release with `SUMMARY` prepended above the consolidated
+  `## [VERSION]` notes from `CHANGELOG.md`,
 - rotates the milestone (creates `v{NEXT_VERSION}`, moves open issues, closes
   `v{VERSION}`).
 
@@ -204,6 +222,12 @@ Milestone: v{VERSION} closed, v{NEXT_VERSION} created (by the workflow)
 - **Consolidate the changelog in the skill, not the workflow** — the semantic
   merge of grouped bullets is judgement the workflow cannot do; it only reads
   the finished `## [VERSION]` section.
+- **Always draft and pass a `summary`** (step 6a) — the workflow still
+  publishes without one (silently falling back to the raw CHANGELOG notes
+  alone), but every release should carry a human-readable overview, not just
+  a bullet dump. Writing it is judgement the workflow can't do either, same
+  reasoning as changelog consolidation — draft it in the skill, never leave
+  it for a human to paste in after the fact.
 - **Milestone rotation is best-effort** — the workflow warns and continues if
   the milestone is missing.
 - **No interactive prompts mid-pipeline** — if anything is ambiguous, abort

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
 # Dispatch-driven release. The /release skill merges the version-bump PR via
-# GitHub MCP, then triggers this workflow with the target version. The runner
-# creates the v* tag, publishes to npm, cuts the GitHub release, and rotates the
-# milestone — everything the MCP-only skill cannot do itself.
+# GitHub MCP, then triggers this workflow with the target version (and a
+# skill-drafted release summary). The runner creates the v* tag, publishes to
+# npm, cuts the GitHub release, and rotates the milestone — everything the
+# MCP-only skill cannot do itself.
 #
 # Why a PAT: github-actions[bot] cannot be added to the v* tag-protection
 # ruleset's bypass list, so the built-in GITHUB_TOKEN cannot create the tag. A
@@ -21,6 +22,9 @@ on:
       version:
         description: 'Version to release, e.g. 1.31.0 (must already be committed to main)'
         required: true
+      summary:
+        description: 'Optional 1-paragraph release summary, prepended above the CHANGELOG notes'
+        required: false
 
 # id-token: write is required for npm provenance attestation generation.
 # issues: write is required for milestone rotation.
@@ -93,18 +97,29 @@ jobs:
 
       # Notes come from the already-consolidated ## [version] CHANGELOG section
       # (the skill does the semantic consolidation before merging), not
-      # --generate-notes. Idempotent: skip if the release already exists so a
-      # re-run never fails on the last step.
+      # --generate-notes, optionally prefixed by the skill-drafted `summary`
+      # input (the skill writes this while it has full release context; the
+      # workflow never generates prose itself — no LLM call or new secret
+      # here). SUMMARY is passed via env, not templated into the script
+      # directly, so free-form text can't break out of the shell command.
+      # Idempotent: skip if the release already exists so a re-run never
+      # fails on the last step.
       - name: Create GitHub release with consolidated notes
         env:
           GH_TOKEN: ${{ github.token }}
+          SUMMARY: ${{ inputs.summary }}
         run: |
           V="v${{ steps.ver.outputs.version }}"
-          NOTES=$(awk -v hdr="## [${{ steps.ver.outputs.version }}]" '
+          CHANGELOG_NOTES=$(awk -v hdr="## [${{ steps.ver.outputs.version }}]" '
             index($0, hdr) == 1 { f = 1; next }
             f && /^## \[/ { exit }
             f { print }
           ' CHANGELOG.md)
+          if [ -n "$SUMMARY" ]; then
+            NOTES=$(printf '%s\n\n%s' "$SUMMARY" "$CHANGELOG_NOTES")
+          else
+            NOTES="$CHANGELOG_NOTES"
+          fi
           if gh release view "$V" >/dev/null 2>&1; then
             echo "Release $V already exists — leaving its notes unchanged."
           else


### PR DESCRIPTION
## Summary

- The `/release` skill's GitHub release notes were just the raw `## [VERSION]` `CHANGELOG.md` section verbatim, with no human-readable overview — this required manually pasting a summary into the release notes after every release (found while releasing v1.32.0).
- `.github/workflows/release.yml` gains an optional `summary` `workflow_dispatch` input, passed via `env` (not templated directly into the shell script, so free-form text can't break out of the command) and prepended above the CHANGELOG notes when creating the GitHub release via `gh release create`.
- `.claude/skills/release/SKILL.md` gains a new step 6a: draft a 2-5 sentence plain-prose summary while consolidating the changelog (same judgement call as changelog consolidation, so it belongs in the skill, not a CI LLM call), and pass it as the `summary` input when triggering the workflow in step 10.
- No CI secrets or LLM calls added — the summary is authored once, at release time, by whoever/whatever runs `/release`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms `release.yml` is valid YAML.
- [ ] Next `/release` run exercises the new `summary` input end-to-end (workflow only fires on release, so this can't be tested standalone without cutting a release).

---
_Generated by [Claude Code](https://claude.ai/code/session_012KdCG2g53rv23pNYr6KKiC)_