### PR TITLE
Fix docs-deploy release publish deleting gh-pages .git metadata

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -13,6 +13,11 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Redeploy a specific released version, e.g. 1.32.0 (recovery path for a failed tag-push deploy; leave blank to redeploy /unreleased/ from the dispatched ref instead)'
+        required: false
 
 permissions:
   contents: write
@@ -32,8 +37,18 @@ jobs:
 
       - name: Determine channel
         id: channel
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          if [[ -n "$DISPATCH_VERSION" ]]; then
+            # Manual recovery path: redeploy an already-tagged release without
+            # re-pushing the tag (tags are immutable and shouldn't be moved
+            # just to re-run a deploy that failed after the build step, e.g.
+            # the '.git' worktree wipe fixed alongside this input).
+            echo "target=v${DISPATCH_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "version=${DISPATCH_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             V="${GITHUB_REF#refs/tags/v}"
             echo "target=v${V}" >> "$GITHUB_OUTPUT"
             echo "version=${V}" >> "$GITHUB_OUTPUT"
@@ -88,7 +103,11 @@ jobs:
 
           if [ "$IS_RELEASE" = "true" ]; then
             # '/' always mirrors the latest tagged release, never tip-of-main.
-            find "$SITE" -mindepth 1 -maxdepth 1 ! -name "$TARGET" ! -name 'unreleased' ! -name 'v*' -exec rm -rf {} +
+            # '.git' must stay excluded: it doesn't match 'v*' (it starts with
+            # a dot), so without this guard the worktree's own git metadata
+            # gets wiped and every command from here on fails with "fatal:
+            # not a git repository".
+            find "$SITE" -mindepth 1 -maxdepth 1 ! -name "$TARGET" ! -name 'unreleased' ! -name 'v*' ! -name '.git' -exec rm -rf {} +
             cp -r "$DEST"/. "$SITE/"
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `.github/workflows/docs-deploy.yml`: the release-channel cleanup step (`find "$SITE" ... ! -name 'v*' -exec rm -rf {} +`) deleted the gh-pages worktree's own `.git` metadata file on every tagged release, since `.git` starts with a dot and matches none of the exclusion patterns — every subsequent git command then failed with `fatal: not a git repository`, silently leaving the published docs site (and its `/` root, which is supposed to mirror the latest tagged release) stuck on the previous version. Added `! -name '.git'` to the exclusion list, and added a `workflow_dispatch` `version` input as a recovery path to manually redeploy an already-tagged release without moving the (immutable) release tag.
+
 ## [1.32.0] - 2026-08-09
 
 ### Added

--- a/src/process/ar1.js
+++ b/src/process/ar1.js
@@ -117,6 +117,7 @@ export default class AR1 extends Process {
    * @param {Array} path Array of observed states (as returned by path()).
    * @returns {AR1} A new instance with estimated phi and sigma.
    * @throws {Error} If path has fewer than 4 states.
+   * @ignore
    */
   static fit (path) {
     if (!Array.isArray(path) || path.length < 4) {

--- a/src/process/brownian-bridge.js
+++ b/src/process/brownian-bridge.js
@@ -129,6 +129,7 @@ export default class BrownianBridge extends Process {
    * @returns {BrownianBridge} A new instance with estimated sigma.
    * @throws {Error} If T or dt is not > 0, if T/dt is not at least 2, or if path does not
    * contain exactly T/dt + 1 states.
+   * @ignore
    */
   static fit (path, T, dt = 0.1) {
     Process.validate({ T, dt }, ['T > 0', 'dt > 0'])

--- a/src/process/brownian-motion.js
+++ b/src/process/brownian-motion.js
@@ -108,6 +108,7 @@ export default class BrownianMotion extends Process {
    * @param {number} [dt=1] Time step between consecutive path observations (must be > 0).
    * @returns {BrownianMotion} A new instance with estimated mu and sigma.
    * @throws {Error} If path has fewer than 3 states, or if dt is not > 0.
+   * @ignore
    */
   static fit (path, dt = 1) {
     Process.validate({ dt }, ['dt > 0'])

--- a/src/process/compound-poisson.js
+++ b/src/process/compound-poisson.js
@@ -161,6 +161,7 @@ export default class CompoundPoisson extends Process {
    * @throws {Error} If path has fewer than 2 states, if dt is not > 0, if jumpDistConstructor
    * does not expose a static fit() method, or if the path contains no non-zero increments to
    * recover jump sizes from.
+   * @ignore
    */
   static fit (path, dt = 1, jumpDistConstructor) {
     Process.validate({ dt }, ['dt > 0'])

--- a/src/process/cox-ingersoll-ross.js
+++ b/src/process/cox-ingersoll-ross.js
@@ -137,6 +137,7 @@ export default class CoxIngersollRoss extends Process {
    * @returns {CoxIngersollRoss} A new instance with estimated kappa, theta, and sigma.
    * @throws {Error} If path has fewer than 4 states, if dt is not > 0, if the estimated
    * AR(1) slope falls outside (0,1), or if the estimated sigma^2 is not positive.
+   * @ignore
    */
   static fit (path, dt = 1) {
     Process.validate({ dt }, ['dt > 0'])

--- a/src/process/geometric-brownian-motion.js
+++ b/src/process/geometric-brownian-motion.js
@@ -125,6 +125,7 @@ export default class GeometricBrownianMotion extends Process {
    * @param {number} [dt=1] Time step between consecutive path observations (must be > 0).
    * @returns {GeometricBrownianMotion} A new instance with estimated mu and sigma.
    * @throws {Error} If path has fewer than 3 states, contains a non-positive state, or if dt is not > 0.
+   * @ignore
    */
   static fit (path, dt = 1) {
     Process.validate({ dt }, ['dt > 0'])

--- a/src/process/ornstein-uhlenbeck.js
+++ b/src/process/ornstein-uhlenbeck.js
@@ -116,6 +116,7 @@ export default class OrnsteinUhlenbeck extends Process {
    * @returns {OrnsteinUhlenbeck} A new instance with estimated theta, mu, and sigma.
    * @throws {Error} If path has fewer than 4 states, if dt is not > 0, or if the estimated
    * AR(1) slope falls outside (0,1) (too short or too noisy a path to recover mean reversion).
+   * @ignore
    */
   static fit (path, dt = 1) {
     Process.validate({ dt }, ['dt > 0'])

--- a/src/process/poisson.js
+++ b/src/process/poisson.js
@@ -93,6 +93,7 @@ export default class Poisson extends Process {
    * @returns {Poisson} A new instance with estimated lambda.
    * @throws {Error} If path has fewer than 2 states, if dt is not > 0, if the path
    * decreases anywhere, or if the estimated lambda is not positive (no arrivals observed).
+   * @ignore
    */
   static fit (path, dt = 1) {
     Process.validate({ dt }, ['dt > 0'])

--- a/src/process/random-walk.js
+++ b/src/process/random-walk.js
@@ -104,6 +104,7 @@ export default class RandomWalk extends Process {
    * @returns {RandomWalk} A new instance with estimated p.
    * @throws {Error} If path has fewer than 2 states, if any step is not +1 or -1, or if the
    * estimated p falls outside (0,1) (path contains only up-steps or only down-steps).
+   * @ignore
    */
   static fit (path) {
     if (!Array.isArray(path) || path.length < 2) {


### PR DESCRIPTION
The release-channel cleanup in docs-deploy.yml removed everything in the
gh-pages worktree except entries matching the release target, 'unreleased',
or 'v*' — but '.git' starts with a dot and matched none of those, so it got
deleted too. Every git command after that (add/commit/push) then failed with
"fatal: not a git repository", so the v1.32.0 tag-push deploy failed silently
after the docs build succeeded, leaving the published site's root and version
list stuck on v1.31.0.

Add '.git' to the exclusion list, and add a workflow_dispatch 'version' input
so a failed release deploy can be manually re-run afterwards without moving
the (immutable) release tag.