### PR TITLE
Fix stale local main ref in skill diff-capture steps

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -129,7 +129,7 @@ If you genuinely noticed nothing, pass an empty list — the agent will skim the
 
 **Step 4.5b — Invoke `ops-triage`.**
 
-Spawn the `ops-triage` agent with `branch`, `session_kind: "build"`, `target_issue`, `observations`, and `diff_path` (the patch file from `.claude/tmp/`, if Stage 5 hasn't created it yet, build one with `git diff origin/main...HEAD > .claude/tmp/triage-diff-<branch>.patch`).
+Spawn the `ops-triage` agent with `branch`, `session_kind: "build"`, `target_issue`, `observations`, and `diff_path` (the patch file from `.claude/tmp/`, if Stage 5 hasn't created it yet, build one with `git fetch origin main && git diff origin/main...HEAD > .claude/tmp/triage-diff-<branch>.patch` — a freshly-fetched `origin/main` avoids a stale local `main` ref).
 
 The agent returns three buckets: `definite`, `ambiguous`, `not_a_bug`.
 

--- a/.claude/skills/compound/SKILL.md
+++ b/.claude/skills/compound/SKILL.md
@@ -12,9 +12,9 @@ When the user invokes `/compound` or `/compound <description>`:
 
 ### 1. Gather Context
 
-If a description is provided, use it as context. Otherwise:
-- `git diff main...HEAD`
-- `git log main..HEAD --oneline`
+If a description is provided, use it as context. Otherwise, first sync the fresh upstream ref without touching the local `main` branch: `git fetch origin main`. Then:
+- `git diff origin/main...HEAD`
+- `git log origin/main..HEAD --oneline`
 - Spawn the **discovery-thoughts** agent to find the related plan/research
 
 ### 2. Check for Existing Solutions

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -55,7 +55,7 @@ If tests fail, debug and fix. If the fix grows too complex, stop and suggest `/b
 
 Compile observations noticed during steps 3–4 (pre-existing NaN at a boundary, a flaky test, a docstring that contradicts the code, etc.) into a structured list. Each entry needs `summary`, `stage`, `evidence`, and your tentative `orchestrator_call`.
 
-Spawn the `ops-triage` agent with `branch`, `session_kind: "fix"`, `target_issue`, the `observations` list, and a `diff_path` (write `git diff main...HEAD` to `.claude/tmp/triage-diff-<branch>.patch` if not already done).
+Spawn the `ops-triage` agent with `branch`, `session_kind: "fix"`, `target_issue`, the `observations` list, and a `diff_path` (run `git fetch origin main && git diff origin/main...HEAD > .claude/tmp/triage-diff-<branch>.patch` if not already done — diffing against a freshly-fetched `origin/main` avoids a stale local `main` ref when the session started already checked out on the feature branch).
 
 Act on the result:
 - **`definite` with `route: "fix"`** (trivial/moderate): spawn the `ops-fix` agent with `summary`, `difficulty`, `fix_context`, and `branch`, one bug at a time (sequentially — they share the working tree). On `status: "fixed"`, count as "fixed inline". On `status: "escalated"`, fall back to `ops-issue` using the entry's drafted `title`/`priority`/`extra_labels` and a body built from `summary` + the escalation reason.
@@ -70,7 +70,7 @@ Report: `> "Triage: <N> fixed inline, <M> filed (<URLs>), <K> skipped, <L> not a
 Check if any `.js` files were modified:
 
 ```bash
-git diff main --name-only | grep '\.js$'
+git fetch origin main && git diff origin/main --name-only | grep '\.js$'
 ```
 
 **If `.js` files were modified**: invoke `/review` via the Skill tool. If P1/P2 findings, auto-fix, re-run tests, and re-review once. If still P1/P2 after retry, STOP and report.

--- a/.claude/skills/hotfix/SKILL.md
+++ b/.claude/skills/hotfix/SKILL.md
@@ -63,7 +63,7 @@ e. **If tests fail**: debug directly — no recovery agents needed for a small f
 
 Compile observations noticed during step 4 (a flaky test, a pre-existing NaN at a boundary, a contradicting docstring, etc.) into a structured list with `summary`, `stage`, `evidence`, and your tentative `orchestrator_call`.
 
-Spawn the `ops-triage` agent with `branch`, `session_kind: "hotfix"`, `target_issue`, the `observations` list, and a `diff_path` (write `git diff main...HEAD` to `.claude/tmp/triage-diff-<branch>.patch` first).
+Spawn the `ops-triage` agent with `branch`, `session_kind: "hotfix"`, `target_issue`, the `observations` list, and a `diff_path` (run `git fetch origin main && git diff origin/main...HEAD > .claude/tmp/triage-diff-<branch>.patch` first — diffing against a freshly-fetched `origin/main` avoids a stale local `main` ref when the session started already checked out on the feature branch, so step 2 never touched local `main`).
 
 Act on the result:
 - **`definite` with `route: "fix"`** (trivial/moderate): spawn the `ops-fix` agent with `summary`, `difficulty`, `fix_context`, and `branch`, one bug at a time (sequentially — they share the working tree). On `status: "fixed"`, count as "fixed inline". On `status: "escalated"`, fall back to `ops-issue` using the entry's drafted `title`/`priority`/`extra_labels` and a body built from `summary` + the escalation reason.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -12,14 +12,16 @@ When the user invokes `/pr`:
 
 ### 1. Gather Context
 
-Run in parallel:
-- `git branch --show-current`
-- `git log main..HEAD --oneline`
-- `git diff main...HEAD`
-- `git status`
-- `git log main..HEAD --format="%s%n%n%b"`
+First sync the fresh upstream ref without touching the local `main` branch: `git fetch origin main`.
 
-If the branch is `main`, stop. If no commits ahead of main, stop. If there are uncommitted changes, invoke `/commit` first.
+Then run in parallel:
+- `git branch --show-current`
+- `git log origin/main..HEAD --oneline`
+- `git diff origin/main...HEAD`
+- `git status`
+- `git log origin/main..HEAD --format="%s%n%n%b"`
+
+If the branch is `main`, stop. If no commits ahead of `origin/main`, stop. If there are uncommitted changes, invoke `/commit` first.
 
 ### 2. Pre-flight CI checks
 
@@ -40,7 +42,7 @@ Report format on failure:
 Get the list of `.js` files changed in this branch:
 
 ```bash
-git diff main...HEAD --name-only | grep '\.js$'
+git diff origin/main...HEAD --name-only | grep '\.js$'
 ```
 
 For each changed `.js` file, call the CodeScene `code_health_score` tool. If any file scores **below 10.0**:
@@ -78,7 +80,7 @@ If the merge **fails with conflicts**:
 Search in this order, stopping at the first match:
 
 1. **Branch name** — patterns: `^(\d+)-`, `^claude/build-(\d+)-`, `^claude/(\d+)-`
-2. **Commit messages** — `git log main..HEAD --format=%B | grep -oE '#[0-9]+'`
+2. **Commit messages** — `git log origin/main..HEAD --format=%B | grep -oE '#[0-9]+'`
 3. **Plan frontmatter** — look for `github_issue: <number>`
 
 If no issue detected, skip the closing keyword. Do not invent one.
@@ -112,7 +114,7 @@ Categorize every change:
 
 Check for ADR references in the diff and commits:
 ```bash
-git diff main...HEAD --name-only | grep decisions/
+git diff origin/main...HEAD --name-only | grep decisions/
 ```
 
 If non-trivial changes exist but no ADRs are found, add a warning block:

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -12,13 +12,15 @@ When the user invokes `/review`:
 
 ### 1. Gather Context
 
-Run these commands in parallel:
+First sync the fresh upstream ref without touching the local `main` branch: `git fetch origin main`.
+
+Then run these commands in parallel:
 
 - `git branch --show-current` — get current branch name
-- `git diff main...HEAD` — full diff of all changes
+- `git diff origin/main...HEAD` — full diff of all changes
 - `git diff` — any unstaged changes
 - `git diff --staged` — any staged changes
-- `git log main..HEAD --oneline` — list of commits on this branch
+- `git log origin/main..HEAD --oneline` — list of commits on this branch
 
 If the branch is `main`, stop: "You're on main. Switch to a feature branch first."
 If there are no changes, stop: "Nothing to review — no changes found."
@@ -44,7 +46,7 @@ Compare the diff against the plan and check:
 
 Save the diff to a temporary file:
 ```bash
-mkdir -p .claude/tmp && git diff main...HEAD > .claude/tmp/review-diff-$(git branch --show-current).patch
+mkdir -p .claude/tmp && git diff origin/main...HEAD > .claude/tmp/review-diff-$(git branch --show-current).patch
 ```
 
 Then launch all eight **in a single parallel call**, telling each to read `.claude/tmp/review-diff-<branch-name>.patch`:

--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -29,9 +29,11 @@ Parse the issue body for acceptance criteria (checkboxes, "Acceptance Criteria" 
 
 ### 3. Gather Implementation Context
 
-Run in parallel:
-- `git diff main...HEAD` — full diff
-- `git log main..HEAD --oneline` — commits
+First sync the fresh upstream ref without touching the local `main` branch: `git fetch origin main`.
+
+Then run these in parallel:
+- `git diff origin/main...HEAD` — full diff
+- `git log origin/main..HEAD --oneline` — commits
 
 Also spawn the **discovery-thoughts** agent to find any related plan or research.
 


### PR DESCRIPTION
Closes #1371

## Summary
- Fixed the diff-capture steps in `.claude/skills/{hotfix,fix,build,pr,review}/SKILL.md` to diff against a freshly-fetched `origin/main` instead of the local `main` branch ref, which can go arbitrarily stale in sessions that start already checked out on a feature branch (e.g. via `/resolve`) — the local `main` checkout/pull step is then never touched, so downstream `main...HEAD` diffs (and `main..HEAD` logs) can be handed corrupted data.
- Also fixed the identical bug in `.claude/skills/validate/SKILL.md` and `.claude/skills/compound/SKILL.md`, discovered during this session's mandatory bug-triage step (`ops-triage` classified it `definite`/`trivial`, routed to `ops-fix`).
- Each fix follows the issue's suggested "fetch fresh, don't touch local `main`" approach: `git fetch origin main` followed by `origin/main`-based diff/log commands, never `git checkout main`.

## Checklist
- [x] `npm run standard` passes (no linter errors)
- [x] `npm test` passes (all tests green, coverage thresholds met)
- [x] `npm run typecheck` passes
- [ ] Tests added or updated for changed behavior — N/A, workflow-tooling markdown only, no test suite covers `SKILL.md` prose
- [ ] If a new distribution was added: entry added to `test/dist-cases.js` — N/A
- [ ] If a new distribution was added: class added to `dist/ranjs.d.ts` (alphabetical) — N/A
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — skipped; this is a pure `.claude/skills/` tooling fix with no user-visible library behavior change
- [x] Production-code diff is under ~400 lines (tests excluded) — no `src/`/`scripts/` code touched at all

## Non-trivial changes
_No non-trivial changes — this PR only edits `.claude/skills/*/SKILL.md` workflow documentation; no `src/`/`scripts/` code is affected._

---
*Generated with [Claude Code](https://claude.ai/code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GG7Li2hZCHT9WBHaQNtwYk)_