### PR TITLE
Fix broken sidebar links from stale dot-form @link anchors

### DIFF
--- a/src/dist/alpha.js
+++ b/src/dist/alpha.js
@@ -7,7 +7,7 @@ import { erf, erfinv } from '../special'
  * $f(x; \alpha, \beta) = \frac{\phi\Big(\alpha - \frac{\beta}{x}\Big)}{x^2 \Phi(\alpha)},$
  *
  * where $\alpha, \beta > 0$ and $\phi(x), \Phi(x)$ denote the probability density and cumulative probability
- * functions of the [normal distribution]{@link #dist.Normal}.
+ * functions of the [normal distribution]{@link #dist-Normal}.
  * Support: $x > 0$.
  *
  * @class Alpha

--- a/src/dist/balding-nichols.js
+++ b/src/dist/balding-nichols.js
@@ -9,7 +9,7 @@ import rBeta from './_beta'
  * $f(x; \alpha, \beta) = \frac{x^{\alpha - 1} (1 - x)^{\beta - 1}}{\mathrm{B}(\alpha, \beta)},$
  *
  * where $\alpha = \frac{1 - F}{F} p$, $\beta = \frac{1 - F}{F} (1 - p)$ and $F, p \in (0, 1)$.
- * Support: $x \in (0, 1)$. It is simply a re-parametrization of the [beta distribution]{@link #dist.Beta}.
+ * Support: $x \in (0, 1)$. It is simply a re-parametrization of the [beta distribution]{@link #dist-Beta}.
  *
  * @class BaldingNichols
  * @memberof ran.dist

--- a/src/dist/birnbaum-saunders.js
+++ b/src/dist/birnbaum-saunders.js
@@ -8,7 +8,7 @@ import normal from './_normal'
  *
  * $f(x; \mu, \beta, \gamma) = \frac{z + 1 / z}{2 \gamma (x - \mu)} \phi\Big(\frac{z - 1 / z}{\gamma}\Big),$
  *
- * with $\mu \in \mathbb{R}$, $\beta, \gamma > 0$, $z = \sqrt{\frac{x - \mu}{\beta}}$ and $\phi(x)$ is the probability density function of the standard [normal distribution]{@link #dist.Normal}. Support: $x \in (\mu, \infty)$.
+ * with $\mu \in \mathbb{R}$, $\beta, \gamma > 0$, $z = \sqrt{\frac{x - \mu}{\beta}}$ and $\phi(x)$ is the probability density function of the standard [normal distribution]{@link #dist-Normal}. Support: $x \in (\mu, \infty)$.
  *
  * @class BirnbaumSaunders
  * @memberof ran.dist

--- a/src/dist/mielke.js
+++ b/src/dist/mielke.js
@@ -7,7 +7,7 @@ import { beta } from '../special'
  *
  * $f(x; k, s) = \frac{k x^{k - 1}}{(1 + x^s)^{1 + k/s}},$
  *
- * with $k, s > 0$. Support: $x > 0$. It can be viewed as a re-parametrization of the [Dagum distribution]{@link #dist.Dagum}.
+ * with $k, s > 0$. Support: $x > 0$. It can be viewed as a re-parametrization of the [Dagum distribution]{@link #dist-Dagum}.
  *
  * @class Mielke
  * @memberof ran.dist

--- a/src/dist/skew-normal.js
+++ b/src/dist/skew-normal.js
@@ -8,7 +8,7 @@ import Normal from './normal'
  * $f(x; \xi, \omega, \alpha) = \frac{2}{\omega} \phi\bigg(\frac{x - \xi}{\omega}\bigg) \Phi\bigg(\alpha \frac{x - \xi}{\omega}\bigg),$
  *
  * where $\xi, \alpha \in \mathbb{R}$, $\omega > 0$ and $\phi(x)$, $\Phi(x)$ denote the probability density and
- * cumulative distribution functions of the standard [normal distribution]{@link #dist.Normal}.
+ * cumulative distribution functions of the standard [normal distribution]{@link #dist-Normal}.
  * Support: $x \in \mathbb{R}$.
  *
  * @class SkewNormal

--- a/src/dist/slash.js
+++ b/src/dist/slash.js
@@ -7,7 +7,7 @@ import Normal from './normal'
  *
  * $f(x) = \begin{cases}\frac{\phi(0) - \phi(x)}{x^2} &\quad\text{if $x \ne 0$},\\\\ \frac{1}{2 \sqrt{2 \pi}} &\quad\text{if $x = 0$}\\\\ \end{cases},$
  *
- * where $\phi(x)$ is the probability density function of the standard [normal distribution]{@link #dist.Normal}.
+ * where $\phi(x)$ is the probability density function of the standard [normal distribution]{@link #dist-Normal}.
  * Support: $x \in \mathbb{R}$.
  *
  * @class Slash


### PR DESCRIPTION
## Summary

Six JSDoc `{@link #dist.X}` tags (`alpha`, `slash`, `balding-nichols`, `skew-normal`, `birnbaum-saunders`, `mielke`) pointed at `#dist.Normal`, `#dist.Beta`, and `#dist.Dagum` — the dot-separated form. But `docs/index.js` generates each card's actual `id` by taking `ran.<namespace>.<Name>`, stripping the `ran.` prefix, and replacing the first remaining dot with a dash (`dist-Normal`, `dist-Beta`, `dist-Dagum`). The hand-written links were never updated to match, so clicking them — or the equivalent sidebar entries pointing at the same anchor — went nowhere.

Verified by building `docs/index.html` and diffing every sidebar `<a href="#...">` against every card's `id="..."`: 3 broken hrefs (`dist.Beta`, `dist.Dagum`, `dist.Normal`) before, 0 after, out of 278 total links.

## Checklist

- [x] `npm run standard` passes (no linter errors)
- [x] `npm run typecheck` passes
- [ ] Tests added or updated for changed behavior — n/a, JSDoc link-text fix only, no behavior change
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — n/a
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — n/a
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped per CLAUDE.md's docs-only exemption
- [x] Production-code diff is under ~400 lines (tests excluded) — 6 lines


---
_Generated by [Claude Code](https://claude.ai/code/session_01WzxgYYodavZhQVRedt8rvG)_