### PR TITLE
Hide CompoundPoisson.marginal() override from the docs site

### DIFF
--- a/src/process/compound-poisson.js
+++ b/src/process/compound-poisson.js
@@ -125,6 +125,7 @@ export default class CompoundPoisson extends Process {
    * @param {number} t Time.
    * @returns {import('../dist/_distribution').default} A `Tweedie` instance when `jumpDist` is `Gamma`.
    * @throws {Error} If `t <= 0`, or if `jumpDist` is not a `ran.dist.Gamma` instance.
+   * @ignore
    */
   marginal (t) {
     if (t <= 0) {


### PR DESCRIPTION
## Summary

`CompoundPoisson.marginal()` carries its own full `@memberof`-tagged JSDoc block, unlike every other process's `marginal()` override, which uses a bare `/** @inheritdoc */` and therefore never generates its own `documentation.js` entry. That made `CompoundPoisson` the only process with a duplicate `marginal()` page alongside `Process.marginal()`'s general contract on the docs site. Adds `@ignore`, the same convention already used for `Process.validate()` and each process's individual `fit()` override.

Verified with a full `npm run docs` build: only `Process.marginal` remains in the generated `docs/index.html`; the `CompoundPoisson`-specific entry is gone. `tsc`-driven `.d.ts` generation is unaffected since `@ignore` only suppresses `documentation.js` output, not `@param`/`@returns`/`@throws` parsing.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green)
- [x] `npm run typecheck` passes
- [ ] Tests added or updated for changed behavior — n/a, JSDoc-only visibility change, no behavior change
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — n/a
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — n/a
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped per CLAUDE.md's docs-only exemption
- [x] Production-code diff is under ~400 lines (tests excluded) — 1 line


---
_Generated by [Claude Code](https://claude.ai/code/session_01WzxgYYodavZhQVRedt8rvG)_